### PR TITLE
Image pasting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ if (MSVC)
 endif()
 
 set(TEV_SOURCES
+    include/tev/imageio/ClipboardImageLoader.h src/imageio/ClipboardImageLoader.cpp
     include/tev/imageio/ExrImageLoader.h src/imageio/ExrImageLoader.cpp
     include/tev/imageio/ImageLoader.h src/imageio/ImageLoader.cpp
     include/tev/imageio/ImageSaver.h src/imageio/ImageSaver.cpp

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -9,7 +9,7 @@
 #include <tev/ThreadPool.h>
 
 #include <atomic>
-#include <fstream>
+#include <istream>
 #include <map>
 #include <memory>
 #include <string>

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -9,6 +9,7 @@
 #include <tev/ThreadPool.h>
 
 #include <atomic>
+#include <fstream>
 #include <map>
 #include <memory>
 #include <string>
@@ -25,7 +26,7 @@ struct ImageData {
 
 class Image {
 public:
-    Image(const filesystem::path& path, const std::string& channelSelector);
+    Image(const filesystem::path& path, std::istream& iStream, const std::string& channelSelector);
 
     const filesystem::path& path() const {
         return mPath;
@@ -104,6 +105,7 @@ private:
     const int mId;
 };
 
+std::shared_ptr<Image> tryLoadImage(filesystem::path path, std::istream& iStream, std::string channelSelector);
 std::shared_ptr<Image> tryLoadImage(filesystem::path path, std::string channelSelector);
 
 struct ImageAddition {

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -202,6 +202,8 @@ private:
     bool mIsDraggingImage = false;
 
     Eigen::Vector2f mDraggingStartPosition;
+
+    size_t mClipboardIndex = 0;
 };
 
 TEV_NAMESPACE_END

--- a/include/tev/imageio/ClipboardImageLoader.h
+++ b/include/tev/imageio/ClipboardImageLoader.h
@@ -1,0 +1,27 @@
+// This file was developed by Thomas Müller <thomas94@gmx.net>.
+// It is published under the BSD 3-Clause License within the LICENSE file.
+
+#pragma once
+
+#include <tev/Image.h>
+#include <tev/imageio/ImageLoader.h>
+
+#include <istream>
+
+TEV_NAMESPACE_BEGIN
+
+class ClipboardImageLoader : public ImageLoader {
+public:
+    bool canLoadFile(std::istream& iStream) const override;
+    ImageData load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector) const override;
+
+    std::string name() const override {
+        return "clipboard";
+    }
+
+    bool hasPremultipliedAlpha() const override {
+        return false;
+    }
+};
+
+TEV_NAMESPACE_END

--- a/include/tev/imageio/ExrImageLoader.h
+++ b/include/tev/imageio/ExrImageLoader.h
@@ -6,14 +6,14 @@
 #include <tev/Image.h>
 #include <tev/imageio/ImageLoader.h>
 
-#include <fstream>
+#include <istream>
 
 TEV_NAMESPACE_BEGIN
 
 class ExrImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::ifstream& f) const override;
-    ImageData load(std::ifstream& f, const filesystem::path& path, const std::string& channelSelector) const override;
+    bool canLoadFile(std::istream& iStream) const override;
+    ImageData load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector) const override;
 
     std::string name() const override {
         return "OpenEXR";

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -6,7 +6,7 @@
 #include <tev/Channel.h>
 #include <tev/Image.h>
 
-#include <fstream>
+#include <istream>
 #include <string>
 
 TEV_NAMESPACE_BEGIN
@@ -15,8 +15,8 @@ class ImageLoader {
 public:
     virtual ~ImageLoader() {}
 
-    virtual bool canLoadFile(std::ifstream& f) const = 0;
-    virtual ImageData load(std::ifstream& f, const filesystem::path& path, const std::string& channelSelector) const = 0;
+    virtual bool canLoadFile(std::istream& iStream) const = 0;
+    virtual ImageData load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector) const = 0;
 
     virtual std::string name() const = 0;
 

--- a/include/tev/imageio/ImageSaver.h
+++ b/include/tev/imageio/ImageSaver.h
@@ -7,7 +7,7 @@
 
 #include <Eigen/Core>
 
-#include <fstream>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -33,7 +33,7 @@ public:
 template <typename T>
 class TypedImageSaver : public ImageSaver {
 public:
-    virtual void save(std::ofstream& f, const filesystem::path& path, const std::vector<T>& data, const Eigen::Vector2i& imageSize, int nChannels) const = 0;
+    virtual void save(std::ostream& oStream, const filesystem::path& path, const std::vector<T>& data, const Eigen::Vector2i& imageSize, int nChannels) const = 0;
 };
 
 TEV_NAMESPACE_END

--- a/include/tev/imageio/PfmImageLoader.h
+++ b/include/tev/imageio/PfmImageLoader.h
@@ -6,14 +6,14 @@
 #include <tev/Image.h>
 #include <tev/imageio/ImageLoader.h>
 
-#include <fstream>
+#include <istream>
 
 TEV_NAMESPACE_BEGIN
 
 class PfmImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::ifstream& f) const override;
-    ImageData load(std::ifstream& f, const filesystem::path& path, const std::string& channelSelector) const override;
+    bool canLoadFile(std::istream& iStream) const override;
+    ImageData load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector) const override;
 
     std::string name() const override {
         return "PFM";

--- a/include/tev/imageio/StbiHdrImageSaver.h
+++ b/include/tev/imageio/StbiHdrImageSaver.h
@@ -5,13 +5,13 @@
 
 #include <tev/imageio/ImageSaver.h>
 
-#include <fstream>
+#include <ostream>
 
 TEV_NAMESPACE_BEGIN
 
 class StbiHdrImageSaver : public TypedImageSaver<float> {
 public:
-    void save(std::ofstream& f, const filesystem::path& path, const std::vector<float>& data, const Eigen::Vector2i& imageSize, int nChannels) const override;
+    void save(std::ostream& oStream, const filesystem::path& path, const std::vector<float>& data, const Eigen::Vector2i& imageSize, int nChannels) const override;
 
     bool hasPremultipliedAlpha() const override {
         return false;

--- a/include/tev/imageio/StbiImageLoader.h
+++ b/include/tev/imageio/StbiImageLoader.h
@@ -6,14 +6,14 @@
 #include <tev/Image.h>
 #include <tev/imageio/ImageLoader.h>
 
-#include <fstream>
+#include <istream>
 
 TEV_NAMESPACE_BEGIN
 
 class StbiImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::ifstream& f) const override;
-    ImageData load(std::ifstream& f, const filesystem::path& path, const std::string& channelSelector) const override;
+    bool canLoadFile(std::istream& iStream) const override;
+    ImageData load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector) const override;
 
     std::string name() const override {
         return "STBI";

--- a/include/tev/imageio/StbiLdrImageSaver.h
+++ b/include/tev/imageio/StbiLdrImageSaver.h
@@ -5,13 +5,13 @@
 
 #include <tev/imageio/ImageSaver.h>
 
-#include <fstream>
+#include <ostream>
 
 TEV_NAMESPACE_BEGIN
 
 class StbiLdrImageSaver : public TypedImageSaver<char> {
 public:
-    void save(std::ofstream& f, const filesystem::path& path, const std::vector<char>& data, const Eigen::Vector2i& imageSize, int nChannels) const override;
+    void save(std::ostream& oStream, const filesystem::path& path, const std::vector<char>& data, const Eigen::Vector2i& imageSize, int nChannels) const override;
 
     bool hasPremultipliedAlpha() const override {
         return false;

--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -63,6 +63,7 @@ HelpWindow::HelpWindow(Widget *parent, function<void()> closeCallback)
         addRow(imageLoading, COMMAND + "+W",                             "Close Image");
         addRow(imageLoading, COMMAND + "+Shift+W",                       "Close All Images");
         addRow(imageLoading, COMMAND + "+C",                             "Copy Image or Path to Clipboard");
+        addRow(imageLoading, COMMAND + "+V",                             "Paste Image from Clipboard");
 
         new Label{shortcuts, "Image Options", "sans-bold", 18};
         auto imageSelection = new Widget{shortcuts};

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -18,34 +18,29 @@ TEV_NAMESPACE_BEGIN
 
 atomic<int> Image::sId(0);
 
-Image::Image(const filesystem::path& path, const string& channelSelector)
+Image::Image(const filesystem::path& path, istream& iStream, const string& channelSelector)
 : mPath{path}, mChannelSelector{channelSelector}, mId{sId++} {
-    if (!channelSelector.empty()) {
-        mName = tfm::format("%s:%s", path, channelSelector);
-    } else {
-        mName = path.str();
-    }
+    mName = channelSelector.empty() ? path.str() : tfm::format("%s:%s", path, channelSelector);
 
     auto start = chrono::system_clock::now();
 
-    ifstream f{nativeString(mPath), ios_base::binary};
-    if (!f) {
-        throw invalid_argument{tfm::format("File %s could not be opened.", mPath)};
+    if (!iStream) {
+        throw invalid_argument{tfm::format("Image %s could not be opened.", mName)};
     }
 
     std::string loadMethod;
     for (const auto& imageLoader : ImageLoader::getLoaders()) {
         // If we arrived at the last loader, then we want to at least try loading the image,
         // even if it is likely to fail.
-        bool useLoader = imageLoader == ImageLoader::getLoaders().back() || imageLoader->canLoadFile(f);
+        bool useLoader = imageLoader == ImageLoader::getLoaders().back() || imageLoader->canLoadFile(iStream);
 
         // Reset file cursor in case file load check changed it.
-        f.clear();
-        f.seekg(0);
+        iStream.clear();
+        iStream.seekg(0);
 
         if (useLoader) {
             loadMethod = imageLoader->name();
-            mData = imageLoader->load(f, mPath, mChannelSelector);
+            mData = imageLoader->load(iStream, mPath, mChannelSelector);
             ensureValid();
 
             if (imageLoader->hasPremultipliedAlpha()) {
@@ -60,7 +55,7 @@ Image::Image(const filesystem::path& path, const string& channelSelector)
 
     ensureValid();
 
-    tlog::success() << tfm::format("Loaded '%s' via %s after %.3f seconds.", mPath, loadMethod, elapsedSeconds.count());
+    tlog::success() << tfm::format("Loaded '%s' via %s after %.3f seconds.", mName, loadMethod, elapsedSeconds.count());
 }
 
 string Image::shortName() const {
@@ -203,14 +198,7 @@ void Image::ensureValid() {
     }
 }
 
-shared_ptr<Image> tryLoadImage(path path, string channelSelector) {
-    try {
-        path = path.make_absolute();
-    } catch (runtime_error e) {
-        // If for some strange reason we can not obtain an absolute path, let's still
-        // try to open the image at the given path just to make sure.
-    }
-
+shared_ptr<Image> tryLoadImage(path path, istream& iStream, string channelSelector) {
     auto handleException = [&](const exception& e) {
         if (channelSelector.empty()) {
             tlog::error() << tfm::format("Could not load '%s'. %s", path, e.what());
@@ -220,7 +208,7 @@ shared_ptr<Image> tryLoadImage(path path, string channelSelector) {
     };
 
     try {
-        return make_shared<Image>(path, channelSelector);
+        return make_shared<Image>(path, iStream, channelSelector);
     } catch (const invalid_argument& e) {
         handleException(e);
     } catch (const runtime_error& e) {
@@ -230,6 +218,18 @@ shared_ptr<Image> tryLoadImage(path path, string channelSelector) {
     }
 
     return nullptr;
+}
+
+shared_ptr<Image> tryLoadImage(path path, string channelSelector) {
+    try {
+        path = path.make_absolute();
+    } catch (runtime_error e) {
+        // If for some strange reason we can not obtain an absolute path, let's still
+        // try to open the image at the given path just to make sure.
+    }
+
+    ifstream fileStream{nativeString(path), ios_base::binary};
+    return tryLoadImage(path, fileStream, channelSelector);
 }
 
 void BackgroundImagesLoader::enqueue(const path& path, const string& channelSelector, bool shallSelect) {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -8,7 +8,8 @@
 #include <Iex.h>
 
 #include <chrono>
-#include <iostream>
+#include <fstream>
+#include <istream>
 
 using namespace Eigen;
 using namespace filesystem;

--- a/src/imageio/ClipboardImageLoader.cpp
+++ b/src/imageio/ClipboardImageLoader.cpp
@@ -1,0 +1,109 @@
+// This file was developed by Thomas Müller <thomas94@gmx.net>.
+// It is published under the BSD 3-Clause License within the LICENSE file.
+
+#include <tev/imageio/ClipboardImageLoader.h>
+#include <tev/ThreadPool.h>
+
+#include <clip.h>
+
+using namespace Eigen;
+using namespace std;
+
+TEV_NAMESPACE_BEGIN
+
+bool ClipboardImageLoader::canLoadFile(istream& iStream) const {
+    char b[4];
+    iStream.read(b, sizeof(b));
+
+    bool result = !!iStream && iStream.gcount() == sizeof(b) && string(b, sizeof(b)) == "clip";
+
+    iStream.clear();
+    iStream.seekg(0);
+    return result;
+}
+
+ImageData ClipboardImageLoader::load(istream& iStream, const filesystem::path&, const string& channelSelector) const {
+    ImageData result;
+    ThreadPool threadPool;
+
+    char magic[4];
+    clip::image_spec spec;
+
+    iStream.read(magic, 4);
+    string magicString(magic, 4);
+
+    if (magicString != "clip") {
+        throw invalid_argument{tfm::format("Invalid magic clipboard string %s", magicString)};
+    }
+
+    iStream.read(reinterpret_cast<char*>(&spec), sizeof(clip::image_spec));
+    if (iStream.gcount() < (streamsize)sizeof(clip::image_spec)) {
+        throw invalid_argument{tfm::format("Not sufficient bytes to read image spec (%d vs %d)", iStream.gcount(), sizeof(clip::image_spec))};
+    }
+
+    Vector2i size{spec.width, spec.height};
+
+    auto numPixels = (DenseIndex)size.x() * size.y();
+    if (numPixels == 0) {
+        throw invalid_argument{"Image has zero pixels."};
+    }
+
+    auto numChannels = (int)(spec.bits_per_pixel / 8);
+    auto numBytesPerRow = numChannels * size.x();
+    auto numBytes = (DenseIndex)numBytesPerRow * size.y();
+
+    vector<Channel> channels = makeNChannels(numChannels, size);
+
+    vector<char> data(numBytes);
+    iStream.read(reinterpret_cast<char*>(data.data()), numBytes);
+    if (iStream.gcount() < (streamsize)numBytes) {
+        throw invalid_argument{tfm::format("Not sufficient bytes to read image data (%d vs %d)", iStream.gcount(), numBytes)};
+    }
+
+    int shifts[4] = {
+        (int)(spec.red_shift / 8),
+        (int)(spec.green_shift / 8),
+        (int)(spec.blue_shift / 8),
+        (int)(spec.alpha_shift / 8),
+    };
+
+    for (int c = 0; c < numChannels; ++c) {
+        if (shifts[c] >= numChannels) {
+            throw invalid_argument{"Invalid shift encountered in clipboard image."};
+        }
+    }
+
+    threadPool.parallelFor<DenseIndex>(0, size.y(), [&](DenseIndex y) {
+        for (int x = 0; x < size.x(); ++x) {
+            int baseIdx = y * numBytesPerRow + x * numChannels;
+            for (int c = 0; c < numChannels; ++c) {
+                unsigned char val = data[baseIdx + shifts[c]];
+                channels[c].at({x, y}) = toLinear(val / 255.0f);
+            }
+        }
+    });
+
+    vector<pair<size_t, size_t>> matches;
+    for (size_t i = 0; i < channels.size(); ++i) {
+        size_t matchId;
+        if (matchesFuzzy(channels[i].name(), channelSelector, &matchId)) {
+            matches.emplace_back(matchId, i);
+        }
+    }
+
+    if (!channelSelector.empty()) {
+        sort(begin(matches), end(matches));
+    }
+
+    for (const auto& match : matches) {
+        result.channels.emplace_back(move(channels[match.second]));
+    }
+
+    // The clipboard can not contain layers, so all channels simply reside
+    // within a topmost root layer.
+    result.layers.emplace_back("");
+
+    return result;
+}
+
+TEV_NAMESPACE_END

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -9,30 +9,93 @@
 #include <ImfInputPart.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfStdIO.h>
+#include <Iex.h>
+
+#include <fstream>
+#include <sstream>
+
+#include <errno.h>
 
 using namespace Eigen;
 using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
-bool ExrImageLoader::canLoadFile(ifstream& f) const {
+
+class StdIStream: public Imf::IStream
+{
+public:
+    StdIStream(istream& stream, const char fileName[])
+    : Imf::IStream{fileName}, mStream{stream} {
+
+    }
+
+    bool read(char c[/*n*/], int n) override {
+        if (!mStream)
+            throw IEX_NAMESPACE::InputExc("Unexpected end of file.");
+
+        clearError();
+        mStream.read(c, n);
+        return checkError(mStream, n);
+    }
+
+    Imf::Int64 tellg() override {
+        return streamoff(mStream.tellg());
+    }
+
+    void seekg(Imf::Int64 pos) override {
+        mStream.seekg(pos);
+        checkError(mStream);
+    }
+
+    void clear() override {
+        mStream.clear();
+    }
+
+private:
+    // The following error-checking functions were copy&pasted from the OpenEXR source code
+    static void clearError() {
+        errno = 0;
+    }
+
+    static bool checkError(istream& is, streamsize expected = 0) {
+        if (!is) {
+            if (errno) {
+                IEX_NAMESPACE::throwErrnoExc();
+            }
+
+            if (is.gcount() < expected) {
+                THROW (IEX_NAMESPACE::InputExc, "Early end of file: read " << is.gcount() 
+                    << " out of " << expected << " requested bytes.");
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    istream& mStream;
+};
+
+bool ExrImageLoader::canLoadFile(istream& iStream) const {
     // Taken from http://www.openexr.com/ReadingAndWritingImageFiles.pdf
     char b[4];
-    f.read(b, sizeof(b));
+    iStream.read(b, sizeof(b));
 
-    bool result = !!f && f.gcount() == sizeof(b) && b[0] == 0x76 && b[1] == 0x2f && b[2] == 0x31 && b[3] == 0x01;
+    bool result = !!iStream && iStream.gcount() == sizeof(b) && b[0] == 0x76 && b[1] == 0x2f && b[2] == 0x31 && b[3] == 0x01;
 
-    f.clear();
-    f.seekg(0);
+    iStream.clear();
+    iStream.seekg(0);
     return result;
 }
 
-ImageData ExrImageLoader::load(ifstream& f, const filesystem::path& path, const string& channelSelector) const {
+ImageData ExrImageLoader::load(istream& iStream, const filesystem::path& path, const string& channelSelector) const {
     ImageData result;
     ThreadPool threadPool;
 
-    Imf::StdIFStream imfStream{f, path.str().c_str()};
-    Imf::MultiPartInputFile multiPartFile{imfStream};
+    StdIStream stdIStream{iStream, path.str().c_str()};
+    Imf::MultiPartInputFile multiPartFile{stdIStream};
     int numParts = multiPartFile.parts();
 
     if (numParts <= 0) {

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -8,11 +8,9 @@
 #include <ImfInputFile.h>
 #include <ImfInputPart.h>
 #include <ImfMultiPartInputFile.h>
-#include <ImfStdIO.h>
 #include <Iex.h>
 
-#include <fstream>
-#include <sstream>
+#include <istream>
 
 #include <errno.h>
 

--- a/src/imageio/ImageLoader.cpp
+++ b/src/imageio/ImageLoader.cpp
@@ -1,6 +1,7 @@
 // This file was developed by Thomas Müller <thomas94@gmx.net>.
 // It is published under the BSD 3-Clause License within the LICENSE file.
 
+#include <tev/imageio/ClipboardImageLoader.h>
 #include <tev/imageio/ExrImageLoader.h>
 #include <tev/imageio/ImageLoader.h>
 #include <tev/imageio/PfmImageLoader.h>
@@ -16,6 +17,7 @@ const vector<unique_ptr<ImageLoader>>& ImageLoader::getLoaders() {
         vector<unique_ptr<ImageLoader>> imageLoaders;
         imageLoaders.emplace_back(new ExrImageLoader());
         imageLoaders.emplace_back(new PfmImageLoader());
+        imageLoaders.emplace_back(new ClipboardImageLoader());
         imageLoaders.emplace_back(new StbiImageLoader());
         return imageLoaders;
     };

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -9,18 +9,18 @@ using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
-bool PfmImageLoader::canLoadFile(ifstream& f) const {
+bool PfmImageLoader::canLoadFile(istream& iStream) const {
     char b[2];
-    f.read(b, sizeof(b));
+    iStream.read(b, sizeof(b));
 
-    bool result = !!f && f.gcount() == sizeof(b) && b[0] == 'P' && (b[1] == 'F' || b[1] == 'f');
+    bool result = !!iStream && iStream.gcount() == sizeof(b) && b[0] == 'P' && (b[1] == 'F' || b[1] == 'f');
 
-    f.clear();
-    f.seekg(0);
+    iStream.clear();
+    iStream.seekg(0);
     return result;
 }
 
-ImageData PfmImageLoader::load(ifstream& f, const filesystem::path&, const string& channelSelector) const {
+ImageData PfmImageLoader::load(istream& iStream, const filesystem::path&, const string& channelSelector) const {
     ImageData result;
     ThreadPool threadPool;
 
@@ -28,7 +28,7 @@ ImageData PfmImageLoader::load(ifstream& f, const filesystem::path&, const strin
     Vector2i size;
     float scale;
 
-    f >> magic >> size.x() >> size.y() >> scale;
+    iStream >> magic >> size.x() >> size.y() >> scale;
 
     if (magic != "PF" && magic != "Pf") {
         throw invalid_argument{tfm::format("Invalid magic PFM string %s", magic)};
@@ -54,13 +54,13 @@ ImageData PfmImageLoader::load(ifstream& f, const filesystem::path&, const strin
 
     // Skip last newline at the end of the header.
     string line;
-    getline(f, line);
+    getline(iStream, line);
 
     // Read entire file in binary mode.
     vector<float> data(numFloats);
-    f.read(reinterpret_cast<char*>(data.data()), numBytes);
-    if (f.gcount() < (streamsize)numBytes) {
-        throw invalid_argument{tfm::format("Not sufficient bytes to read (%d vs %d)", f.gcount(), numBytes)};
+    iStream.read(reinterpret_cast<char*>(data.data()), numBytes);
+    if (iStream.gcount() < (streamsize)numBytes) {
+        throw invalid_argument{tfm::format("Not sufficient bytes to read (%d vs %d)", iStream.gcount(), numBytes)};
     }
 
     // Reverse bytes of every float if endianness does not match up with system

--- a/src/imageio/StbiHdrImageSaver.cpp
+++ b/src/imageio/StbiHdrImageSaver.cpp
@@ -5,7 +5,7 @@
 
 #include <stb_image_write.h>
 
-#include <fstream>
+#include <ostream>
 #include <vector>
 
 using namespace Eigen;
@@ -14,12 +14,12 @@ using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
-void StbiHdrImageSaver::save(ofstream& f, const path& path, const vector<float>& data, const Vector2i& imageSize, int nChannels) const {
+void StbiHdrImageSaver::save(ostream& oStream, const path& path, const vector<float>& data, const Vector2i& imageSize, int nChannels) const {
     static const auto stbiOfstreamWrite = [](void* context, void* data, int size) {
-        reinterpret_cast<ofstream*>(context)->write(reinterpret_cast<char*>(data), size);
+        reinterpret_cast<ostream*>(context)->write(reinterpret_cast<char*>(data), size);
     };
 
-    stbi_write_hdr_to_func(stbiOfstreamWrite, &f, imageSize.x(), imageSize.y(), nChannels, data.data());
+    stbi_write_hdr_to_func(stbiOfstreamWrite, &oStream, imageSize.x(), imageSize.y(), nChannels, data.data());
 }
 
 TEV_NAMESPACE_END

--- a/src/imageio/StbiHdrImageSaver.cpp
+++ b/src/imageio/StbiHdrImageSaver.cpp
@@ -15,11 +15,11 @@ using namespace std;
 TEV_NAMESPACE_BEGIN
 
 void StbiHdrImageSaver::save(ostream& oStream, const path& path, const vector<float>& data, const Vector2i& imageSize, int nChannels) const {
-    static const auto stbiOfstreamWrite = [](void* context, void* data, int size) {
+    static const auto stbiOStreamWrite = [](void* context, void* data, int size) {
         reinterpret_cast<ostream*>(context)->write(reinterpret_cast<char*>(data), size);
     };
 
-    stbi_write_hdr_to_func(stbiOfstreamWrite, &oStream, imageSize.x(), imageSize.y(), nChannels, data.data());
+    stbi_write_hdr_to_func(stbiOStreamWrite, &oStream, imageSize.x(), imageSize.y(), nChannels, data.data());
 }
 
 TEV_NAMESPACE_END

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -11,44 +11,44 @@ using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
-bool StbiImageLoader::canLoadFile(ifstream&) const {
+bool StbiImageLoader::canLoadFile(istream&) const {
     // Pretend you can load any file and throw exception on failure.
     // TODO: Add proper check.
     return true;
 }
 
-ImageData StbiImageLoader::load(ifstream& f, const filesystem::path&, const string& channelSelector) const {
+ImageData StbiImageLoader::load(istream& iStream, const filesystem::path&, const string& channelSelector) const {
     ImageData result;
     ThreadPool threadPool;
 
     static const stbi_io_callbacks callbacks = {
         // Read
         [](void* context, char* data, int size) {
-            auto stream = reinterpret_cast<ifstream*>(context);
+            auto stream = reinterpret_cast<istream*>(context);
             stream->read(data, size);
             return (int)stream->gcount();
         },
         // Seek
         [](void* context, int size) {
-            reinterpret_cast<ifstream*>(context)->seekg(size, ios_base::cur);
+            reinterpret_cast<istream*>(context)->seekg(size, ios_base::cur);
         },
         // EOF
         [](void* context) {
-            return (int)!!(*reinterpret_cast<ifstream*>(context));
+            return (int)!!(*reinterpret_cast<istream*>(context));
         },
     };
 
     void* data;
     int numChannels;
     Vector2i size;
-    bool isHdr = stbi_is_hdr_from_callbacks(&callbacks, &f) != 0;
-    f.clear();
-    f.seekg(0);
+    bool isHdr = stbi_is_hdr_from_callbacks(&callbacks, &iStream) != 0;
+    iStream.clear();
+    iStream.seekg(0);
 
     if (isHdr) {
-        data = stbi_loadf_from_callbacks(&callbacks, &f, &size.x(), &size.y(), &numChannels, 0);
+        data = stbi_loadf_from_callbacks(&callbacks, &iStream, &size.x(), &size.y(), &numChannels, 0);
     } else {
-        data = stbi_load_from_callbacks(&callbacks, &f, &size.x(), &size.y(), &numChannels, 0);
+        data = stbi_load_from_callbacks(&callbacks, &iStream, &size.x(), &size.y(), &numChannels, 0);
     }
 
     if (!data) {

--- a/src/imageio/StbiLdrImageSaver.cpp
+++ b/src/imageio/StbiLdrImageSaver.cpp
@@ -16,20 +16,20 @@ using namespace std;
 TEV_NAMESPACE_BEGIN
 
 void StbiLdrImageSaver::save(ostream& iStream, const path& path, const vector<char>& data, const Vector2i& imageSize, int nChannels) const {
-    static const auto stbiOfstreamWrite = [](void* context, void* data, int size) {
+    static const auto stbiOStreamWrite = [](void* context, void* data, int size) {
         reinterpret_cast<ostream*>(context)->write(reinterpret_cast<char*>(data), size);
     };
 
     auto extension = toLower(path.extension());
 
     if (extension == "jpg" || extension == "jpeg") {
-        stbi_write_jpg_to_func(stbiOfstreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data(), 100);
+        stbi_write_jpg_to_func(stbiOStreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data(), 100);
     } else if (extension == "png") {
-        stbi_write_png_to_func(stbiOfstreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data(), 0);
+        stbi_write_png_to_func(stbiOStreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data(), 0);
     } else if (extension == "bmp") {
-        stbi_write_bmp_to_func(stbiOfstreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data());
+        stbi_write_bmp_to_func(stbiOStreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data());
     } else if (extension == "tga") {
-        stbi_write_tga_to_func(stbiOfstreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data());
+        stbi_write_tga_to_func(stbiOStreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data());
     } else {
         throw invalid_argument{tfm::format("Image '%s' has unknown format.", path)};
     }

--- a/src/imageio/StbiLdrImageSaver.cpp
+++ b/src/imageio/StbiLdrImageSaver.cpp
@@ -6,7 +6,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 
-#include <fstream>
+#include <ostream>
 #include <vector>
 
 using namespace Eigen;
@@ -15,21 +15,21 @@ using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
-void StbiLdrImageSaver::save(ofstream& f, const path& path, const vector<char>& data, const Vector2i& imageSize, int nChannels) const {
+void StbiLdrImageSaver::save(ostream& iStream, const path& path, const vector<char>& data, const Vector2i& imageSize, int nChannels) const {
     static const auto stbiOfstreamWrite = [](void* context, void* data, int size) {
-        reinterpret_cast<ofstream*>(context)->write(reinterpret_cast<char*>(data), size);
+        reinterpret_cast<ostream*>(context)->write(reinterpret_cast<char*>(data), size);
     };
 
     auto extension = toLower(path.extension());
 
     if (extension == "jpg" || extension == "jpeg") {
-        stbi_write_jpg_to_func(stbiOfstreamWrite, &f, imageSize.x(), imageSize.y(), nChannels, data.data(), 100);
+        stbi_write_jpg_to_func(stbiOfstreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data(), 100);
     } else if (extension == "png") {
-        stbi_write_png_to_func(stbiOfstreamWrite, &f, imageSize.x(), imageSize.y(), nChannels, data.data(), 0);
+        stbi_write_png_to_func(stbiOfstreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data(), 0);
     } else if (extension == "bmp") {
-        stbi_write_bmp_to_func(stbiOfstreamWrite, &f, imageSize.x(), imageSize.y(), nChannels, data.data());
+        stbi_write_bmp_to_func(stbiOfstreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data());
     } else if (extension == "tga") {
-        stbi_write_tga_to_func(stbiOfstreamWrite, &f, imageSize.x(), imageSize.y(), nChannels, data.data());
+        stbi_write_tga_to_func(stbiOfstreamWrite, &iStream, imageSize.x(), imageSize.y(), nChannels, data.data());
     } else {
         throw invalid_argument{tfm::format("Image '%s' has unknown format.", path)};
     }


### PR DESCRIPTION
- Adds support for pasting an image into tev to open it (e.g. from a web browser or a chat client)
- Generalizes image-loading and image-saving routines to arbitrary istreams and ostreams