### PR TITLE
Make sidebar resizable

### DIFF
--- a/include/ImageCanvas.h
+++ b/include/ImageCanvas.h
@@ -16,13 +16,14 @@ class ImageCanvas : public nanogui::GLCanvas {
 public:
     ImageCanvas(nanogui::Widget* parent, float pixelRatio);
 
-    bool mouseMotionEvent(const Eigen::Vector2i& p, const Eigen::Vector2i& rel, int button, int modifiers) override;
-
     bool scrollEvent(const Eigen::Vector2i& p, const Eigen::Vector2f& rel) override;
 
     void drawGL() override;
 
     void draw(NVGcontext *ctx) override;
+
+    void translate(const Eigen::Vector2f& amount);
+    void scale(float amount, const Eigen::Vector2f& origin);
 
     void setExposure(float exposure) {
         mExposure = exposure;
@@ -80,9 +81,6 @@ private:
     float computeMeanValue();
 
     Eigen::Vector2f pixelOffset(const Eigen::Vector2i& size) const;
-
-    void translate(const Eigen::Vector2f& amount);
-    void scale(float amount, const Eigen::Vector2f& origin);
 
     // Assembles the transform from canonical space to
     // the [-1, 1] square for the current image.

--- a/include/ImageViewer.h
+++ b/include/ImageViewer.h
@@ -120,7 +120,7 @@ private:
     std::shared_ptr<Image> nthVisibleImage(size_t n);
 
     bool canDragSidebarFrom(const Eigen::Vector2i& p) {
-        return mSidebar->visible() && abs(p.x() - mSidebar->fixedWidth()) < 20;
+        return mSidebar->visible() && abs(p.x() - mSidebar->fixedWidth()) < 10;
     }
 
     int visibleSidebarWidth() {

--- a/include/ImageViewer.h
+++ b/include/ImageViewer.h
@@ -29,6 +29,9 @@ public:
     ImageViewer();
     ImageViewer(std::shared_ptr<SharedQueue<ImageAddition>> imagesToAdd);
 
+    bool mouseButtonEvent(const Eigen::Vector2i &p, int button, bool down, int modifiers) override;
+    bool mouseMotionEvent(const Eigen::Vector2i& p, const Eigen::Vector2i& rel, int button, int modifiers) override;
+
     bool dropEvent(const std::vector<std::string>& filenames) override;
 
     bool keyboardEvent(int key, int scancode, int action, int modifiers) override;
@@ -116,12 +119,27 @@ private:
     std::shared_ptr<Image> nextImage(const std::shared_ptr<Image>& image, EDirection direction);
     std::shared_ptr<Image> nthVisibleImage(size_t n);
 
+    bool canDragSidebarFrom(const Eigen::Vector2i& p) {
+        return mSidebar->visible() && abs(p.x() - mSidebar->fixedWidth()) < 20;
+    }
+
+    int visibleSidebarWidth() {
+        return mSidebar->visible() ? mSidebar->fixedWidth() : 0;
+    }
+
+    int visibleFooterHeight() {
+        return mFooter->visible() ? mFooter->fixedHeight() : 0;
+    }
+
     bool mRequiresFilterUpdate = true;
     bool mRequiresLayoutUpdate = true;
 
     nanogui::Widget* mVerticalScreenSplit;
 
     nanogui::Widget* mSidebar;
+    nanogui::Button* mHelpButton;
+    nanogui::Widget* mSidebarLayout;
+
     nanogui::Widget* mFooter;
 
     nanogui::Label* mExposureLabel;
@@ -151,6 +169,9 @@ private:
     std::string mCurrentLayer;
 
     HelpWindow* mHelpWindow = nullptr;
+
+    bool mIsDraggingSidebar = false;
+    bool mIsDraggingImage = false;
 };
 
 TEV_NAMESPACE_END

--- a/src/ImageButton.cpp
+++ b/src/ImageButton.cpp
@@ -114,7 +114,7 @@ void ImageButton::draw(NVGcontext *ctx) {
         mCutoff = 0;
     } else if (mSize != mSizeForWhichCutoffWasComputed) {
         mCutoff = 0;
-        while (nvgTextBounds(ctx, 0, 0, mCaption.substr(mCutoff).c_str(), nullptr, nullptr) > mSize.x() - 25 - idSize) {
+        while (mCutoff < mCaption.size() && nvgTextBounds(ctx, 0, 0, mCaption.substr(mCutoff).c_str(), nullptr, nullptr) > mSize.x() - 25 - idSize) {
             ++mCutoff;
         }
 
@@ -122,7 +122,7 @@ void ImageButton::draw(NVGcontext *ctx) {
     }
 
     string caption = mCaption.substr(mCutoff);
-    if (mCutoff > 0) {
+    if (mCutoff > 0 && mCutoff < mCaption.size()) {
         caption = string{"…"} + caption;
     }
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -313,7 +313,7 @@ bool ImageViewer::mouseMotionEvent(const Eigen::Vector2i& p, const Eigen::Vector
     }
 
     if (mIsDraggingSidebar) {
-        mSidebar->setFixedWidth(p.x());
+        mSidebar->setFixedWidth(max(0, p.x()));
         requestLayoutUpdate();
     } else if (mIsDraggingImage) {
         // If left mouse button is held, move the image with mouse movement

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -315,7 +315,7 @@ bool ImageViewer::mouseMotionEvent(const Eigen::Vector2i& p, const Eigen::Vector
     }
 
     if (mIsDraggingSidebar) {
-        mSidebar->setFixedWidth(max(0, p.x()));
+        mSidebar->setFixedWidth(max(200, p.x()));
         requestLayoutUpdate();
     } else if (mIsDraggingImage) {
         // If left mouse button is held, move the image with mouse movement

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -289,7 +289,7 @@ bool ImageViewer::mouseButtonEvent(const Vector2i &p, int button, bool down, int
         if (canDragSidebarFrom(p)) {
             mIsDraggingSidebar = true;
             return true;
-        } else if (p.x() > visibleSidebarWidth() && p.y() < mSize.y() - visibleFooterHeight()) {
+        } else if (mImageCanvas->contains(p)) {
             mIsDraggingImage = true;
             return true;
         }
@@ -307,9 +307,11 @@ bool ImageViewer::mouseMotionEvent(const Eigen::Vector2i& p, const Eigen::Vector
     }
 
     if (mIsDraggingSidebar || canDragSidebarFrom(p)) {
-        setCursor(Cursor::HResize);
+        mSidebarLayout->setCursor(Cursor::HResize);
+        mImageCanvas->setCursor(Cursor::HResize);
     } else {
-        setCursor(Cursor::Arrow);
+        mSidebarLayout->setCursor(Cursor::Arrow);
+        mImageCanvas->setCursor(Cursor::Arrow);
     }
 
     if (mIsDraggingSidebar) {
@@ -928,7 +930,7 @@ void ImageViewer::toggleHelpWindow() {
 }
 
 void ImageViewer::openImageDialog() {
-    vector<string> paths = file_dialog_multiple(
+    vector<string> paths = file_dialog(
     {
         {"exr",  "OpenEXR image"},
         {"hdr",  "HDR image"},
@@ -941,7 +943,7 @@ void ImageViewer::openImageDialog() {
         {"pnm",  "Portable Any Map image"},
         {"psd",  "PSD image"},
         {"tga",  "Truevision TGA image"},
-    });
+    }, false, true);
 
     for (size_t i = 0; i < paths.size(); ++i) {
         const string& imageFile = paths[i];

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -41,28 +41,26 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
     mSidebar = new Widget{horizontalScreenSplit};
     mSidebar->setFixedWidth(200);
 
-    auto helpButton = new Button{mSidebar, "", ENTYPO_ICON_HELP};
-    helpButton->setPosition(Vector2i{162, 5});
-    helpButton->setCallback([this]() { toggleHelpWindow(); });
-    helpButton->setFontSize(15);
-    helpButton->setTooltip("Information about using tev.");
+    mHelpButton = new Button{mSidebar, "", ENTYPO_ICON_HELP};
+    mHelpButton->setCallback([this]() { toggleHelpWindow(); });
+    mHelpButton->setFontSize(15);
+    mHelpButton->setTooltip("Information about using tev.");
 
-    auto sidebarLayout = new Widget{mSidebar};
-    sidebarLayout->setLayout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 0, 0});
-    sidebarLayout->setFixedWidth(200);
+    mSidebarLayout = new Widget{mSidebar};
+    mSidebarLayout->setLayout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 0, 0});
 
     mImageCanvas = new ImageCanvas{horizontalScreenSplit, pixelRatio()};
 
     // Exposure label and slider
     {
-        auto panel = new Widget{sidebarLayout};
+        auto panel = new Widget{mSidebarLayout};
         panel->setLayout(new BoxLayout{Orientation::Horizontal, Alignment::Fill, 5});
         new Label{panel, "Tonemapping", "sans-bold", 25};
         panel->setTooltip(
             "Various tonemapping options. Hover the individual controls to learn more!"
         );
 
-        panel = new Widget{sidebarLayout};
+        panel = new Widget{mSidebarLayout};
         panel->setLayout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 5});
 
         mExposureLabel = new Label{panel, "", "sans-bold", 15};
@@ -79,7 +77,7 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
             "Keyboard shortcuts:\nE and Shift+E"
         );
 
-        panel = new Widget{sidebarLayout};
+        panel = new Widget{mSidebarLayout};
         panel->setLayout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 5});
 
         mOffsetLabel = new Label{panel, "", "sans-bold", 15};
@@ -99,7 +97,7 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
 
     // Exposure/offset buttons
     {
-        auto buttonContainer = new Widget{sidebarLayout};
+        auto buttonContainer = new Widget{mSidebarLayout};
         buttonContainer->setLayout(new GridLayout{Orientation::Horizontal, 2, Alignment::Fill, 5, 2});
 
         auto makeButton = [&](const string& name, function<void()> callback, int icon = 0, string tooltip = "") {
@@ -116,7 +114,7 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
 
     // Tonemap options
     {
-        mTonemapButtonContainer = new Widget{sidebarLayout};
+        mTonemapButtonContainer = new Widget{mSidebarLayout};
         mTonemapButtonContainer->setLayout(new GridLayout{Orientation::Horizontal, 4, Alignment::Fill, 5, 2});
 
         auto makeTonemapButton = [&](const string& name, function<void()> callback) {
@@ -153,7 +151,7 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
 
     // Error metrics
     {
-        mMetricButtonContainer = new Widget{sidebarLayout};
+        mMetricButtonContainer = new Widget{mSidebarLayout};
         mMetricButtonContainer->setLayout(new GridLayout{Orientation::Horizontal, 5, Alignment::Fill, 5, 2});
 
         auto makeMetricButton = [&](const string& name, function<void()> callback) {
@@ -195,10 +193,10 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
 
     // Image selection
     {
-        auto spacer = new Widget{sidebarLayout};
+        auto spacer = new Widget{mSidebarLayout};
         spacer->setHeight(10);
 
-        auto panel = new Widget{sidebarLayout};
+        auto panel = new Widget{mSidebarLayout};
         panel->setLayout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 5});
         auto label = new Label{panel, "Images", "sans-bold", 25};
         label->setTooltip(
@@ -207,7 +205,7 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
             "While a reference image is set, the currently selected image is not simply displayed, but compared to the reference image."
         );
 
-        panel = new Widget{sidebarLayout};
+        panel = new Widget{mSidebarLayout};
         panel->setLayout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 5});
         label = new Label{panel, "Filter", "sans-bold", 15};
 
@@ -226,7 +224,7 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
             HelpWindow::COMMAND
         ));
 
-        auto tools = new Widget{sidebarLayout};
+        auto tools = new Widget{mSidebarLayout};
         tools->setLayout(new GridLayout{Orientation::Horizontal, 4, Alignment::Fill, 5, 2});
 
         auto makeImageButton = [&](const string& name, function<void()> callback, int icon = 0, string tooltip = "") {
@@ -252,11 +250,11 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
             removeImage(mCurrentImage);
         }, ENTYPO_ICON_CIRCLED_CROSS, tfm::format("Close (%s+W)", HelpWindow::COMMAND));
 
-        spacer = new Widget{sidebarLayout};
+        spacer = new Widget{mSidebarLayout};
         spacer->setHeight(3);
 
-        mImageScrollContainer = new VScrollPanel{sidebarLayout};
-        mImageScrollContainer->setFixedWidth(sidebarLayout->fixedWidth());
+        mImageScrollContainer = new VScrollPanel{mSidebarLayout};
+        mImageScrollContainer->setFixedWidth(mSidebarLayout->fixedWidth());
 
         mScrollContent = new Widget{mImageScrollContainer};
         mScrollContent->setLayout(new BoxLayout{Orientation::Vertical, Alignment::Fill});
@@ -280,6 +278,56 @@ ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
 
     this->setSize(Vector2i(1024, 800));
     selectReference(nullptr);
+}
+
+bool ImageViewer::mouseButtonEvent(const Vector2i &p, int button, bool down, int modifiers) {
+    if (Screen::mouseButtonEvent(p, button, down, modifiers)) {
+        return true;
+    }
+
+    if (down) {
+        if (canDragSidebarFrom(p)) {
+            mIsDraggingSidebar = true;
+            return true;
+        } else if (p.x() > visibleSidebarWidth() && p.y() < mSize.y() - visibleFooterHeight()) {
+            mIsDraggingImage = true;
+            return true;
+        }
+    } else {
+        mIsDraggingSidebar = false;
+        mIsDraggingImage = false;
+    }
+
+    return false;
+}
+
+bool ImageViewer::mouseMotionEvent(const Eigen::Vector2i& p, const Eigen::Vector2i& rel, int button, int modifiers) {
+    if (Screen::mouseMotionEvent(p, rel, button, modifiers)) {
+        return true;
+    }
+
+    if (mIsDraggingSidebar || canDragSidebarFrom(p)) {
+        setCursor(Cursor::HResize);
+    } else {
+        setCursor(Cursor::Arrow);
+    }
+
+    if (mIsDraggingSidebar) {
+        mSidebar->setFixedWidth(p.x());
+        requestLayoutUpdate();
+    } else if (mIsDraggingImage) {
+        // If left mouse button is held, move the image with mouse movement
+        if ((button & 1) != 0) {
+            mImageCanvas->translate(rel.cast<float>());
+        }
+
+        // If middle mouse button is held, zoom in-out with up-down mouse movement
+        if ((button & 4) != 0) {
+            mImageCanvas->scale(rel.y() / 10.0f, p.cast<float>());
+        }
+    }
+
+    return false;
 }
 
 bool ImageViewer::dropEvent(const vector<string>& filenames) {
@@ -845,6 +893,10 @@ void ImageViewer::toggleMaximized() {
 }
 
 void ImageViewer::setUiVisible(bool shouldBeVisible) {
+    if (!shouldBeVisible) {
+        mIsDraggingSidebar = false;
+    }
+
     mSidebar->setVisible(shouldBeVisible);
 
     bool shouldFooterBeVisible = false;
@@ -981,10 +1033,13 @@ void ImageViewer::updateFilter() {
 }
 
 void ImageViewer::updateLayout() {
-    int sidebarWidth = mSidebar->visible() ? mSidebar->fixedWidth() : 0;
-    int footerHeight = mFooter->visible() ? mFooter->fixedHeight() : 0;
+    int sidebarWidth = visibleSidebarWidth();
+    int footerHeight = visibleFooterHeight();
     mImageCanvas->setFixedSize(mSize - Vector2i{sidebarWidth, footerHeight});
     mSidebar->setFixedHeight(mSize.y() - footerHeight);
+
+    mHelpButton->setPosition(Vector2i{mSidebar->fixedWidth() - 38, 5});
+    mSidebarLayout->setFixedWidth(mSidebar->fixedWidth());
 
     mVerticalScreenSplit->setFixedSize(mSize);
     mImageScrollContainer->setFixedHeight(


### PR DESCRIPTION
Makes the sidebar resizable. In order to not break image dragging, the supporting code has, too, been moved from `ImageCanvas` to `ImageViewer`, in the process improving the behavior when moving the mouse out of the window while dragging.