### PR TITLE
Add copy functionality to sidebar

### DIFF
--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -471,6 +471,8 @@ bool ImageViewer::keyboardEvent(int key, int scancode, int action, int modifiers
         } else if (key == GLFW_KEY_ESCAPE || key == GLFW_KEY_Q) {
             setVisible(false);
             return true;
+        } else if (mCurrentImage && key == GLFW_KEY_C && (modifiers & GLFW_MOD_CONTROL)) {
+            glfwSetClipboardString(mGLFWWindow, mCurrentImage->name().c_str());
         }
     }
 


### PR DESCRIPTION
When pressing `ctrl+c`, tev will now copy the full path + any `:channel` extensions to the clipboard.