### PR TITLE
Only update filter and layout at most once per frame

### DIFF
--- a/include/ImageButton.h
+++ b/include/ImageButton.h
@@ -21,8 +21,14 @@ public:
 
     void draw(NVGcontext *ctx) override;
 
-    const std::string& caption() {
+    const std::string& caption() const {
         return mCaption;
+    }
+
+    void setCaption(const std::string& caption) {
+        mCaption = caption;
+        // Require cutoff re-computation.
+        mSizeForWhichCutoffWasComputed = Eigen::Vector2i::Constant(0);
     }
 
     void setReferenceCallback(const std::function<void(bool)> &callback) {

--- a/include/ImageViewer.h
+++ b/include/ImageViewer.h
@@ -97,7 +97,12 @@ public:
 
     void openImageDialog();
 
+    void requestLayoutUpdate() {
+        mRequiresLayoutUpdate = true;
+    }
+
 private:
+    void updateFilter();
     void updateLayout();
     void updateTitle();
     std::string layerName(size_t index);
@@ -110,6 +115,9 @@ private:
 
     std::shared_ptr<Image> nextImage(const std::shared_ptr<Image>& image, EDirection direction);
     std::shared_ptr<Image> nthVisibleImage(size_t n);
+
+    bool mRequiresFilterUpdate = true;
+    bool mRequiresLayoutUpdate = true;
 
     nanogui::Widget* mVerticalScreenSplit;
 

--- a/src/ImageButton.cpp
+++ b/src/ImageButton.cpp
@@ -112,7 +112,7 @@ void ImageButton::draw(NVGcontext *ctx) {
 
     if (mSize.x() == preferredSize(ctx).x()) {
         mCutoff = 0;
-    } else if(mSize != mSizeForWhichCutoffWasComputed) {
+    } else if (mSize != mSizeForWhichCutoffWasComputed) {
         mCutoff = 0;
         while (nvgTextBounds(ctx, 0, 0, mCaption.substr(mCutoff).c_str(), nullptr, nullptr) > mSize.x() - 25 - idSize) {
             ++mCutoff;


### PR DESCRIPTION
- This prevents stalls when loading a large amount of images at once.
- Previously, the program would re-compute the layout multiple times in a row in certain cases. This is no longer required.