### PR TITLE
Fix various problems with single-channel images

### DIFF
--- a/include/tev/Channel.h
+++ b/include/tev/Channel.h
@@ -14,7 +14,6 @@ class Channel {
 public:
     using RowMatrixXf = Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
-    Channel(size_t index, Eigen::Vector2i size);
     Channel(const std::string& name, Eigen::Vector2i size);
 
     const std::string& name() const {

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -11,12 +11,6 @@ using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
-Channel::Channel(size_t index, Vector2i size) {
-    vector<string> channelNames = {"R", "G", "B", "A"};
-    mName = index < channelNames.size() ? channelNames[index] : to_string(index - channelNames.size());
-    mData.resize(size.y(), size.x());
-}
-
 Channel::Channel(const std::string& name, Vector2i size)
 : mName{name} {
     mData.resize(size.y(), size.x());

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -49,6 +49,21 @@ bool isPfmFile(ifstream& f) {
     return result;
 }
 
+vector<Channel> makeNChannels(int numChannels, Vector2i size) {
+    vector<Channel> channels;
+    if (numChannels > 1) {
+        const vector<string> channelNames = {"R", "G", "B", "A"};
+        for (int c = 0; c < numChannels; ++c) {
+            string name = c < (int)channelNames.size() ? channelNames[c] : to_string(c);
+            channels.emplace_back(name, size);
+        }
+    } else {
+        channels.emplace_back("L", size);
+    }
+
+    return channels;
+}
+
 atomic<int> Image::sId(0);
 
 Image::Image(const filesystem::path& path, const string& channelSelector)
@@ -206,10 +221,7 @@ void Image::readPfm(ifstream& f) {
     bool isPfmLittleEndian = scale < 0;
     scale = abs(scale);
 
-    vector<Channel> channels;
-    for (int c = 0; c < numChannels; ++c) {
-        channels.emplace_back(c, size);
-    }
+    vector<Channel> channels = makeNChannels(numChannels, size);
 
     auto numPixels = (DenseIndex)size.x() * size.y();
     auto numFloats = numPixels * numChannels;
@@ -296,10 +308,7 @@ void Image::readStbi(ifstream& f) {
 
     ScopeGuard dataGuard{[data] { stbi_image_free(data); }};
 
-    vector<Channel> channels;
-    for (int c = 0; c < numChannels; ++c) {
-        channels.emplace_back(c, size);
-    }
+    vector<Channel> channels = makeNChannels(numChannels, size);
 
     auto numPixels = (DenseIndex)size.x() * size.y();
     if (isHdr) {

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -135,7 +135,7 @@ void ImageCanvas::draw(NVGcontext *ctx) {
                         string str = tfm::format("%.4f", values[i]);
                         Vector2f pos{
                             mPos.x() + nano.x(),
-                            mPos.y() + nano.y() + (i - 0.5f * (values.size() - 1)) * fontSize,
+                            mPos.y() + nano.y() + (i - 0.5f * (colors.size() - 1)) * fontSize,
                         };
 
                         Color col = colors[i];


### PR DESCRIPTION
- Fixes https://github.com/Tom94/tev/issues/47
- Fixes only-alpha-channel images being colored red
- Fixes difference images not working correctly when only-alpha-channel images are involved
- Fixes pixel values being positioned incorrectly for single-channel images in general