### PR TITLE
Fix for parsing PFM header

### DIFF
--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -228,7 +228,8 @@ void Image::readPfm(ifstream& f) {
     auto numBytes = numFloats * sizeof(float);
 
     // Skip last newline at the end of the header.
-    f.seekg(1, ios_base::cur);
+    string line;
+    getline(f, line);
 
     // Read entire file in binary mode.
     vector<float> data(numFloats);


### PR DESCRIPTION
Previously, the PFM parser used seekg(1) to move past the newline
at the end of the header. For files created using CR+LF end-of-line
marker, seekg(2) would be needed. Calling std::getline() instead handles
that transparently.