### PR TITLE
Improve histograms in subtle ways

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 project(tev)
-set(VERSION "1.4.dev")
+set(VERSION "1.5.dev")
 
 # Set ourselves as the startup project in visual studio.
 # Not available until cmake 3.6, but doesn't break older versions.

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -6,6 +6,7 @@
 #include <tev/Channel.h>
 #include <tev/GlTexture.h>
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <string>
@@ -55,9 +56,15 @@ public:
         return mLayers;
     }
 
+    int id() const {
+        return mId;
+    }
+
     std::string toString() const;
 
 private:
+    static std::atomic<int> sId;
+
     void readStbi();
     void readExr();
 
@@ -72,6 +79,8 @@ private:
     std::map<std::string, GlTexture> mTextures;
 
     std::vector<std::string> mLayers;
+
+    const int mId;
 };
 
 std::shared_ptr<Image> tryLoadImage(std::string filename, std::string channelSelector);

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -56,7 +56,10 @@ public:
         mRequestedLayer = layerName;
     }
 
-    std::vector<std::string> getChannels(const Image& image) const;
+    static std::vector<std::string> getChannels(const Image& image, const std::string& requestedLayer);
+    std::vector<std::string> getChannels(const Image& image) const {
+        return getChannels(image, mRequestedLayer);
+    }
 
     Eigen::Vector2i getImageCoords(const Image& image, Eigen::Vector2i mousePos);
 
@@ -75,7 +78,10 @@ public:
         mTonemap = tonemap;
     }
 
-    Eigen::Vector3f applyTonemap(const Eigen::Vector3f& value) const;
+    static Eigen::Vector3f applyTonemap(const Eigen::Vector3f& value, ETonemap tonemap);
+    Eigen::Vector3f applyTonemap(const Eigen::Vector3f& value) const {
+        return applyTonemap(value, mTonemap);
+    }
 
     EMetric metric() const {
         return mMetric;
@@ -85,7 +91,10 @@ public:
         mMetric = metric;
     }
 
-    float applyMetric(float value, float reference) const;
+    static float applyMetric(float value, float reference, EMetric metric);
+    float applyMetric(float value, float reference) const {
+        return applyMetric(value, reference, mMetric);
+    }
 
     void fitImageToScreen(const Image& image);
     void resetTransform();
@@ -95,8 +104,19 @@ public:
     std::shared_ptr<Lazy<std::shared_ptr<CanvasStatistics>>> canvasStatistics();
 
 private:
-    std::vector<Channel> channelsFromDisplayedImage() const;
-    std::shared_ptr<CanvasStatistics> computeCanvasStatistics() const;
+    static std::vector<Channel> channelsFromImages(
+        std::shared_ptr<Image> image,
+        std::shared_ptr<Image> reference,
+        const std::string& requestedLayer,
+        EMetric metric
+    );
+
+    static std::shared_ptr<CanvasStatistics> computeCanvasStatistics(
+        std::shared_ptr<Image> image,
+        std::shared_ptr<Image> reference,
+        const std::string& requestedLayer,
+        EMetric metric
+    );
 
     Eigen::Vector2f pixelOffset(const Eigen::Vector2i& size) const;
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -33,7 +33,7 @@ bool isExrFile(const string& filename) {
     return !!f && b[0] == 0x76 && b[1] == 0x2f && b[2] == 0x31 && b[3] == 0x01;
 }
 
-atomic<int> Image::sId = 0;
+atomic<int> Image::sId(0);
 
 Image::Image(const string& filename, const string& channelSelector)
 : mFilename{ filename }, mChannelSelector{ channelSelector }, mId{sId++} {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -33,8 +33,10 @@ bool isExrFile(const string& filename) {
     return !!f && b[0] == 0x76 && b[1] == 0x2f && b[2] == 0x31 && b[3] == 0x01;
 }
 
+atomic<int> Image::sId = 0;
+
 Image::Image(const string& filename, const string& channelSelector)
-: mFilename{filename}, mChannelSelector{channelSelector} {
+: mFilename{ filename }, mChannelSelector{ channelSelector }, mId{sId++} {
     if (!channelSelector.empty()) {
         mName = tfm::format("%s:%s", filename, channelSelector);
     } else {

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -428,8 +428,8 @@ shared_ptr<Lazy<shared_ptr<CanvasStatistics>>> ImageCanvas::canvasStatistics() {
 
     string channels = join(getChannels(*mImage), ",");
     string key = mReference ?
-        tfm::format("%s-%s-%s-%d", mImage->filename(), channels, mReference->filename(), mMetric) :
-        tfm::format("%s-%s", mImage->filename(), channels);
+        tfm::format("%d-%s-%d-%d", mImage->id(), channels, mReference->id(), mMetric) :
+        tfm::format("%d-%s", mImage->id(), channels);
 
     auto iter = mMeanValues.find(key);
     if (iter != end(mMeanValues)) {

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -541,8 +541,10 @@ shared_ptr<CanvasStatistics> ImageCanvas::computeCanvasStatistics(
 
     size_t nChannels = 0;
 
+    const Channel* alphaChannel = nullptr;
     for (const auto& channel : flattened) {
         if (channel.name() == "A") {
+            alphaChannel = &channel;
             continue;
         }
 
@@ -596,7 +598,7 @@ shared_ptr<CanvasStatistics> ImageCanvas::computeCanvasStatistics(
         size_t numElements = (size_t)channelSize.x() * channelSize.y();
         for (size_t i = 0; i < numElements; ++i) {
             int bin = valToBin(channel.eval(i));
-            result->histogram(bin, iChannel) += 1;
+            result->histogram(bin, iChannel) += alphaChannel ? alphaChannel->eval(i) : 1;
         }
 
         ++iChannel;

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -604,7 +604,7 @@ shared_ptr<CanvasStatistics> ImageCanvas::computeCanvasStatistics(
         ++iChannel;
     }
 
-    result->histogram /= result->histogram.maxCoeff() * 1.3f;
+    result->histogram *= NUM_BINS * 0.25f / ((size_t)image->size().x() * image->size().y() * nChannels);
     result->histogramZero = valToBin(0);
     return result;
 }

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -498,7 +498,7 @@ vector<Channel> ImageCanvas::channelsFromImages(
                 } else {
                     for (int y = 0; y < size.y(); ++y) {
                         for (int x = 0; x < size.x(); ++x) {
-                            result[i].at({x, y}) = applyMetric(
+                            result[i].at({x, y}) = ImageCanvas::applyMetric(
                                 chan->eval({x, y}),
                                 referenceChan->eval({x + offset.x(), y + offset.y()}),
                                 metric
@@ -516,7 +516,7 @@ vector<Channel> ImageCanvas::channelsFromImages(
                 } else {
                     for (int y = 0; y < size.y(); ++y) {
                         for (int x = 0; x < size.x(); ++x) {
-                            result[i].at({x, y}) = applyMetric(chan->eval({x, y}), 0, metric);
+                            result[i].at({x, y}) = ImageCanvas::applyMetric(chan->eval({x, y}), 0, metric);
                         }
                     }
                 }

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -553,7 +553,7 @@ void ImageViewer::drawContents() {
     updateTitle();
 
     // Update histogram
-    static const string histogramTooltipBase = "Histogram of color values.Adapts to the currently chosen layer and error metric.";
+    static const string histogramTooltipBase = "Histogram of color values. Adapts to the currently chosen layer and error metric.";
     auto lazyCanvasStatistics = mImageCanvas->canvasStatistics();
     if (lazyCanvasStatistics) {
         if (lazyCanvasStatistics->isReady()) {
@@ -574,7 +574,7 @@ void ImageViewer::drawContents() {
                 statistics->maximum)
             );
         }
-        
+
     } else {
         mHistogram->setValues(MatrixXf::Zero(1, 1));
         mHistogram->setMinimum(0);

--- a/src/MultiGraph.cpp
+++ b/src/MultiGraph.cpp
@@ -7,7 +7,6 @@
 
 #include <nanogui/theme.h>
 #include <nanogui/opengl.h>
-#include <nanogui/serializer/core.h>
 
 using namespace Eigen;
 using namespace nanogui;

--- a/src/MultiGraph.cpp
+++ b/src/MultiGraph.cpp
@@ -64,7 +64,7 @@ void MultiGraph::draw(NVGcontext *ctx) {
 
             auto color = i < colors.size() ? colors[i] : mForegroundColor;
             nvgLineTo(ctx, mPos.x() + mSize.x(), mPos.y() + mSize.y());
-            nvgFillColor(ctx, colors[i]);
+            nvgFillColor(ctx, color);
             nvgFill(ctx);
         }
 

--- a/src/MultiGraph.cpp
+++ b/src/MultiGraph.cpp
@@ -55,9 +55,10 @@ void MultiGraph::draw(NVGcontext *ctx) {
         for (size_t i = 0; i < (size_t)mValues.cols(); i++) {
             nvgBeginPath(ctx);
             nvgMoveTo(ctx, mPos.x(), mPos.y() + mSize.y());
+            
             for (size_t j = 0; j < (size_t)mValues.rows(); j++) {
                 float value = mValues(j, i);
-                float vx = mPos.x() + j * mSize.x() / (float)(mValues.rows() - 1);
+                float vx = mPos.x() + 2 + j * (mSize.x() - 4) / (float)(mValues.rows() - 1);
                 float vy = mPos.y() + (1 - value) * mSize.y();
                 nvgLineTo(ctx, vx, vy);
             }
@@ -72,7 +73,7 @@ void MultiGraph::draw(NVGcontext *ctx) {
 
         if (mZeroBin > 0) {
             nvgBeginPath(ctx);
-            nvgRect(ctx, mPos.x() + mZeroBin * mSize.x() / (float)(mValues.rows() - 1), mPos.y() + 15, 1, mSize.y() - 15);
+            nvgRect(ctx, mPos.x() + 2 + mZeroBin * (mSize.x() - 4) / (float)(mValues.rows() - 1), mPos.y() + 15, 1, mSize.y() - 15);
             nvgFillColor(ctx, Color(200, 255));
             nvgFill(ctx);
         }


### PR DESCRIPTION
- Don't cut off the left-most and right-most parts of the histogram.
- Reloading an image now does not hit the cache but instead re-makes a new histogram.
- Fix race condition with loading images and immediately deleting them.