### PR TITLE
Better image updates via IPC

### DIFF
--- a/include/tev/Ipc.h
+++ b/include/tev/Ipc.h
@@ -30,6 +30,15 @@ struct IpcPacketUpdateImage {
     std::vector<float> imageData;
 };
 
+struct IpcPacketUpdateImageMultiChannel {
+    std::string imageName;
+    bool grabFocus;
+    int32_t nChannels;
+    std::vector<std::string> channelNames;
+    int32_t x, y, width, height;
+    std::vector<std::vector<float>> imageData; // One set of data per channel
+};
+
 struct IpcPacketCloseImage {
     std::string imageName;
 };
@@ -50,6 +59,7 @@ public:
         CloseImage = 2,
         UpdateImage = 3,
         CreateImage = 4,
+        UpdateImageMultiChannel = 5,
     };
 
     IpcPacket() = default;
@@ -72,12 +82,14 @@ public:
     void setReloadImage(const std::string& imageName, bool grabFocus);
     void setCloseImage(const std::string& imageName);
     void setUpdateImage(const std::string& imageName, bool grabFocus, const std::string& channel, int x, int y, int width, int height, const std::vector<float>& imageData);
+    void setUpdateImageMultiChannel(const std::string& imageName, bool grabFocus, int nChannels, const std::vector<std::string>& channelNames, int x, int y, int width, int height, const std::vector<std::vector<float>>& imageData);
     void setCreateImage(const std::string& imageName, bool grabFocus, int width, int height, int nChannels, const std::vector<std::string>& channelNames);
 
     IpcPacketOpenImage interpretAsOpenImage() const;
     IpcPacketReloadImage interpretAsReloadImage() const;
     IpcPacketCloseImage interpretAsCloseImage() const;
     IpcPacketUpdateImage interpretAsUpdateImage() const;
+    IpcPacketUpdateImageMultiChannel interpretAsUpdateImageMultiChannel() const;
     IpcPacketCreateImage interpretAsCreateImage() const;
 
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -290,6 +290,20 @@ int mainFunc(const vector<string>& arguments) {
                                 break;
                             }
 
+                            case IpcPacket::UpdateImageMultiChannel: {
+                                while (!imageViewer) { }
+                                auto info = packet.interpretAsUpdateImageMultiChannel();
+                                imageViewer->scheduleToUiThread([&,info] {
+                                    string imageString = ensureUtf8(info.imageName);
+                                    for (int i = 0; i < info.nChannels; ++i) {
+                                        imageViewer->updateImage(imageString, info.grabFocus, info.channelNames[i], info.x, info.y, info.width, info.height, info.imageData[i]);
+                                    }
+                                });
+
+                                glfwPostEmptyEvent();
+                                break;
+                            }
+
                             case IpcPacket::CreateImage: {
                                 while (!imageViewer) { }
                                 auto info = packet.interpretAsCreateImage();


### PR DESCRIPTION
Fixes #112 

- Removes the buffer size limitation such that images can be updated without tiling. (Legacy limitation of having used raw UDP packets that have a maximum size.)
- Adds the ability to update multiple channels at once to avoid flickering.

@mmp perhaps this is interesting for pbrt?