### PR TITLE
Do not allow multiple instances of tev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 
 set(TEV_LIBS IlmImf nanogui ${NANOGUI_EXTRA_LIBS})
 if (MSVC)
-    set(TEV_LIBS ${TEV_LIBS} zlibstatic)
+    set(TEV_LIBS ${TEV_LIBS} zlibstatic wsock32 ws2_32)
 endif()
 
 add_executable(tev

--- a/include/Common.h
+++ b/include/Common.h
@@ -17,12 +17,7 @@
 #   include <Windows.h>
 using socklen_t = int;
 #else
-#   ifdef __APPLE__
-#       include <arpa/inet.h>
-#       include <fcntl.h>
-#       include <netinet/in.h>
-#   endif
-#   include <sys/types.h>
+#   include <netinet/in.h>
 #endif
 
 #ifdef _WIN32

--- a/include/Common.h
+++ b/include/Common.h
@@ -81,6 +81,8 @@ std::string toUpper(std::string str);
 
 bool matches(std::string text, std::string filter);
 
+std::string absolutePath(std::string path);
+
 enum ETonemap : int {
     SRGB = 0,
     Gamma,

--- a/include/Common.h
+++ b/include/Common.h
@@ -15,7 +15,13 @@
 #ifdef _WIN32
 #   define NOMINMAX
 #   include <Windows.h>
+using socklen_t = int;
 #else
+#   ifdef __APPLE__
+#       include <arpa/inet.h>
+#       include <fcntl.h>
+#       include <netinet/in.h>
+#   endif
 #   include <sys/types.h>
 #endif
 
@@ -119,7 +125,7 @@ public:
     }
 
     void sendToPrimaryInstance(std::string message);
-    void receiveFromSecondaryInstance(std::function<void(std::string)> callback);
+    bool receiveFromSecondaryInstance(std::function<void(std::string)> callback);
 
 private:
     bool mIsPrimaryInstance;
@@ -131,6 +137,7 @@ private:
 #else
     int mLockFileDescriptor;
     int mSocket;
+    std::string mLockFile;
 #endif
 };
 

--- a/include/ImageViewer.h
+++ b/include/ImageViewer.h
@@ -26,8 +26,7 @@ struct ImageAddition {
 
 class ImageViewer : public nanogui::Screen {
 public:
-    ImageViewer();
-    ImageViewer(std::shared_ptr<SharedQueue<ImageAddition>> imagesToAdd);
+    ImageViewer(std::shared_ptr<Ipc> ipc, std::shared_ptr<SharedQueue<ImageAddition>> imagesToAdd);
 
     bool mouseButtonEvent(const Eigen::Vector2i &p, int button, bool down, int modifiers) override;
     bool mouseMotionEvent(const Eigen::Vector2i& p, const Eigen::Vector2i& rel, int button, int modifiers) override;
@@ -130,6 +129,8 @@ private:
     int visibleFooterHeight() {
         return mFooter->visible() ? mFooter->fixedHeight() : 0;
     }
+
+    std::shared_ptr<Ipc> mIpc;
 
     bool mRequiresFilterUpdate = true;
     bool mRequiresLayoutUpdate = true;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -7,8 +7,12 @@
 #include <cctype>
 #include <map>
 
-#ifdef _WIN32
-#include <Windows.h>
+#ifndef _WIN32
+#   include <errno.h>
+#   include <pwd.h>
+#   include <unistd.h>
+#   define SOCKET_ERROR (-1)
+#   define INVALID_SOCKET (-1)
 #endif
 
 using namespace std;
@@ -113,6 +117,133 @@ void toggleConsole() {
     if (GetCurrentProcessId() == consoleProcessId) {
         ShowWindow(console, IsWindowVisible(console) ? SW_HIDE : SW_SHOW);
     }
+#endif
+}
+
+static string lastSocketError() {
+#ifdef _WIN32
+    int lastError = WSAGetLastError();
+    char* s = NULL;
+    FormatMessage(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL, lastError, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&s, 0, NULL);
+    
+    string result = tfm::format("%s (%d)", s, lastError);
+    LocalFree(s);
+
+    return result;
+#else
+    return tfm::format("%s (%d)", strerror(errno), errno);
+#endif
+}
+
+Ipc::Ipc() {
+    static const string lockName = ".tev-lock";
+    static const string localhost = "127.0.0.1";
+    static const short port = 1415;
+
+    memset((char*)&mAddress, 0, sizeof(mAddress));
+
+#ifdef _WIN32
+    //Make sure at most one instance of the tool is running
+    mInstanceMutex = CreateMutex(NULL, TRUE, lockName.c_str());
+    mIsPrimaryInstance = mInstanceMutex && GetLastError() != ERROR_ALREADY_EXISTS;
+    if (!mIsPrimaryInstance) {
+        // No need to keep the handle to the existing mutex if we're not the primary instance.
+        if (mInstanceMutex) {
+            ReleaseMutex(mInstanceMutex);
+            CloseHandle(mInstanceMutex);
+        }
+    }
+
+    // Initialize Winsock
+    WSADATA wsaData;
+    if (WSAStartup(MAKEWORD(2, 2), &wsaData) != NO_ERROR) {
+        cerr << "Could not initialize WSA; inter-process communication will not function." << endl;
+    }
+#else
+    struct passwd* pw = getpwuid(getuid());
+    string homedir = pw->pw_dir;
+
+    string lockFile = homedir + "/" + lockName;
+
+    mLockFileDescriptor = open(lockFile.c_str(), O_RDWR | O_CREAT, 0666);
+    mIsPrimaryInstance = !flock(fd, LOCK_EX | LOCK_NB));
+    if (!mIsPrimaryInstance) {
+        close(mLockFileDescriptor);
+    }
+#endif
+
+    mAddress.sin_family = AF_INET;
+    mAddress.sin_port = htons(port);
+
+#ifdef _WIN32
+    mAddress.sin_addr.S_un.S_addr = inet_addr(localhost.c_str());
+#else
+    inet_aton(localhost.c_str(), &mAddress.sin_addr);
+#endif
+
+    mSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (mSocket == INVALID_SOCKET) {
+        cerr << "Could not create UDP socket; inter-process communication will not function: " << lastSocketError() << endl;
+    }
+
+    // Make socket non-blocking
+#ifdef _WIN32
+    u_long mode = 1;
+    ioctlsocket(mSocket, FIONBIO, &mode);
+#else
+    int flags = fcntl(mSocket, F_GETFL, 0);
+    fcntl(s, F_SETFL, flags | O_NONBLOCK);
+#endif
+
+    // Listen to UDP packets if we're the primary instance.
+    if (mIsPrimaryInstance) {
+        int result = ::bind(mSocket, (sockaddr*)&mAddress, sizeof(mAddress));
+        if (result == SOCKET_ERROR) {
+            cerr << "Could not bind UDP socket; inter-process communication will not function: " << lastSocketError() << endl;
+        }
+    }
+}
+
+void Ipc::sendToPrimaryInstance(string message) {
+    int bytesSent = sendto(mSocket, message.c_str(), (int)message.length() + 1, 0, (sockaddr*)&mAddress, sizeof(mAddress));
+    if (bytesSent == -1) {
+        throw runtime_error{tfm::format("Could not send to primary instance: %s", lastSocketError())};
+    }
+}
+
+void Ipc::receiveFromSecondaryInstance(function<void(string)> callback) {
+    sockaddr_in recvAddress;
+    int recvAddressSize = sizeof(recvAddress);
+    char recvBuffer[16384];
+
+    int bytesReceived = recvfrom(mSocket, recvBuffer, sizeof(recvBuffer), 0, (sockaddr*)&recvAddress, &recvAddressSize);
+    if (bytesReceived <= 0) {
+        return;
+    }
+
+    if (recvBuffer[bytesReceived - 1] == '\0') {
+        // We probably received a valid string. Let's pass it to our callback function.
+        // TODO: Proper handling of multiple concatenated and partial packets.
+        callback(recvBuffer);
+    }
+}
+
+Ipc::~Ipc() {
+#ifdef _WIN32
+    if (mIsPrimaryInstance) {
+        ReleaseMutex(mInstanceMutex);
+        CloseHandle(mInstanceMutex);
+    }
+
+    closesocket(mSocket);
+#else
+    if (mIsPrimaryInstance) {
+        close(mLockFileDescriptor);
+    }
+
+    close(mSocket);
 #endif
 }
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -288,12 +288,14 @@ Ipc::~Ipc() {
         closesocket(mSocket);
     }
 #else
-    if (mIsPrimaryInstance && mLockFileDescriptor != -1) {
-        close(mLockFileDescriptor);
-    }
+    if (mIsPrimaryInstance) {
+        if (mLockFileDescriptor != -1) {
+            close(mLockFileDescriptor);
+        }
 
-    // Delete the lock file if it exists.
-    unlink(mLockFile.c_str());
+        // Delete the lock file if it exists.
+        unlink(mLockFile.c_str());
+    }
 
     if (mSocket != INVALID_SOCKET) {
         close(mSocket);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -8,8 +8,13 @@
 #include <map>
 
 #ifndef _WIN32
-#   include <errno.h>
+#   include <arpa/inet.h>
+#   include <cstring>
+#   include <cerrno>
+#   include <fcntl.h>
 #   include <pwd.h>
+#   include <sys/file.h>
+#   include <sys/types.h>
 #   include <unistd.h>
 #   define SOCKET_ERROR (-1)
 #   define INVALID_SOCKET (-1)

--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -109,14 +109,14 @@ HelpWindow::HelpWindow(Widget *parent, function<void()> closeCallback)
     addRow(layerSelection, "Left or A",  "Select Previous Layer");
 
     new Label{this, "Interface", "sans-bold", 18};
-    auto interface = new Widget{this};
-    interface->setLayout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 0, 0});
+    auto ui = new Widget{this};
+    ui->setLayout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 0, 0});
 
-    addRow(interface, ALT + "+Enter", "Maximize");
-    addRow(interface, COMMAND + "+B", "Toggle GUI");
-    addRow(interface, "H",            "Show Help (this Window)");
-    addRow(interface, COMMAND + "+P", "Find Image or Layer");
-    addRow(interface, "Q or Esc",     "Quit");
+    addRow(ui, ALT + "+Enter", "Maximize");
+    addRow(ui, COMMAND + "+B", "Toggle GUI");
+    addRow(ui, "H",            "Show Help (this Window)");
+    addRow(ui, COMMAND + "+P", "Find Image or Layer");
+    addRow(ui, "Q or Esc",     "Quit");
 }
 
 bool HelpWindow::keyboardEvent(int key, int scancode, int action, int modifiers) {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -357,7 +357,8 @@ shared_ptr<Image> tryLoadImage(string filename, string channelSelector) {
     try {
         filename = absolutePath(filename);
     } catch (runtime_error e) {
-        cerr << tfm::format("absolutePath('%s') failed: %s. Trying to load image anyway...", filename, e.what()) << endl;
+        // If for some strange reason we can not obtain an absolute path, let's still
+        // try to open the image at the given path just to make sure.
     }
 
     try {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -355,6 +355,12 @@ l_foundPart:
 
 shared_ptr<Image> tryLoadImage(string filename, string channelSelector) {
     try {
+        filename = absolutePath(filename);
+    } catch (runtime_error e) {
+        cerr << tfm::format("absolutePath('%s') failed: %s. Trying to load image anyway...", filename, e.what()) << endl;
+    }
+
+    try {
         return make_shared<Image>(filename, channelSelector);
     } catch (invalid_argument e) {
         tfm::format(cerr, "Could not load image from %s:%s - %s\n", filename, channelSelector, e.what());

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -483,6 +483,7 @@ bool ImageViewer::keyboardEvent(int key, int scancode, int action, int modifiers
 }
 
 void ImageViewer::drawContents() {
+    bool receivedFileViaIpc = false;
     while (mIpc->receiveFromSecondaryInstance([this](string imageString) {
         ThreadPool::singleWorker().enqueueTask([imageString, this] {
             size_t colonPos = min(imageString.length() - 1, imageString.find_last_of(":"));
@@ -491,7 +492,9 @@ void ImageViewer::drawContents() {
                 mImagesToAdd->push({true, image});
             }
         });
-    }));
+    })) {
+        receivedFileViaIpc = true;
+    }
 
     try {
         while (true) {
@@ -499,6 +502,10 @@ void ImageViewer::drawContents() {
             addImage(addition.image, addition.shallSelect);
         }
     } catch (runtime_error) {
+    }
+
+    if (receivedFileViaIpc) {
+        glfwFocusWindow(mGLFWWindow);
     }
 
     if (mRequiresFilterUpdate) {

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -483,7 +483,7 @@ bool ImageViewer::keyboardEvent(int key, int scancode, int action, int modifiers
 }
 
 void ImageViewer::drawContents() {
-    mIpc->receiveFromSecondaryInstance([this](string imageString) {
+    while (mIpc->receiveFromSecondaryInstance([this](string imageString) {
         ThreadPool::singleWorker().enqueueTask([imageString, this] {
             size_t colonPos = min(imageString.length() - 1, imageString.find_last_of(":"));
             auto image = tryLoadImage(imageString.substr(0, colonPos), imageString.substr(colonPos + 1));
@@ -491,7 +491,7 @@ void ImageViewer::drawContents() {
                 mImagesToAdd->push({true, image});
             }
         });
-    });
+    }));
 
     try {
         while (true) {

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -21,14 +21,12 @@ using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
-ImageViewer::ImageViewer()
-: ImageViewer{make_shared<SharedQueue<ImageAddition>>()} {
-}
-
-ImageViewer::ImageViewer(shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
-: nanogui::Screen{Vector2i{1024, 799}, "tev"}, mImagesToAdd{imagesToAdd} {
+ImageViewer::ImageViewer(shared_ptr<Ipc> ipc, shared_ptr<SharedQueue<ImageAddition>> imagesToAdd)
+: nanogui::Screen{Vector2i{1024, 799}, "tev"}, mIpc{ipc}, mImagesToAdd{imagesToAdd} {
     // At this point we no longer need the standalone console (if it exists).
     toggleConsole();
+
+    TEV_ASSERT(mIpc->isPrimaryInstance(), "ImageViewer may only exist in the primary instance of tev.");
 
     mBackground = Color{0.23f, 1.0f};
 
@@ -485,6 +483,16 @@ bool ImageViewer::keyboardEvent(int key, int scancode, int action, int modifiers
 }
 
 void ImageViewer::drawContents() {
+    mIpc->receiveFromSecondaryInstance([this](string imageString) {
+        ThreadPool::singleWorker().enqueueTask([imageString, this] {
+            size_t colonPos = min(imageString.length() - 1, imageString.find_last_of(":"));
+            auto image = tryLoadImage(imageString.substr(0, colonPos), imageString.substr(colonPos + 1));
+            if (image) {
+                mImagesToAdd->push({true, image});
+            }
+        });
+    });
+
     try {
         while (true) {
             auto addition = mImagesToAdd->tryPop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,7 @@ int mainFunc(int argc, char* argv[]) {
             try {
                 ipc->sendToPrimaryInstance(absolutePath(imageFile) + ":" + channelSelector);
             } catch (runtime_error e) {
-                cerr << tfm::format("Invalid file '%s': %s", imageFile, e.what()) << endl;
+                cerr << "Invalid file '" << imageFile << "': " << e.what() << endl;
             }
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,11 @@ int mainFunc(int argc, char* argv[]) {
                 continue;
             }
 
-            ipc->sendToPrimaryInstance(imageFile + ":" + channelSelector);
+            try {
+                ipc->sendToPrimaryInstance(absolutePath(imageFile) + ":" + channelSelector);
+            } catch (runtime_error e) {
+                cerr << tfm::format("Invalid file '%s': %s", imageFile, e.what()) << endl;
+            }
         }
 
         return 0;


### PR DESCRIPTION
If an instance of tev is already open, then images will always be opened in that instance.
- On unix, running instances are checked via a lock file in the home directory.
- On windows, running instances are checked via a global mutex.
- Filenames are transferred from secondary instances to the primary instance via lean UDP.
- Always opens images at absolute paths.