### PR TITLE
Make gamma configurable

### DIFF
--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -42,6 +42,10 @@ public:
         mOffset = offset;
     }
 
+    void setGamma(float gamma) {
+        mGamma = gamma;
+    }
+
     float applyExposureAndOffset(float value);
 
     void setImage(std::shared_ptr<Image> image) {
@@ -78,9 +82,9 @@ public:
         mTonemap = tonemap;
     }
 
-    static Eigen::Vector3f applyTonemap(const Eigen::Vector3f& value, ETonemap tonemap);
+    static Eigen::Vector3f applyTonemap(const Eigen::Vector3f& value, float gamma, ETonemap tonemap);
     Eigen::Vector3f applyTonemap(const Eigen::Vector3f& value) const {
-        return applyTonemap(value, mTonemap);
+        return applyTonemap(value, mGamma, mTonemap);
     }
 
     EMetric metric() const {
@@ -136,6 +140,8 @@ private:
     float mPixelRatio = 1;
     float mExposure = 0;
     float mOffset = 0;
+    float mGamma = 2.2f;
+
     std::shared_ptr<Image> mImage;
     std::shared_ptr<Image> mReference;
 

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -72,6 +72,12 @@ public:
 
     void setOffset(float value);
 
+    float gamma() {
+        return mGammaSlider->value();
+    }
+
+    void setGamma(float value);
+
     void normalizeExposureAndOffset();
     void resetImage();
 
@@ -158,6 +164,9 @@ private:
 
     nanogui::Label* mOffsetLabel;
     nanogui::Slider* mOffsetSlider;
+
+    nanogui::Label* mGammaLabel;
+    nanogui::Slider* mGammaSlider;
 
     nanogui::Widget* mTonemapButtonContainer;
     nanogui::Widget* mMetricButtonContainer;

--- a/include/tev/UberShader.h
+++ b/include/tev/UberShader.h
@@ -25,6 +25,7 @@ public:
         const Eigen::Matrix3f& transformImage,
         float exposure,
         float offset,
+        float gamma,
         ETonemap tonemap
     );
 
@@ -38,6 +39,7 @@ public:
         const Eigen::Matrix3f& transformReference,
         float exposure,
         float offset,
+        float gamma,
         ETonemap tonemap,
         EMetric metric
     );
@@ -58,6 +60,7 @@ private:
         const Eigen::Matrix3f& transformImage,
         float exposure,
         float offset,
+        float gamma,
         ETonemap tonemap
     );
 

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -62,6 +62,7 @@ void ImageCanvas::drawGL() {
             transform(mImage.get()).inverse().matrix(),
             mExposure,
             mOffset,
+            mGamma,
             mTonemap
         );
         return;
@@ -78,6 +79,7 @@ void ImageCanvas::drawGL() {
         transform(mReference.get()).inverse().matrix(),
         mExposure,
         mOffset,
+        mGamma,
         mTonemap,
         mMetric
     );
@@ -288,7 +290,7 @@ void ImageCanvas::getValuesAtNanoPos(Vector2i mousePos, vector<float>& result) {
     }
 }
 
-Vector3f ImageCanvas::applyTonemap(const Vector3f& value, ETonemap tonemap) {
+Vector3f ImageCanvas::applyTonemap(const Vector3f& value, float gamma, ETonemap tonemap) {
     Vector3f result;
     switch (tonemap) {
         case ETonemap::SRGB:
@@ -298,7 +300,6 @@ Vector3f ImageCanvas::applyTonemap(const Vector3f& value, ETonemap tonemap) {
             }
         case ETonemap::Gamma:
             {
-                static const float gamma = 2.2f;
                 result = {pow(value.x(), 1 / gamma), pow(value.y(), 1 / gamma), pow(value.z(), 1 / gamma)};
                 break;
             }

--- a/src/UberShader.cpp
+++ b/src/UberShader.cpp
@@ -62,6 +62,7 @@ UberShader::UberShader()
 
         uniform float exposure;
         uniform float offset;
+        uniform float gamma;
         uniform int tonemap;
         uniform int metric;
 
@@ -101,7 +102,7 @@ UberShader::UberShader()
         vec3 applyTonemap(vec3 col) {
             switch (tonemap) {
                 case SRGB:        return vec3(sRGB(col.r), sRGB(col.g), sRGB(col.b));
-                case GAMMA:       return pow(col, vec3(1.0 / 2.2));
+                case GAMMA:       return pow(col, vec3(1.0 / gamma));
                 // Here grayscale is compressed such that the darkest color is is 1/1024th as bright as the brightest color.
                 case FALSE_COLOR: return falseColor(log2(average(col)) / 10.0 + 0.5);
                 case POS_NEG:     return vec3(-average(min(col, vec3(0.0))) * 2.0, average(max(col, vec3(0.0))) * 2.0, 0.0);
@@ -198,11 +199,12 @@ void UberShader::draw(
     const Matrix3f& transformImage,
     float exposure,
     float offset,
+    float gamma,
     ETonemap tonemap
 ) {
     mShader.bind();
     bindCheckerboardData(pixelSize, checkerSize);
-    bindImageData(textureImage, transformImage, exposure, offset, tonemap);
+    bindImageData(textureImage, transformImage, exposure, offset, gamma, tonemap);
     mShader.setUniform("hasImage", true);
     mShader.setUniform("hasReference", false);
     mShader.drawIndexed(GL_TRIANGLES, 0, 2);
@@ -217,12 +219,13 @@ void UberShader::draw(
     const Matrix3f& transformReference,
     float exposure,
     float offset,
+    float gamma,
     ETonemap tonemap,
     EMetric metric
 ) {
     mShader.bind();
     bindCheckerboardData(pixelSize, checkerSize);
-    bindImageData(textureImage, transformImage, exposure, offset, tonemap);
+    bindImageData(textureImage, transformImage, exposure, offset, gamma, tonemap);
     bindReferenceData(textureReference, transformReference, metric);
     mShader.setUniform("hasImage", true);
     mShader.setUniform("hasReference", true);
@@ -240,6 +243,7 @@ void UberShader::bindImageData(
     const Matrix3f& transformImage,
     float exposure,
     float offset,
+    float gamma,
     ETonemap tonemap
 ) {
     glActiveTexture(GL_TEXTURE0);
@@ -251,6 +255,7 @@ void UberShader::bindImageData(
 
     mShader.setUniform("exposure", exposure);
     mShader.setUniform("offset", offset);
+    mShader.setUniform("gamma", gamma);
     mShader.setUniform("tonemap", static_cast<int>(tonemap));
 
     glActiveTexture(GL_TEXTURE2);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,13 @@ int mainFunc(const vector<string>& arguments) {
         {'f', "filter"},
     };
 
+    ValueFlag<float> gammaFlag{
+        parser,
+        "GAMMA",
+        "The exponent used when TONEMAP is 'Gamma'. Default is 2.2.",
+        {'g', "gamma"},
+    };
+
     HelpFlag helpFlag{
         parser,
         "HELP",
@@ -95,7 +102,7 @@ int mainFunc(const vector<string>& arguments) {
         "The tonemapping algorithm to use. "
         "The available tonemaps are:\n"
         "sRGB   - sRGB\n"
-        "Gamma  - Gamma curve (2.2)\n"
+        "Gamma  - Gamma curve\n"
         "FC     - False Color\n"
         "PN     - Positive=Green, Negative=Red\n"
         "Default is sRGB.",
@@ -209,6 +216,7 @@ int mainFunc(const vector<string>& arguments) {
         // Apply parameter flags
         if (exposureFlag) { app->setExposure(get(exposureFlag)); }
         if (filterFlag)   { app->setFilter(get(filterFlag)); }
+        if (gammaFlag)    { app->setGamma(get(gammaFlag)); }
         if (metricFlag)   { app->setMetric(toMetric(get(metricFlag))); }
         if (offsetFlag)   { app->setOffset(get(offsetFlag)); }
         if (tonemapFlag)  { app->setTonemap(toTonemap(get(tonemapFlag))); }


### PR DESCRIPTION
Looks like so:
<img width="201" alt="screenshot 2018-06-26 07 02 59" src="https://user-images.githubusercontent.com/4923655/41890436-cee0c84c-790f-11e8-976f-f976626a81b0.png">

The gamma slider is disabled whenever another tonemapping option is selected.

Closes https://github.com/Tom94/tev/issues/51