### PR TITLE
Load images via standard input

### DIFF
--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -7,7 +7,6 @@
 #include <tev/Image.h>
 #include <tev/ImageButton.h>
 #include <tev/ImageCanvas.h>
-#include <tev/Ipc.h>
 #include <tev/Lazy.h>
 #include <tev/MultiGraph.h>
 #include <tev/SharedQueue.h>

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -54,6 +54,8 @@ public:
 
     void reloadAllImages();
 
+    void tryLoadImageBackground(const filesystem::path& path, const std::string& channelSelector, bool shallSelect = false);
+
     void selectImage(const std::shared_ptr<Image>& image, bool stopPlayback = true);
 
     void selectLayer(std::string name);

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -23,14 +23,9 @@
 
 TEV_NAMESPACE_BEGIN
 
-struct ImageAddition {
-    bool shallSelect;
-    std::shared_ptr<Image> image;
-};
-
 class ImageViewer : public nanogui::Screen {
 public:
-    ImageViewer(std::shared_ptr<SharedQueue<ImageAddition>> imagesToAdd, bool processPendingDrops);
+    ImageViewer(const std::shared_ptr<BackgroundImagesLoader>& imagesLoader, bool processPendingDrops);
     virtual ~ImageViewer();
 
     bool mouseButtonEvent(const Eigen::Vector2i &p, int button, bool down, int modifiers) override;
@@ -53,8 +48,6 @@ public:
     void reloadImage(std::shared_ptr<Image> image);
 
     void reloadAllImages();
-
-    void tryLoadImageBackground(const filesystem::path& path, const std::string& channelSelector, bool shallSelect = false);
 
     void selectImage(const std::shared_ptr<Image>& image, bool stopPlayback = true);
 
@@ -172,7 +165,8 @@ private:
     nanogui::Widget* mTonemapButtonContainer;
     nanogui::Widget* mMetricButtonContainer;
 
-    std::shared_ptr<SharedQueue<ImageAddition>> mImagesToAdd;
+    std::shared_ptr<BackgroundImagesLoader> mImagesLoader;
+
     std::shared_ptr<Image> mCurrentImage;
     std::shared_ptr<Image> mCurrentReference;
 

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -30,7 +30,7 @@ struct ImageAddition {
 
 class ImageViewer : public nanogui::Screen {
 public:
-    ImageViewer(std::shared_ptr<Ipc> ipc, std::shared_ptr<SharedQueue<ImageAddition>> imagesToAdd, bool processPendingDrops);
+    ImageViewer(std::shared_ptr<SharedQueue<ImageAddition>> imagesToAdd, bool processPendingDrops);
     virtual ~ImageViewer();
 
     bool mouseButtonEvent(const Eigen::Vector2i &p, int button, bool down, int modifiers) override;
@@ -147,7 +147,6 @@ private:
         return mFooter->visible() ? mFooter->fixedHeight() : 0;
     }
 
-    std::shared_ptr<Ipc> mIpc;
     SharedQueue<std::function<void(void)>> mTaskQueue;
 
     bool mRequiresFilterUpdate = true;

--- a/include/tev/ThreadPool.h
+++ b/include/tev/ThreadPool.h
@@ -79,15 +79,6 @@ public:
         waitUntilFinished();
     }
 
-    static ThreadPool& singleWorker() {
-        static ThreadPool threadPool{1};
-        return threadPool;
-    }
-
-    static void shutdown() {
-        singleWorker().shutdownThreads(1);
-    }
-
 private:
     size_t mNumThreads = 0;
     std::vector<std::thread> mThreads;

--- a/scripts/mac-run-tev.sh
+++ b/scripts/mac-run-tev.sh
@@ -1,26 +1,3 @@
 #!/bin/bash
 
-realpath() {
-    # If the path starts with a slash, then it is already
-    # absolute. Otherwise, simply prepend current dir.
-    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
-
-# Transform all path arguments to absolute paths.
-# This is required, since opening an app in macOS
-# does not let us control the working directory of
-# the app, and relative paths may thus not work.
-paths=()
-for var in "$@"
-do
-    # Command-line arguments starting with - or :
-    # are not interpreted as paths by tev, so we
-    # should not expand them.
-    if  [[ $var == -* ]] || [[ $var == :* ]]; then
-        paths+=($var)
-    else
-        paths+=("$(realpath "$var")")
-    fi
-done
-
-open -n -a tev --args "${paths[@]}"
+/Applications/tev.app/Contents/MacOS/tev "$@"

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -204,4 +204,13 @@ shared_ptr<Image> tryLoadImage(path path, string channelSelector) {
     return nullptr;
 }
 
+void BackgroundImagesLoader::enqueue(const path& path, const string& channelSelector, bool shallSelect) {
+    mWorkers.enqueueTask([path, channelSelector, shallSelect, this] {
+        auto image = tryLoadImage(path, channelSelector);
+        if (image) {
+            mLoadedImages.push({ shallSelect, image });
+        }
+    });
+}
+
 TEV_NAMESPACE_END

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -2,7 +2,6 @@
 // It is published under the BSD 3-Clause License within the LICENSE file.
 
 #include <tev/ImageViewer.h>
-#include <tev/ThreadPool.h>
 
 #include <filesystem/path.h>
 

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -21,7 +21,7 @@ bool PfmImageLoader::canLoadFile(ifstream& f) const {
     return result;
 }
 
-ImageData PfmImageLoader::load(ifstream& f, const filesystem::path& path, const string& channelSelector) const {
+ImageData PfmImageLoader::load(ifstream& f, const filesystem::path&, const string& channelSelector) const {
     ImageData result;
     ThreadPool threadPool;
 

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -11,13 +11,13 @@ using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
-bool StbiImageLoader::canLoadFile(ifstream& f) const {
+bool StbiImageLoader::canLoadFile(ifstream&) const {
     // Pretend you can load any file and throw exception on failure.
     // TODO: Add proper check.
     return true;
 }
 
-ImageData StbiImageLoader::load(ifstream& f, const filesystem::path& path, const string& channelSelector) const {
+ImageData StbiImageLoader::load(ifstream& f, const filesystem::path&, const string& channelSelector) const {
     ImageData result;
     ThreadPool threadPool;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,7 +192,9 @@ int mainFunc(const vector<string>& arguments) {
     thread stdinThread{[&]() {
         string channelSelector;
         while (!shallShutdown) {
-            for (string imageFile; getline(cin, imageFile);) {
+            for (string line; getline(cin, line);) {
+                string imageFile = tev::ensureUtf8(line);
+
                 if (imageFile.empty()) {
                     continue;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,7 +184,7 @@ int mainFunc(const vector<string>& arguments) {
 
     shared_ptr<BackgroundImagesLoader> imagesLoader = make_shared<BackgroundImagesLoader>();
 
-    atomic<bool> shallShutdown = false;
+    atomic<bool> shallShutdown{false};
 
     // Spawn a background thread that opens images passed via stdin.
     // To allow whitespace characters in filenames, we use the convention that


### PR DESCRIPTION
tev can now receive image paths via standard input. The paths must be separated by newline characters.

Example:
`$ find *.exr | tev`

This PR also refactors background image loading and fixes some tev-console interactions on macOS.