### PR TITLE
Better histogram text

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -37,6 +37,8 @@
     if (UNLIKELY(!(cond))) \
         throw std::runtime_error{tfm::format(description, ##__VA_ARGS__)};
 
+struct NVGcontext;
+
 TEV_NAMESPACE_BEGIN
 
 template <typename T>
@@ -72,6 +74,8 @@ std::string toUpper(std::string str);
 bool endsWith(const std::string& str, const std::string& ending);
 
 bool matches(std::string text, std::string filter);
+
+void drawTextWithShadow(NVGcontext* ctx, float x, float y, std::string text, float shadowAlpha = 1.0f);
 
 int lastError();
 int lastSocketError();

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -3,6 +3,8 @@
 
 #include <tev/Common.h>
 
+#include <nanogui/opengl.h>
+
 #include <algorithm>
 #include <cctype>
 #include <map>
@@ -15,6 +17,7 @@
 #   include <unistd.h>
 #endif
 
+using namespace nanogui;
 using namespace std;
 
 TEV_NAMESPACE_BEGIN
@@ -74,6 +77,15 @@ bool matches(string text, string filter) {
     }
 
     return false;
+}
+
+void drawTextWithShadow(NVGcontext* ctx, float x, float y, string text, float shadowAlpha) {
+    nvgSave(ctx);
+    nvgFontBlur(ctx, 2);
+    nvgFillColor(ctx, Color{0.0f, shadowAlpha});
+    nvgText(ctx, x + 1, y + 1, text.c_str(), NULL);
+    nvgRestore(ctx);
+    nvgText(ctx, x, y, text.c_str(), NULL);
 }
 
 ETonemap toTonemap(string name) {

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -127,16 +127,9 @@ void ImageCanvas::draw(NVGcontext *ctx) {
                             mPos.y() + nano.y() + (i - 0.5f * (values.size() - 1)) * fontSize,
                         };
 
-                        // First draw a shadow such that the font will be visible on white background.
-                        nvgFontBlur(ctx, 2);
-                        nvgFillColor(ctx, Color(0.0f, fontAlpha));
-                        nvgText(ctx, pos.x() + 1, pos.y() + 1, str.c_str(), nullptr);
-
-                        // Actual text.
-                        nvgFontBlur(ctx, 0);
                         Color col = colors[i];
                         nvgFillColor(ctx, Color(col.r(), col.g(), col.b(), fontAlpha));
-                        nvgText(ctx, pos.x(), pos.y(), str.c_str(), nullptr);
+                        drawTextWithShadow(ctx, pos.x(), pos.y(), str, fontAlpha);
                     }
                 }
             }

--- a/src/MultiGraph.cpp
+++ b/src/MultiGraph.cpp
@@ -72,7 +72,11 @@ void MultiGraph::draw(NVGcontext *ctx) {
 
         if (mZeroBin > 0) {
             nvgBeginPath(ctx);
-            nvgRect(ctx, mPos.x() + 2 + mZeroBin * (mSize.x() - 4) / (float)(mValues.rows() - 1), mPos.y() + 15, 1, mSize.y() - 15);
+            nvgRect(ctx, mPos.x() + 1 + mZeroBin * (mSize.x() - 4) / (float)(mValues.rows() - 1), mPos.y() + 15, 4, mSize.y() - 15);
+            nvgFillColor(ctx, Color(0, 128));
+            nvgFill(ctx);
+            nvgBeginPath(ctx);
+            nvgRect(ctx, mPos.x() + 2 + mZeroBin * (mSize.x() - 4) / (float)(mValues.rows() - 1), mPos.y() + 15, 2, mSize.y() - 15);
             nvgFillColor(ctx, Color(200, 255));
             nvgFill(ctx);
         }
@@ -82,17 +86,17 @@ void MultiGraph::draw(NVGcontext *ctx) {
         nvgFontSize(ctx, 14.0f);
         nvgTextAlign(ctx, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
         nvgFillColor(ctx, mTextColor);
-        nvgText(ctx, mPos.x() + 3, mPos.y() + 1, tfm::format("%.3f", mMinimum).c_str(), NULL);
+        drawTextWithShadow(ctx, mPos.x() + 3, mPos.y() + 1, tfm::format("%.3f", mMinimum));
 
         nvgTextAlign(ctx, NVG_ALIGN_MIDDLE | NVG_ALIGN_TOP);
         nvgFillColor(ctx, mTextColor);
         string meanString = tfm::format("%.3f", mMean);
         float textWidth = nvgTextBounds(ctx, 0, 0, meanString.c_str(), nullptr, nullptr);
-        nvgText(ctx, mPos.x() + mSize.x() / 2 - textWidth / 2, mPos.y() + 1, meanString.c_str(), NULL);
+        drawTextWithShadow(ctx, mPos.x() + mSize.x() / 2 - textWidth / 2, mPos.y() + 1, meanString);
 
         nvgTextAlign(ctx, NVG_ALIGN_RIGHT | NVG_ALIGN_TOP);
         nvgFillColor(ctx, mTextColor);
-        nvgText(ctx, mPos.x() + mSize.x() - 3, mPos.y() + 1, tfm::format("%.3f", mMaximum).c_str(), NULL);
+        drawTextWithShadow(ctx, mPos.x() + mSize.x() - 3, mPos.y() + 1, tfm::format("%.3f", mMaximum));
 
         if (!mCaption.empty()) {
             nvgFontSize(ctx, 14.0f);

--- a/src/MultiGraph.cpp
+++ b/src/MultiGraph.cpp
@@ -83,7 +83,7 @@ void MultiGraph::draw(NVGcontext *ctx) {
 
         nvgFontFace(ctx, "sans");
 
-        nvgFontSize(ctx, 14.0f);
+        nvgFontSize(ctx, 15.0f);
         nvgTextAlign(ctx, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
         nvgFillColor(ctx, mTextColor);
         drawTextWithShadow(ctx, mPos.x() + 3, mPos.y() + 1, tfm::format("%.3f", mMinimum));


### PR DESCRIPTION
- Increases the histogram label font size from 14 to 15 units to be consistent with the rest of __tev__.
- Adds a shadow to histogram labels such that they are readable even if they overlap a bright region of the histogram.