### PR TITLE
Order channels according to selector when ordering heuristics fail

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -139,7 +139,11 @@ std::vector<std::string> split(std::string text, const std::string& delim);
 std::string toLower(std::string str);
 std::string toUpper(std::string str);
 
-bool matches(std::string text, std::string filter, bool isRegex);
+bool matchesFuzzy(std::string text, std::string filter, size_t* matchedPartId = nullptr);
+bool matchesRegex(std::string text, std::string filter);
+inline bool matchesFuzzyOrRegex(const std::string& text, const std::string& filter, bool isRegex) {
+    return isRegex ? matchesRegex(text, filter) : matchesFuzzy(text, filter);
+}
 
 void drawTextWithShadow(NVGcontext* ctx, float x, float y, std::string text, float shadowAlpha = 1.0f);
 

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -19,7 +19,7 @@ TEV_NAMESPACE_BEGIN
 class ImageLoader;
 
 struct ImageData {
-    std::map<std::string, Channel> channels;
+    std::vector<Channel> channels;
     std::vector<std::string> layers;
 };
 
@@ -42,12 +42,13 @@ public:
     std::string shortName() const;
 
     bool hasChannel(const std::string& channelName) const {
-        return mData.channels.count(channelName) != 0;
+        return channel(channelName) != nullptr;
     }
 
     const Channel* channel(const std::string& channelName) const {
-        if (hasChannel(channelName)) {
-            return &mData.channels.at(channelName);
+        auto it = std::find_if(std::begin(mData.channels), std::end(mData.channels), [&channelName](const Channel& c) { return c.name() == channelName; });
+        if (it != std::end(mData.channels)) {
+            return &(*it);
         } else {
             return nullptr;
         }
@@ -58,11 +59,11 @@ public:
     std::vector<std::string> channelsInLayer(std::string layerName) const;
 
     Eigen::Vector2i size() const {
-        return mData.channels.begin()->second.size();
+        return mData.channels.front().size();
     }
 
     Eigen::DenseIndex count() const {
-        return mData.channels.begin()->second.count();
+        return mData.channels.front().count();
     }
 
     const std::vector<std::string>& layers() const {

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -46,14 +46,15 @@ string utf16to8(const wstring& utf16) {
 
 vector<string> split(string text, const string& delim) {
     vector<string> result;
+    size_t begin = 0;
     while (true) {
-        size_t begin = text.find_last_of(delim);
-        if (begin == string::npos) {
-            result.emplace_back(text);
+        size_t end = text.find_first_of(delim, begin);
+        if (end == string::npos) {
+            result.emplace_back(text.substr(begin));
             return result;
         } else {
-            result.emplace_back(text.substr(begin + 1));
-            text.resize(begin);
+            result.emplace_back(text.substr(begin, end - begin));
+            begin = end + 1;
         }
     }
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -70,48 +70,53 @@ string toUpper(string str) {
     return str;
 }
 
-bool matches(string text, string filter, bool isRegex) {
-    auto matchesFuzzy = [](string text, string filter) {
-        if (filter.empty()) {
-            return true;
-        }
+bool matchesFuzzy(string text, string filter, size_t* matchedPartId) {
+    if (matchedPartId) {
+        // Default value of 0. Is actually returned when the filter
+        // is empty or when there is no match.
+        *matchedPartId = 0;
+    }
 
-        // Perform matching on lowercase strings
-        text = toLower(text);
-        filter = toLower(filter);
+    if (filter.empty()) {
+        return true;
+    }
 
-        auto words = split(filter, ", ");
-        // We don't want people entering multiple spaces in a row to match everything.
-        words.erase(remove(begin(words), end(words), ""), end(words));
+    // Perform matching on lowercase strings
+    text = toLower(text);
+    filter = toLower(filter);
 
-        if (words.empty()) {
-            return true;
-        }
+    auto words = split(filter, ", ");
+    // We don't want people entering multiple spaces in a row to match everything.
+    words.erase(remove(begin(words), end(words), ""), end(words));
 
-        // Match every word of the filter separately.
-        for (const auto& word : words) {
-            if (text.find(word) != string::npos) {
-                return true;
+    if (words.empty()) {
+        return true;
+    }
+
+    // Match every word of the filter separately.
+    for (size_t i = 0; i < words.size(); ++i) {
+        if (text.find(words[i]) != string::npos) {
+            if (matchedPartId) {
+                *matchedPartId = i;
             }
-        }
-
-        return false;
-    };
-
-    auto matchesRegex = [](string text, string filter) {
-        if (filter.empty()) {
             return true;
         }
+    }
 
-        try {
-            regex searchRegex{filter, std::regex_constants::ECMAScript | std::regex_constants::icase};
-            return regex_search(text, searchRegex);
-        } catch (const regex_error&) {
-            return false;
-        }
-    };
+    return false;
+}
 
-    return isRegex ? matchesRegex(text, filter) : matchesFuzzy(text, filter);
+bool matchesRegex(string text, string filter) {
+    if (filter.empty()) {
+        return true;
+    }
+
+    try {
+        regex searchRegex{filter, std::regex_constants::ECMAScript | std::regex_constants::icase};
+        return regex_search(text, searchRegex);
+    } catch (const regex_error&) {
+        return false;
+    }
 }
 
 void drawTextWithShadow(NVGcontext* ctx, float x, float y, string text, float shadowAlpha) {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -116,20 +116,20 @@ vector<string> Image::channelsInLayer(string layerName) const {
     vector<string> result;
 
     if (layerName.empty()) {
-        for (const auto& kv : mData.channels) {
-            if (kv.first.find(".") == string::npos) {
-                result.emplace_back(kv.first);
+        for (const auto& c : mData.channels) {
+            if (c.name().find(".") == string::npos) {
+                result.emplace_back(c.name());
             }
         }
     } else {
-        for (const auto& kv : mData.channels) {
+        for (const auto& c : mData.channels) {
             // If the layer name starts at the beginning, and
             // if no other dot is found after the end of the layer name,
             // then we have found a channel of this layer.
-            if (kv.first.find(layerName) == 0 && kv.first.length() > layerName.length()) {
-                const auto& channelWithoutLayer = kv.first.substr(layerName.length() + 1);
+            if (c.name().find(layerName) == 0 && c.name().length() > layerName.length()) {
+                const auto& channelWithoutLayer = c.name().substr(layerName.length() + 1);
                 if (channelWithoutLayer.find(".") == string::npos) {
-                    result.emplace_back(kv.first);
+                    result.emplace_back(c.name());
                 }
             }
         }
@@ -165,11 +165,11 @@ void Image::ensureValid() {
         throw runtime_error{"Images must have at least one channel."};
     }
 
-    for (const auto& kv : mData.channels) {
-        if (kv.second.size() != size()) {
+    for (const auto& c : mData.channels) {
+        if (c.size() != size()) {
             throw runtime_error{tfm::format(
                 "All channels must have the same size as their image. (%s:%dx%d != %dx%d)",
-                kv.first, kv.second.size().x(), kv.second.size().y(), size().x(), size().y()
+                c.name(), c.size().x(), c.size().y(), size().x(), size().y()
             )};
         }
     }

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -1350,11 +1350,11 @@ void ImageViewer::updateFilter() {
         // This is the case if the image name matches the image part
         // and at least one of the image's layers matches the layer part.
         auto doesImageMatch = [&](const shared_ptr<Image>& image) {
-            bool doesMatch = matches(image->name(), imagePart, useRegex());
+            bool doesMatch = matchesFuzzyOrRegex(image->name(), imagePart, useRegex());
             if (doesMatch) {
                 bool anyLayersMatch = false;
                 for (const auto& layer : image->layers()) {
-                    if (matches(layer, layerPart, useRegex())) {
+                    if (matchesFuzzyOrRegex(layer, layerPart, useRegex())) {
                         anyLayersMatch = true;
                         break;
                     }
@@ -1439,7 +1439,7 @@ void ImageViewer::updateFilter() {
             selectImage(nthVisibleImage(0));
         }
 
-        if (mCurrentReference && !matches(mCurrentReference->name(), imagePart, useRegex())) {
+        if (mCurrentReference && !matchesFuzzyOrRegex(mCurrentReference->name(), imagePart, useRegex())) {
             selectReference(nullptr);
         }
     }
@@ -1451,13 +1451,13 @@ void ImageViewer::updateFilter() {
         const auto& buttons = mLayerButtonContainer->children();
         for (Widget* button : buttons) {
             ImageButton* ib = dynamic_cast<ImageButton*>(button);
-            ib->setVisible(matches(ib->caption(), layerPart, useRegex()));
+            ib->setVisible(matchesFuzzyOrRegex(ib->caption(), layerPart, useRegex()));
             if (ib->visible()) {
                 ib->setId(id++);
             }
         }
 
-        if (!matches(mCurrentLayer, layerPart, useRegex())) {
+        if (!matchesFuzzyOrRegex(mCurrentLayer, layerPart, useRegex())) {
             selectLayer(nthVisibleLayer(0));
         }
     }

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -48,7 +48,7 @@ ImageData ExrImageLoader::load(ifstream& f, const filesystem::path& path, const 
         const Imf::ChannelList& imfChannels = part.header().channels();
 
         for (Imf::ChannelList::ConstIterator c = imfChannels.begin(); c != imfChannels.end(); ++c) {
-            if (matches(c.name(), channelSelector, false)) {
+            if (matchesFuzzy(c.name(), channelSelector)) {
                 partIdx = i;
                 goto l_foundPart;
             }
@@ -140,7 +140,7 @@ l_foundPart:
     set<string> layerNames;
 
     for (Imf::ChannelList::ConstIterator c = imfChannels.begin(); c != imfChannels.end(); ++c) {
-        if (matches(c.name(), channelSelector, false)) {
+        if (matchesFuzzy(c.name(), channelSelector)) {
             rawChannels.emplace_back(c.name(), c.channel().type);
             layerNames.insert(Channel::head(c.name()));
         }

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -139,11 +139,24 @@ l_foundPart:
     const Imf::ChannelList& imfChannels = file.header().channels();
     set<string> layerNames;
 
+    using match_t = pair<size_t, Imf::ChannelList::ConstIterator>;
+    vector<match_t> matches;
     for (Imf::ChannelList::ConstIterator c = imfChannels.begin(); c != imfChannels.end(); ++c) {
-        if (matchesFuzzy(c.name(), channelSelector)) {
-            rawChannels.emplace_back(c.name(), c.channel().type);
+        size_t matchId;
+        if (matchesFuzzy(c.name(), channelSelector, &matchId)) {
+            matches.emplace_back(matchId, c);
             layerNames.insert(Channel::head(c.name()));
         }
+    }
+
+    // Sort matched channels by matched component of the selector, if one exists.
+    if (!channelSelector.empty()) {
+        sort(begin(matches), end(matches), [](const match_t& m1, const match_t& m2) { return m1.first < m2.first; });
+    }
+
+    for (const auto& match : matches) {
+        const auto& c = match.second;
+        rawChannels.emplace_back(c.name(), c.channel().type);
     }
 
     if (rawChannels.empty()) {
@@ -166,11 +179,11 @@ l_foundPart:
     file.readPixels(dw.min.y, dw.max.y);
 
     for (const auto& rawChannel : rawChannels) {
-        result.channels.emplace(rawChannel.name(), Channel{rawChannel.name(), size});
+        result.channels.emplace_back(Channel{rawChannel.name(), size});
     }
 
     for (size_t i = 0; i < rawChannels.size(); ++i) {
-        rawChannels[i].copyTo(result.channels.at(rawChannels[i].name()), threadPool);
+        rawChannels[i].copyTo(result.channels[i], threadPool);
     }
 
     threadPool.waitUntilFinished();

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -83,7 +83,7 @@ ImageData PfmImageLoader::load(ifstream& f, const filesystem::path&, const strin
 
     for (auto& channel : channels) {
         string name = channel.name();
-        if (matches(name, channelSelector, false)) {
+        if (matchesFuzzy(name, channelSelector)) {
             result.channels.emplace(move(name), move(channel));
         }
     }

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -81,11 +81,20 @@ ImageData PfmImageLoader::load(ifstream& f, const filesystem::path&, const strin
         }
     });
 
-    for (auto& channel : channels) {
-        string name = channel.name();
-        if (matchesFuzzy(name, channelSelector)) {
-            result.channels.emplace(move(name), move(channel));
+    vector<pair<size_t, size_t>> matches;
+    for (size_t i = 0; i < channels.size(); ++i) {
+        size_t matchId;
+        if (matchesFuzzy(channels[i].name(), channelSelector, &matchId)) {
+            matches.emplace_back(matchId, i);
         }
+    }
+
+    if (!channelSelector.empty()) {
+        sort(begin(matches), end(matches));
+    }
+
+    for (const auto& match : matches) {
+        result.channels.emplace_back(move(channels[match.second]));
     }
 
     // PFM can not contain layers, so all channels simply reside

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -77,11 +77,20 @@ ImageData StbiImageLoader::load(ifstream& f, const filesystem::path&, const stri
         });
     }
 
-    for (auto& channel : channels) {
-        string name = channel.name();
-        if (matchesFuzzy(name, channelSelector)) {
-            result.channels.emplace(move(name), move(channel));
+    vector<pair<size_t, size_t>> matches;
+    for (size_t i = 0; i < channels.size(); ++i) {
+        size_t matchId;
+        if (matchesFuzzy(channels[i].name(), channelSelector, &matchId)) {
+            matches.emplace_back(matchId, i);
         }
+    }
+
+    if (!channelSelector.empty()) {
+        sort(begin(matches), end(matches));
+    }
+
+    for (const auto& match : matches) {
+        result.channels.emplace_back(move(channels[match.second]));
     }
 
     // STBI can not load layers, so all channels simply reside

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -79,7 +79,7 @@ ImageData StbiImageLoader::load(ifstream& f, const filesystem::path&, const stri
 
     for (auto& channel : channels) {
         string name = channel.name();
-        if (matches(name, channelSelector, false)) {
+        if (matchesFuzzy(name, channelSelector)) {
             result.channels.emplace(move(name), move(channel));
         }
     }


### PR DESCRIPTION
Addresses part of https://github.com/Tom94/tev/issues/68

Still TODO: improve the heuristics such that they can handle automatic ordering of channels of the form of e.g. \*R\*, \*G\*, \*B\* with common pre- and suffixes.