### PR TITLE
Keyboard shortcut to close all images

### DIFF
--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -44,9 +44,12 @@ public:
 
     void removeImage(std::shared_ptr<Image> image);
 
+    void removeAllImages();
+
     void reloadImage(std::shared_ptr<Image> image);
 
     void reloadAllImages();
+
 
     void selectImage(const std::shared_ptr<Image>& image, bool stopPlayback = true);
 

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -43,13 +43,10 @@ public:
     }
 
     void removeImage(std::shared_ptr<Image> image);
-
     void removeAllImages();
 
     void reloadImage(std::shared_ptr<Image> image);
-
     void reloadAllImages();
-
 
     void selectImage(const std::shared_ptr<Image>& image, bool stopPlayback = true);
 

--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -61,6 +61,7 @@ HelpWindow::HelpWindow(Widget *parent, function<void()> closeCallback)
         addRow(imageLoading, COMMAND + "+R or F5",                       "Reload Image");
         addRow(imageLoading, COMMAND + "+Shift+R or " + COMMAND + "+F5", "Reload All Images");
         addRow(imageLoading, COMMAND + "+W",                             "Close Image");
+        addRow(imageLoading, COMMAND + "+Shift+W",                       "Close All Images");
 
         new Label{shortcuts, "Image Options", "sans-bold", 18};
         auto imageSelection = new Widget{shortcuts};

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -656,7 +656,9 @@ bool ImageViewer::keyboardEvent(int key, int scancode, int action, int modifiers
             }
         }
 
-        if (key == GLFW_KEY_W && modifiers & SYSTEM_COMMAND_MOD) {
+        if (key == GLFW_KEY_W && modifiers & SYSTEM_COMMAND_MOD && modifiers & GLFW_MOD_SHIFT) {
+            removeAllImages();
+        } else if (key == GLFW_KEY_W && modifiers & SYSTEM_COMMAND_MOD) {
             removeImage(mCurrentImage);
         } else if (key == GLFW_KEY_UP || key == GLFW_KEY_W || key == GLFW_KEY_PAGE_UP) {
             if (modifiers & GLFW_MOD_SHIFT) {
@@ -717,7 +719,7 @@ void ImageViewer::drawContents() {
     }
 
     // mTaskQueue contains jobs that should be executed on the main thread. It is useful for handling
-    // callbacks from background threads 
+    // callbacks from background threads
     try {
         while (true) {
             mTaskQueue.tryPop()();
@@ -854,6 +856,27 @@ void ImageViewer::removeImage(shared_ptr<Image> image) {
 
     if (mCurrentReference == image) {
         selectReference(nextCandidate);
+    }
+}
+
+void ImageViewer::removeAllImages() {
+    if (mImages.empty())
+        return;
+
+    // Reset all focus as a workaround a crash caused by nanogui.
+    // TODO: Remove once a fix exists.
+    requestFocus();
+
+    for (long i = mImages.size() - 1; i >= 0; --i) {
+        mImageButtonContainer->removeChild(i);
+    }
+    mImages.clear();
+
+    // No images left to select
+    selectImage(nullptr);
+    selectReference(nullptr);
+    for (auto button : mAnyImageButtons) {
+        button->setEnabled(false);
     }
 }
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -387,8 +387,16 @@ ImageViewer::ImageViewer(const shared_ptr<BackgroundImagesLoader>& imagesLoader,
             }, ENTYPO_ICON_CYCLE, tfm::format("Reload All (%s+Shift+R or %s+F5)", HelpWindow::COMMAND, HelpWindow::COMMAND)));
 
             mCurrentImageButtons.push_back(makeImageButton("", false, [this] {
-                removeImage(mCurrentImage);
-            }, ENTYPO_ICON_CIRCLED_CROSS, tfm::format("Close (%s+W)", HelpWindow::COMMAND)));
+                auto* glfwWindow = screen()->glfwWindow();
+                // There is no explicit access to the currently pressed modifier keys here, so we
+                // need to directly ask GLFW. In case this is needed more often, it may be worth
+                // inheriting Button and overriding mouseButtonEvent (similar to ImageButton).
+                if (glfwGetKey(glfwWindow, GLFW_KEY_LEFT_SHIFT) || glfwGetKey(glfwWindow, GLFW_KEY_RIGHT_SHIFT)) {
+                    removeAllImages();
+                } else {
+                    removeImage(mCurrentImage);
+                }
+            }, ENTYPO_ICON_CIRCLED_CROSS, tfm::format("Close (%s+W); Close All (%s+Shift+W)", HelpWindow::COMMAND, HelpWindow::COMMAND)));
 
             spacer = new Widget{mSidebarLayout};
             spacer->setHeight(3);

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -656,10 +656,12 @@ bool ImageViewer::keyboardEvent(int key, int scancode, int action, int modifiers
             }
         }
 
-        if (key == GLFW_KEY_W && modifiers & SYSTEM_COMMAND_MOD && modifiers & GLFW_MOD_SHIFT) {
-            removeAllImages();
-        } else if (key == GLFW_KEY_W && modifiers & SYSTEM_COMMAND_MOD) {
-            removeImage(mCurrentImage);
+        if (key == GLFW_KEY_W && modifiers & SYSTEM_COMMAND_MOD) {
+            if (modifiers & GLFW_MOD_SHIFT) {
+                removeAllImages();
+            } else {
+                removeImage(mCurrentImage);
+            }
         } else if (key == GLFW_KEY_UP || key == GLFW_KEY_W || key == GLFW_KEY_PAGE_UP) {
             if (modifiers & GLFW_MOD_SHIFT) {
                 selectReference(nextImage(mCurrentReference, Backward));
@@ -867,8 +869,8 @@ void ImageViewer::removeAllImages() {
     // TODO: Remove once a fix exists.
     requestFocus();
 
-    for (long i = mImages.size() - 1; i >= 0; --i) {
-        mImageButtonContainer->removeChild(i);
+    for (size_t i = mImages.size(); i > 0; --i) {
+        mImageButtonContainer->removeChild(i - 1);
     }
     mImages.clear();
 


### PR DESCRIPTION
I found this useful when working with image sequences with hundreds of frames.
I tried to respect the coding style, but let me know if you would like me to adjust something!

---

- [x] `removeAllImages` function and key binding
- [x] Entry in the Help panel

Tested on Ubuntu 18.10.