### PR TITLE
Add background color controls

### DIFF
--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -96,6 +96,14 @@ public:
         return applyMetric(value, reference, mMetric);
     }
 
+    const nanogui::Color& backgroundColor() {
+        return mShader.backgroundColor();
+    }
+
+    void setBackgroundColor(const nanogui::Color& color) {
+        mShader.setBackgroundColor(color);
+    }
+
     void fitImageToScreen(const Image& image);
     void resetTransform();
 

--- a/include/tev/UberShader.h
+++ b/include/tev/UberShader.h
@@ -42,6 +42,14 @@ public:
         EMetric metric
     );
 
+    const nanogui::Color& backgroundColor() {
+        return mBackgroundColor;
+    }
+
+    void setBackgroundColor(const nanogui::Color& color) {
+        mBackgroundColor = color;
+    }
+
 private:
     void bindCheckerboardData(const Eigen::Vector2f& pixelSize, const Eigen::Vector2f& checkerSize);
 
@@ -61,6 +69,8 @@ private:
 
     nanogui::GLShader mShader;
     GlTexture mColorMap;
+
+    nanogui::Color mBackgroundColor = nanogui::Color(0, 0, 0, 0);
 };
 
 TEV_NAMESPACE_END

--- a/src/UberShader.cpp
+++ b/src/UberShader.cpp
@@ -65,6 +65,8 @@ UberShader::UberShader()
         uniform int tonemap;
         uniform int metric;
 
+        uniform vec4 bgColor;
+
         in vec2 checkerUv;
         in vec2 imageUv;
         in vec2 referenceUv;
@@ -130,6 +132,7 @@ UberShader::UberShader()
             vec3 lightGray = vec3(0.55, 0.55, 0.55);
 
             vec3 checker = mod(int(floor(checkerUv.x) + floor(checkerUv.y)), 2) == 0 ? darkGray : lightGray;
+            checker = bgColor.rgb * bgColor.a + checker * (1.0 - bgColor.a);
             if (!hasImage) {
                 color = vec4(checker, 1.0);
                 return;
@@ -202,6 +205,7 @@ void UberShader::draw(
     bindImageData(textureImage, transformImage, exposure, offset, tonemap);
     mShader.setUniform("hasImage", true);
     mShader.setUniform("hasReference", false);
+    mShader.setUniform("bgColor", mBackgroundColor);
     mShader.drawIndexed(GL_TRIANGLES, 0, 2);
 }
 


### PR DESCRIPTION
Allows choosing a background color which overrides the checkerboard background. This is useful for visualizing the look of transparent images on top of various backgrounds.