### PR TITLE
Fix C++11 not being enabled on CMake<3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo")
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
-
 if (APPLE)
     set(CMAKE_MACOSX_RPATH ON)
 endif()
@@ -45,6 +43,8 @@ if (MSVC)
     foreach (CompilerFlag ${CompilerFlags})
         string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
     endforeach()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
 endif()
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/dependencies)


### PR DESCRIPTION
Fixes compilation on Ubuntu 14.04 and possibly some other older linux distributions.