### PR TITLE
Allow reordering images by dragging them

### DIFF
--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -37,6 +37,7 @@ public:
     void drawContents() override;
 
     void insertImage(std::shared_ptr<Image> image, size_t index, bool shallSelect = false);
+    void moveImageInList(size_t oldIndex, size_t newIndex);
 
     void addImage(std::shared_ptr<Image> image, bool shallSelect = false) {
         insertImage(image, mImages.size(), shallSelect);
@@ -200,6 +201,8 @@ private:
 
     bool mIsDraggingSidebar = false;
     bool mIsDraggingImage = false;
+    bool mIsDraggingImageInList = false;
+    size_t mImageIdInListBeingDragged;
 
     Eigen::Vector2f mDraggingStartPosition;
 

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -201,8 +201,8 @@ private:
 
     bool mIsDraggingSidebar = false;
     bool mIsDraggingImage = false;
-    bool mIsDraggingImageInList = false;
-    size_t mImageIdInListBeingDragged;
+    bool mIsDraggingImageButton = false;
+    size_t mDraggedImageButtonId;
 
     Eigen::Vector2f mDraggingStartPosition;
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -449,31 +449,29 @@ ImageViewer::~ImageViewer() {
 bool ImageViewer::mouseButtonEvent(const Vector2i &p, int button, bool down, int modifiers) {
     // Check if the user performed mousedown on an imagebutton so we can mark it as being dragged.
     // This has to occur before Screen::mouseButtonEvent as the button would absorb the event.
-    if(down) {
+    if (down) {
         if (mImageScrollContainer->contains(p)) {
             auto& buttons = mImageButtonContainer->children();
 
-            Eigen::Vector2i relMousePos = (this->absolutePosition() + p) - mImageButtonContainer->absolutePosition();
+            Eigen::Vector2i relMousePos = (absolutePosition() + p) - mImageButtonContainer->absolutePosition();
 
             for (size_t i = 0; i < buttons.size(); ++i) {
                 const auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
-                if(imgButton->contains(relMousePos))
-                {
-                    mImageIdInListBeingDragged = i;
-                    mIsDraggingImageInList = true;
+                if (imgButton->contains(relMousePos)) {
+                    mDraggedImageButtonId = i;
+                    mIsDraggingImageButton = true;
+                    mDraggingStartPosition = (relMousePos - imgButton->position()).cast<float>();
                     break;
                 }
             }
         }
-    } else {
-        mIsDraggingImageInList = false;
     }
 
     if (Screen::mouseButtonEvent(p, button, down, modifiers)) {
         return true;
     }
 
-    if (down) {
+    if (down && !mIsDraggingImageButton) {
         if (canDragSidebarFrom(p)) {
             mIsDraggingSidebar = true;
             mDraggingStartPosition = p.cast<float>();
@@ -484,8 +482,13 @@ bool ImageViewer::mouseButtonEvent(const Vector2i &p, int button, bool down, int
             return true;
         }
     } else {
+        if (mIsDraggingImageButton) {
+            requestLayoutUpdate();
+        }
+
         mIsDraggingSidebar = false;
         mIsDraggingImage = false;
+        mIsDraggingImageButton = false;
     }
 
     return false;
@@ -527,21 +530,27 @@ bool ImageViewer::mouseMotionEvent(const Vector2i& p, const Vector2i& rel, int b
         if ((button & 4) != 0) {
             mImageCanvas->scale(relativeMovement.y() / 10.0f, mDraggingStartPosition);
         }
-    } else if (mIsDraggingImageInList) {
+    } else if (mIsDraggingImageButton) {
         auto& buttons = mImageButtonContainer->children();
-        Eigen::Vector2i relMousePos = (this->absolutePosition() + p) - mImageButtonContainer->absolutePosition();
-        size_t i = 0;
-        for (; i < buttons.size(); ++i) {
-            const auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
-            if(relMousePos.y() < (imgButton->position() + imgButton->size()).y()) {
+        Eigen::Vector2i relMousePos = (absolutePosition() + p) - mImageButtonContainer->absolutePosition();
+        for (size_t i = 0; i < buttons.size(); ++i) {
+            if (i == mDraggedImageButtonId) {
+                continue;
+            }
+            auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
+            if (imgButton->contains(relMousePos)) {
+                Vector2i pos = imgButton->position();
+                pos.y() += (mDraggedImageButtonId - i) * imgButton->size().y();
+                imgButton->setPosition(pos);
+                imgButton->mouseEnterEvent(relMousePos, false);
+
+                moveImageInList(mDraggedImageButtonId, i);
+                mDraggedImageButtonId = i;
                 break;
             }
         }
-        i = std::min(i, buttons.size()-1);
-        if(mImageIdInListBeingDragged != i) {
-            moveImageInList(mImageIdInListBeingDragged, i);
-            mImageIdInListBeingDragged = i;
-        }
+        
+        dynamic_cast<ImageButton*>(buttons[mDraggedImageButtonId])->setPosition(relMousePos - mDraggingStartPosition.cast<int>());
     }
 
     return false;
@@ -855,8 +864,17 @@ void ImageViewer::drawContents() {
     }
 
     if (mRequiresLayoutUpdate) {
+        Vector2i oldDraggedImageButtonPos;
+        auto& buttons = mImageButtonContainer->children();
+        if (mIsDraggingImageButton) {
+            oldDraggedImageButtonPos = dynamic_cast<ImageButton*>(buttons[mDraggedImageButtonId])->position();
+        }
         updateLayout();
         mRequiresLayoutUpdate = false;
+
+        if (mIsDraggingImageButton) {
+            dynamic_cast<ImageButton*>(buttons[mDraggedImageButtonId])->setPosition(oldDraggedImageButtonPos);
+        }
     }
 
     updateTitle();
@@ -900,6 +918,10 @@ void ImageViewer::insertImage(shared_ptr<Image> image, size_t index, bool shallS
         throw invalid_argument{"Image may not be null."};
     }
 
+    if (mIsDraggingImageButton && index <= mDraggedImageButtonId) {
+        ++mDraggedImageButtonId;
+    }
+
     for (auto button : mAnyImageButtons) {
         button->setEnabled(true);
     }
@@ -941,12 +963,12 @@ void ImageViewer::insertImage(shared_ptr<Image> image, size_t index, bool shallS
 }
 
 void ImageViewer::moveImageInList(size_t oldIndex, size_t newIndex) {
-    if(oldIndex == newIndex) {
+    if (oldIndex == newIndex) {
         return;
     }
 
-    assert(oldIndex < mImages.size());
-    assert(newIndex < mImages.size());
+    TEV_ASSERT(oldIndex < mImages.size(), "oldIndex must be smaller than the number of images.");
+    TEV_ASSERT(newIndex < mImages.size(), "newIndex must be smaller than the number of images.");
 
     auto* button = mImageButtonContainer->childAt(oldIndex);
     button->incRef();
@@ -956,7 +978,7 @@ void ImageViewer::moveImageInList(size_t oldIndex, size_t newIndex) {
 
     auto startI = std::min(oldIndex, newIndex);
     auto endI = std::max(oldIndex, newIndex);
-    for(size_t i = startI; i <= endI; ++i) {
+    for (size_t i = startI; i <= endI; ++i) {
         auto* curButton = dynamic_cast<ImageButton*>(mImageButtonContainer->childAt(i));
         curButton->setId(i+1);
     }
@@ -972,6 +994,16 @@ void ImageViewer::removeImage(shared_ptr<Image> image) {
     int id = imageId(image);
     if (id == -1) {
         return;
+    }
+
+    if (mIsDraggingImageButton) {
+        // If we're currently dragging the to-be-removed image, stop.
+        if ((size_t)id == mDraggedImageButtonId) {
+            requestLayoutUpdate();
+            mIsDraggingImageButton = false;
+        } else if ((size_t)id < mDraggedImageButtonId) {
+            --mDraggedImageButtonId;
+        }
     }
 
     auto nextCandidate = nextImage(image, Forward);

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -533,13 +533,12 @@ bool ImageViewer::mouseMotionEvent(const Vector2i& p, const Vector2i& rel, int b
         size_t i = 0;
         for (; i < buttons.size(); ++i) {
             const auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
-            if(relMousePos.y() < (imgButton->position() + imgButton->size()).y()){
+            if(relMousePos.y() < (imgButton->position() + imgButton->size()).y()) {
                 break;
             }
         }
         i = std::min(i, buttons.size()-1);
-        if(mImageIdInListBeingDragged != i)
-        {
+        if(mImageIdInListBeingDragged != i) {
             moveImageInList(mImageIdInListBeingDragged, i);
             mImageIdInListBeingDragged = i;
         }
@@ -942,8 +941,7 @@ void ImageViewer::insertImage(shared_ptr<Image> image, size_t index, bool shallS
 }
 
 void ImageViewer::moveImageInList(size_t oldIndex, size_t newIndex) {
-    if(oldIndex == newIndex)
-    {
+    if(oldIndex == newIndex) {
         return;
     }
 
@@ -958,8 +956,7 @@ void ImageViewer::moveImageInList(size_t oldIndex, size_t newIndex) {
 
     auto startI = std::min(oldIndex, newIndex);
     auto endI = std::max(oldIndex, newIndex);
-    for(size_t i = startI; i <= endI; ++i)
-    {
+    for(size_t i = startI; i <= endI; ++i) {
         auto* curButton = dynamic_cast<ImageButton*>(mImageButtonContainer->childAt(i));
         curButton->setId(i+1);
     }


### PR DESCRIPTION
Thanks for tev! I've found it incredibly useful so far.

This pull request adds functionality to the image list. Users can reorder images by clicking and dragging them around. This can be convenient when you want to reorder frames of an animation, or put images you want to compare next to eachother in the list.