### PR TITLE
Add support for PF4 to PFM loader

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches:
       - master
@@ -50,7 +50,7 @@ jobs:
           submodules: recursive
 
       - name: Setup MSBuild.exe
-        uses: warrenbuckley/Setup-MSBuild@v1
+        uses: microsoft/setup-msbuild@v1.0.2
 
       - name: CMake
         run: cmake .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: sudo apt-get install cmake xorg-dev libglu1-mesa-dev zlib1g-dev zenity
+        run: sudo apt-get update && sudo apt-get install cmake xorg-dev libglu1-mesa-dev zlib1g-dev zenity
       - uses: actions/checkout@v1
         with:
           submodules: recursive

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -31,7 +31,14 @@ ImageData PfmImageLoader::load(istream& iStream, const path&, const string& chan
 
     iStream >> magic >> size.x() >> size.y() >> scale;
 
-    if (magic != "PF" && magic != "Pf" && magic != "PF4") {
+    int numChannels;
+    if (magic == "Pf") {
+        numChannels = 1;
+    } else if (magic == "PF") {
+        numChannels = 3;
+    } else if (magic == "PF4") {
+        numChannels = 4;
+    } else {
         throw invalid_argument{tfm::format("Invalid magic PFM string %s", magic)};
     }
 
@@ -39,19 +46,6 @@ ImageData PfmImageLoader::load(istream& iStream, const path&, const string& chan
         throw invalid_argument{tfm::format("Invalid PFM scale %f", scale)};
     }
 
-    int numChannels = 1;
-    if (magic[1] == 'F')
-    {
-        if (magic.size() == 3 && magic[2] == '4')
-        {
-            numChannels = 4;
-        }
-        else
-        {
-            numChannels = 3;
-        }
-    }
-    
     bool isPfmLittleEndian = scale < 0;
     scale = abs(scale);
 
@@ -61,7 +55,7 @@ ImageData PfmImageLoader::load(istream& iStream, const path&, const string& chan
     if (numPixels == 0) {
         throw invalid_argument{"Image has zero pixels."};
     }
-    
+
     auto numFloats = numPixels * numChannels;
     auto numBytes = numFloats * sizeof(float);
 

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -31,7 +31,7 @@ ImageData PfmImageLoader::load(istream& iStream, const path&, const string& chan
 
     iStream >> magic >> size.x() >> size.y() >> scale;
 
-    if (magic != "PF" && magic != "Pf") {
+    if (magic != "PF" && magic != "Pf" && magic != "PF4") {
         throw invalid_argument{tfm::format("Invalid magic PFM string %s", magic)};
     }
 

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -39,7 +39,19 @@ ImageData PfmImageLoader::load(istream& iStream, const path&, const string& chan
         throw invalid_argument{tfm::format("Invalid PFM scale %f", scale)};
     }
 
-    int numChannels = magic[1] == 'F' ? 3 : 1;
+    int numChannels = 1;
+    if (magic[1] == 'F')
+    {
+        if (magic.size() == 3 && magic[2] == '4')
+        {
+            numChannels = 4;
+        }
+        else
+        {
+            numChannels = 3;
+        }
+    }
+    
     bool isPfmLittleEndian = scale < 0;
     scale = abs(scale);
 
@@ -54,8 +66,8 @@ ImageData PfmImageLoader::load(istream& iStream, const path&, const string& chan
     auto numBytes = numFloats * sizeof(float);
 
     // Skip last newline at the end of the header.
-    string line;
-    getline(iStream, line);
+    char c;
+    while (iStream.get(c) && c != '\r' && c != '\n');
 
     // Read entire file in binary mode.
     vector<float> data(numFloats);


### PR DESCRIPTION
This PR adds support for the PF4 extension to the PFM format, as described in issue #109.

Two changes were made:
 - Modify the parsing of the magic word in the header to detect PF4 (RGBA) images
 - Replace `getline` with a loop that works for both `\r` and `\n`.

Reference images from both the [PFM website](http://www.pauldebevec.com/Research/HDR/PFM/) and the [PF4 website](https://www.cse.cuhk.edu.hk/~ttwong/data/hdrfire/hdrfire.html) now work correctly.