### PR TITLE
Make sure pixels of images with differing resolution are always aligned

### DIFF
--- a/include/ImageCanvas.h
+++ b/include/ImageCanvas.h
@@ -79,6 +79,8 @@ public:
 private:
     float computeMeanValue();
 
+    Eigen::Vector2f pixelOffset(const Eigen::Vector2i& size) const;
+
     void translate(const Eigen::Vector2f& amount);
     void scale(float amount, const Eigen::Vector2f& origin);
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -104,8 +104,15 @@ EMetric toMetric(string name) {
 
 void toggleConsole() {
 #ifdef _WIN32
-    auto console = GetConsoleWindow();
-    ShowWindow(console, IsWindowVisible(console) ? SW_HIDE : SW_SHOW);
+    HWND console = GetConsoleWindow();
+    DWORD consoleProcessId;
+    GetWindowThreadProcessId(console, &consoleProcessId);
+
+    // Only toggle the console if it was actually spawned by tev. If we are
+    // running in a foreign console, then we should leave it be.
+    if (GetCurrentProcessId() == consoleProcessId) {
+        ShowWindow(console, IsWindowVisible(console) ? SW_HIDE : SW_SHOW);
+    }
 #endif
 }
 


### PR DESCRIPTION
Applies an offset of 0.5 in all axes with an even amount of pixels. Due to centering of all images, this makes pixels of images with even and off resolution overlap perfectly, which is needed for differences to make sense.