### PR TITLE
Expand on inter process communication (IPC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Automatically generated files by .vscode
 /.vscode
 
+# Python cache
+__pycache__
+
 # Development project files
 *.sublime-project
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,17 @@ _A false-color comparison of two multi-layer OpenEXR images of a beach ball. Ima
 
 ### Graphical User Interface
 
-Images can be opened via a file dialog or simply by dragging them into __tev__. They can be reloaded, closed, or filtered at any time, so don't worry about opening more images than exactly needed.
+Images can be opened via a file dialog or by dragging them into __tev__.
+They can be reloaded, closed, or filtered at any time, so don't worry about opening more images than exactly needed.
 
-Select an image by left-clicking it, and optionally select a reference image to compare the current selection to by right-clicking. For convenience, the current selection can be moved with the Up/Down or the 1-9 keys. For a comprehensive list of keyboard shortcuts simply click the little "?" icon at the top (or press "h").
+Select an image by left-clicking it, and optionally select a reference image to compare the current selection to by right-clicking.
+For convenience, the current selection can be moved with the Up/Down or the 1-9 keys. For a comprehensive list of keyboard shortcuts click the little "?" icon at the top (or press "h").
 
-If the interface seems overwhelming, simply hover any controls to view an explanatory tooltip.
+If the interface seems overwhelming, you can hover any controls to view an explanatory tooltip.
 
 ### Command Line
 
-Simply supply images as positional command-line arguments.
+__tev__ takes images as positional command-line arguments:
 ```sh
 $ tev foo.exr bar.exr
 ```
@@ -43,35 +45,37 @@ By default, all layers and channels are loaded, but individual layers or channel
 $ tev :depth foo.exr :r,g,b foo.exr bar.exr
 ```
 
-Other command-line arguments also exist (e.g. for starting __tev__ with a pre-set exposure value). For a list of all valid arguments simply invoke
+Other command-line arguments exist (e.g. for starting __tev__ with a pre-set exposure value). For a list of all arguments simply invoke
 ```sh
 $ tev -h
 ```
 
 ### Over the Network
 
-__tev__ supports inter-process communication (IPC) over the network. With IPC, __tev__ can be remote controlled by other applications. The `--host` command line argument controls on which IP and port __tev__ is listening to. The default is `127.0.0.1:14158`, i.e. __tev__ does not respond to requests from external machines by default.
+__tev__ can also be controlled remotely over the network using a simple TCP-based protocol.
 
-The following kinds of operations are supported:
+The `--host` argument specifies the IP and port __tev__ is listening to. By default, __tev__ only accepts connections from localhost (`127.0.0.1:14158`), which is useful, for example, as frontend for a supported renderer like [pbrt version 4](https://github.com/mmp/pbrt-v4).
+
+The following operations exist:
 
 | Operation | Function
 | :--- | :---------- 
-| `OpenImage` | Opens an image from a specified path from the disk of the machine __tev__ is running on.
-| `CreateImage` | Create a blank image with a specified name, size and set of channel names. "R", "G", "B" [, "A"] is what should be used if an image is rendered.
-| `UpdateImage` | Updates the pixel values of a specified image region and a specified set of channels.
+| `OpenImage` | Opens an image from a specified path on the machine __tev__ is running on.
+| `CreateImage` | Creates a blank image with a specified name, size, and set of channels.
+| `UpdateImage` | Updates the pixels in a rectangular region.
 | `CloseImage` | Closes a specified image.
-| `ReloadImage` | Reloads the image with specified path from the disk of the machine __tev__ is running on.
+| `ReloadImage` | Reloads an image from a specified path on the machine __tev__ is running on.
 
-__tev__'s IPC protocol is already implemented in the following languages:
+__tev__'s network protocol is already implemented in the following languages:
 - [Python](src/python/ipc.py) by Thomáš Iser
 - [Rust](https://crates.io/crates/tev_client) by Karel Peeters
 
 
-In case you need a custom implementation: IPC uses a simple protocol over TCP, where each packet has the form
+If using these implementations is not an option, it's easy to write your own one. Each packet has the simple form
 ```
-[uint32_t total_length_in_bytes][char operation_type][char[] operation_specific_payload]
+[uint32_t total_length_in_bytes][byte operation_type][byte[] operation_specific_payload]
 ```
-Every integer must be encoded in little endian format.
+where integers are encoded in little endian.
 
 There are helper functions in [Ipc.cpp](src/ipc.cpp) (`IpcPacket::set*`) that show exactly how each packet has to be assembled. These functions do not rely on external dependencies, so it is recommended to copy and paste them into your project for interfacing with __tev__.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,34 @@ Other command-line arguments also exist (e.g. for starting __tev__ with a pre-se
 $ tev -h
 ```
 
+### Over the Network
+
+__tev__ supports inter-process communication (IPC) over the network. With IPC, __tev__ can be remote controlled by other applications. The `--host` command line argument controls on which IP and port __tev__ is listening to. The default is `127.0.0.1:14158`, i.e. __tev__ does not respond to requests from external machines by default.
+
+The following kinds of operations are supported:
+
+| Operation | Function
+| :--- | :---------- 
+| `OpenImage` | Opens an image from a specified path from the disk of the machine __tev__ is running on.
+| `CreateImage` | Create a blank image with a specified size and a specified set of channel names ("R", "G", "B" [, "A"] is what you should use if you are rendering an image.)
+| `UpdateImage` | Lets you send updated pixel values to a specified image region and a specified set of channels
+| `CloseImage` | Closes the image with specified path.
+| `ReloadImage` | Reloads the image with specified path from the disk of the machine __tev__ is running on.
+
+__tev__'s IPC protocol is already implemented in the following languages:
+- [Python](src/python/ipc.py) by Thomáš Iser
+- [Rust](https://crates.io/crates/tev_client) by Karel Peeters
+
+
+In case you need a custom implementation: IPC uses a simple protocol over TCP, where each packet has the form
+```
+[uint32_t total_length_in_bytes][char operation_type][char[] operation_specific_payload]
+```
+Every integer must be encoded in little endian format.
+
+There are helper functions in [Ipc.cpp](src/ipc.cpp) (`IpcPacket::set*`) that show exactly how each packet has to be assembled. These functions do not rely on external dependencies, so it is recommended to copy and paste them into your project for interfacing with __tev__.
+
+
 ## Obtaining tev
 
 ### macOS / Windows

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following operations exist:
 | `ReloadImage` | Reloads an image from a specified path on the machine __tev__ is running on.
 
 __tev__'s network protocol is already implemented in the following languages:
-- [Python](src/python/ipc.py) by Thomáš Iser
+- [Python](src/python/ipc.py) by Tomáš Iser
 - [Rust](https://crates.io/crates/tev_client) by Karel Peeters
 
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ The following kinds of operations are supported:
 | Operation | Function
 | :--- | :---------- 
 | `OpenImage` | Opens an image from a specified path from the disk of the machine __tev__ is running on.
-| `CreateImage` | Create a blank image with a specified size and a specified set of channel names ("R", "G", "B" [, "A"] is what you should use if you are rendering an image.)
-| `UpdateImage` | Lets you send updated pixel values to a specified image region and a specified set of channels
-| `CloseImage` | Closes the image with specified path.
+| `CreateImage` | Create a blank image with a specified name, size and set of channel names. "R", "G", "B" [, "A"] is what should be used if an image is rendered.
+| `UpdateImage` | Updates the pixel values of a specified image region and a specified set of channels.
+| `CloseImage` | Closes a specified image.
 | `ReloadImage` | Reloads the image with specified path from the disk of the machine __tev__ is running on.
 
 __tev__'s IPC protocol is already implemented in the following languages:

--- a/include/tev/Channel.h
+++ b/include/tev/Channel.h
@@ -3,12 +3,15 @@
 
 #pragma once
 
-#include <tev/ThreadPool.h>
+#include <tev/Common.h>
 
 #include <nanogui/vector.h>
 
-#include <vector>
+#include <Eigen/Dense>
+
+#include <future>
 #include <string>
+#include <vector>
 
 TEV_NAMESPACE_BEGIN
 
@@ -66,8 +69,8 @@ public:
         return {mData.cols(), mData.rows()};
     }
 
-    void divideByAsync(const Channel& other, ThreadPool& pool);
-    void multiplyWithAsync(const Channel& other, ThreadPool& pool);
+    void divideByAsync(const Channel& other, std::vector<std::future<void>>& futures);
+    void multiplyWithAsync(const Channel& other, std::vector<std::future<void>>& futures);
 
     void setZero() { mData.setZero(); }
 

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -6,8 +6,6 @@
 #include <tinyformat.h>
 #include <tinylogger/tinylogger.h>
 
-#include <Eigen/Dense>
-
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -59,6 +57,9 @@
 struct NVGcontext;
 
 TEV_NAMESPACE_BEGIN
+
+class ThreadPool;
+extern ThreadPool* gThreadPool;
 
 inline uint32_t swapBytes(uint32_t value) {
 #ifdef _WIN32

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -9,6 +9,8 @@
 
 #include <nanogui/texture.h>
 
+#include <Eigen/Dense>
+
 #include <atomic>
 #include <istream>
 #include <map>
@@ -149,6 +151,8 @@ public:
 
 private:
     // A single worker is enough, since parallelization will happen _within_ each image load.
+    // We want to focus all resources to load images in order as fast as possible, rather than
+    // our of order.
     ThreadPool mWorkers{1};
     SharedQueue<ImageAddition> mLoadedImages;
 };

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -176,6 +176,9 @@ private:
     EMetric mMetric = Error;
 
     std::map<std::string, std::shared_ptr<Lazy<std::shared_ptr<CanvasStatistics>>>> mMeanValues;
+    // A custom threadpool is used to ensure progress
+    // on the global threadpool, even when excessively
+    // many mean value computations are scheduled.
     ThreadPool mMeanValueThreadPool;
 };
 

--- a/include/tev/MultiGraph.h
+++ b/include/tev/MultiGraph.h
@@ -9,6 +9,8 @@
 
 #include <nanogui/widget.h>
 
+#include <Eigen/Dense>
+
 TEV_NAMESPACE_BEGIN
 
 class MultiGraph : public nanogui::Widget {

--- a/include/tev/UberShader.h
+++ b/include/tev/UberShader.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
+#include <nanogui/shader.h>
 #include <nanogui/texture.h>
 
-#include <nanogui/shader.h>
+#include <Eigen/Dense>
 
 TEV_NAMESPACE_BEGIN
 

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -6,6 +6,8 @@
 #include <tev/Channel.h>
 #include <tev/Image.h>
 
+#include <Eigen/Dense>
+
 #include <istream>
 #include <string>
 

--- a/include/tev/imageio/ImageSaver.h
+++ b/include/tev/imageio/ImageSaver.h
@@ -5,6 +5,8 @@
 
 #include <tev/Common.h>
 
+#include <Eigen/Dense>
+
 #include <ostream>
 #include <string>
 #include <vector>

--- a/scripts/mac-post-install.cmake
+++ b/scripts/mac-post-install.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.12)
 
 # We want to explicitly symlink the newly installed app bundle
 # such that the icon and executable match up correctly.

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -2,6 +2,7 @@
 // It is published under the BSD 3-Clause License within the LICENSE file.
 
 #include <tev/Channel.h>
+#include <tev/ThreadPool.h>
 
 #include <numeric>
 
@@ -51,20 +52,20 @@ Color Channel::color(string channel) {
     return Color(1.0f, 1.0f);
 }
 
-void Channel::divideByAsync(const Channel& other, ThreadPool& pool) {
-    pool.parallelForNoWait<DenseIndex>(0, other.count(), [&](DenseIndex i) {
+void Channel::divideByAsync(const Channel& other, vector<future<void>>& futures) {
+    gThreadPool->parallelForAsync<DenseIndex>(0, other.count(), [&](DenseIndex i) {
         if (other.at(i) != 0) {
             at(i) /= other.at(i);
         } else {
             at(i) = 0;
         }
-    });
+    }, futures);
 }
 
-void Channel::multiplyWithAsync(const Channel& other, ThreadPool& pool) {
-    pool.parallelForNoWait<DenseIndex>(0, other.count(), [&](DenseIndex i) {
+void Channel::multiplyWithAsync(const Channel& other, vector<future<void>>& futures) {
+    gThreadPool->parallelForAsync<DenseIndex>(0, other.count(), [&](DenseIndex i) {
         at(i) *= other.at(i);
-    });
+    }, futures);
 }
 
 void Channel::updateTile(int x, int y, int width, int height, const vector<float>& newData) {

--- a/src/Ipc.cpp
+++ b/src/Ipc.cpp
@@ -249,8 +249,7 @@ IpcPacketUpdateImage IpcPacket::interpretAsUpdateImage() const {
     vector<float> stridedImageData(stridedImageDataSize);
     payload >> stridedImageData;
 
-    ThreadPool threadPool;
-    threadPool.parallelFor<DenseIndex>(0, nPixels, [&](DenseIndex px) {
+    gThreadPool->parallelFor<DenseIndex>(0, nPixels, [&](DenseIndex px) {
         for (int32_t c = 0; c < result.nChannels; ++c) {
             result.imageData[c][px] = stridedImageData[result.channelOffsets[c] + px * result.channelStrides[c]];
         }

--- a/src/imageio/ClipboardImageLoader.cpp
+++ b/src/imageio/ClipboardImageLoader.cpp
@@ -25,7 +25,6 @@ bool ClipboardImageLoader::canLoadFile(istream& iStream) const {
 
 ImageData ClipboardImageLoader::load(istream& iStream, const path&, const string& channelSelector, bool& hasPremultipliedAlpha) const {
     ImageData result;
-    ThreadPool threadPool;
 
     char magic[4];
     clip::image_spec spec;
@@ -84,7 +83,7 @@ ImageData ClipboardImageLoader::load(istream& iStream, const path&, const string
     //       clip doesn't properly handle this... so copy&pasting transparent images
     //       from browsers tends to produce incorrect color values in alpha!=1/0 regions.
     bool premultipliedAlpha = false && numChannels >= 4;
-    threadPool.parallelFor<DenseIndex>(0, size.y(), [&](DenseIndex y) {
+    gThreadPool->parallelFor<DenseIndex>(0, size.y(), [&](DenseIndex y) {
         for (int x = 0; x < size.x(); ++x) {
             int baseIdx = y * numBytesPerRow + x * numChannels;
             for (int c = numChannels-1; c >= 0; --c) {

--- a/src/imageio/DdsImageLoader.cpp
+++ b/src/imageio/DdsImageLoader.cpp
@@ -161,7 +161,6 @@ ImageData DdsImageLoader::load(istream& iStream, const path&, const string& chan
     ScopeGuard comScopeGuard{ []() { CoUninitialize(); } };
 
     ImageData result;
-    ThreadPool threadPool;
     iStream.seekg(0, iStream.end);
     size_t dataSize = iStream.tellg();
     iStream.seekg(0, iStream.beg);
@@ -222,7 +221,7 @@ ImageData DdsImageLoader::load(istream& iStream, const path&, const string& chan
         assert(!DirectX::IsSRGB(metadata.format));
         // Assume that the image data is already in linear space.
         auto typedData = reinterpret_cast<float*>(scratchImage.GetPixels());
-        threadPool.parallelFor<DenseIndex>(0, numPixels, [&](DenseIndex i) {
+        gThreadPool->parallelFor<DenseIndex>(0, numPixels, [&](DenseIndex i) {
             size_t baseIdx = i * numChannels;
             for (int c = 0; c < numChannels; ++c) {
                 channels[c].at(i) = typedData[baseIdx + c];
@@ -234,7 +233,7 @@ ImageData DdsImageLoader::load(istream& iStream, const path&, const string& chan
         // RGB(A) DDS images tend to be in sRGB space, even those not
         // explicitly stored in an *_SRGB format.
         auto typedData = reinterpret_cast<float*>(scratchImage.GetPixels());
-        threadPool.parallelFor<DenseIndex>(0, numPixels, [&](DenseIndex i) {
+        gThreadPool->parallelFor<DenseIndex>(0, numPixels, [&](DenseIndex i) {
             int baseIdx = i * numChannels;
             for (int c = 0; c < numChannels; ++c) {
                 if (c == 3) {

--- a/src/imageio/EmptyImageLoader.cpp
+++ b/src/imageio/EmptyImageLoader.cpp
@@ -2,7 +2,6 @@
 // It is published under the BSD 3-Clause License within the LICENSE file.
 
 #include <tev/imageio/EmptyImageLoader.h>
-#include <tev/ThreadPool.h>
 
 #include <istream>
 

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -23,7 +23,6 @@ bool PfmImageLoader::canLoadFile(istream& iStream) const {
 
 ImageData PfmImageLoader::load(istream& iStream, const path&, const string& channelSelector, bool& hasPremultipliedAlpha) const {
     ImageData result;
-    ThreadPool threadPool;
 
     string magic;
     Vector2i size;
@@ -73,7 +72,7 @@ ImageData PfmImageLoader::load(istream& iStream, const path&, const string& chan
     // Reverse bytes of every float if endianness does not match up with system
     const bool shallSwapBytes = isSystemLittleEndian() != isPfmLittleEndian;
 
-    threadPool.parallelFor<DenseIndex>(0, size.y(), [&](DenseIndex y) {
+    gThreadPool->parallelFor<DenseIndex>(0, size.y(), [&](DenseIndex y) {
         for (int x = 0; x < size.x(); ++x) {
             int baseIdx = (y * size.x() + x) * numChannels;
             for (int c = 0; c < numChannels; ++c) {

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -20,7 +20,6 @@ bool StbiImageLoader::canLoadFile(istream&) const {
 
 ImageData StbiImageLoader::load(istream& iStream, const path&, const string& channelSelector, bool& hasPremultipliedAlpha) const {
     ImageData result;
-    ThreadPool threadPool;
 
     static const stbi_io_callbacks callbacks = {
         // Read
@@ -68,7 +67,7 @@ ImageData StbiImageLoader::load(istream& iStream, const path&, const string& cha
     auto numPixels = (DenseIndex)size.x() * size.y();
     if (isHdr) {
         auto typedData = reinterpret_cast<float*>(data);
-        threadPool.parallelFor<DenseIndex>(0, numPixels, [&](DenseIndex i) {
+        gThreadPool->parallelFor<DenseIndex>(0, numPixels, [&](DenseIndex i) {
             int baseIdx = i * numChannels;
             for (int c = 0; c < numChannels; ++c) {
                 channels[c].at(i) = typedData[baseIdx + c];
@@ -76,7 +75,7 @@ ImageData StbiImageLoader::load(istream& iStream, const path&, const string& cha
         });
     } else {
         auto typedData = reinterpret_cast<unsigned char*>(data);
-        threadPool.parallelFor<DenseIndex>(0, numPixels, [&](DenseIndex i) {
+        gThreadPool->parallelFor<DenseIndex>(0, numPixels, [&](DenseIndex i) {
             int baseIdx = i * numChannels;
             for (int c = 0; c < numChannels; ++c) {
                 if (c == alphaChannelIndex) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,8 @@ using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
+ThreadPool* gThreadPool = new ThreadPool{};
+
 // Image viewer is a static variable to allow other
 // parts of the program to easily schedule operations
 // onto the main nanogui thread loop.
@@ -36,7 +38,7 @@ TEV_NAMESPACE_BEGIN
 // Currently, the only use case is the destruction of
 // OpenGL textures, which _must_ happen on the thread
 // on which the GL context is "current".
-ImageViewer* sImageViewer = nullptr;
+static ImageViewer* sImageViewer = nullptr;
 
 void scheduleToMainThread(const std::function<void()>& fun) {
     if (sImageViewer) {

--- a/src/python/ipc-example.py
+++ b/src/python/ipc-example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# This file was developed by Thomáš Iser & Thomas Müller <thomas94@gmx.net>.
+# This file was developed by Tomáš Iser & Thomas Müller <thomas94@gmx.net>.
 # It is published under the BSD 3-Clause License within the LICENSE file.
 
 """

--- a/src/python/ipc-example.py
+++ b/src/python/ipc-example.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# This file was developed by Thomáš Iser & Thomas Müller <thomas94@gmx.net>.
+# It is published under the BSD 3-Clause License within the LICENSE file.
+
+"""
+Example usage of tev's Python IPC implementation.
+"""
+
+from ipc import TevIpc
+import numpy as np
+
+if __name__ == "__main__":
+    with TevIpc() as tev:
+        image_data = np.full((100,100,3), 1.0)
+        image_data[40:61,:,0] = 0.0
+        image_data[:,40:61,1] = 0.0
+        image_data[50:71,50:71,2] = 0.0
+
+        bonus_data = image_data[:,:,0] + image_data[:,:,1] + image_data[:,:,2]
+
+        tev.create_image("Test Image", width=100, height=100, channel_names=["R","G","B","Bonus"])
+        tev.update_image("Test Image", image_data, ["R", "G", "B"])
+        tev.update_image("Test Image", bonus_data, ["Bonus"])

--- a/src/python/ipc-example.py
+++ b/src/python/ipc-example.py
@@ -12,13 +12,13 @@ import numpy as np
 
 if __name__ == "__main__":
     with TevIpc() as tev:
-        image_data = np.full((100,100,3), 1.0)
+        image_data = np.full((300,200,3), 1.0)
         image_data[40:61,:,0] = 0.0
         image_data[:,40:61,1] = 0.0
         image_data[50:71,50:71,2] = 0.0
 
         bonus_data = image_data[:,:,0] + image_data[:,:,1] + image_data[:,:,2]
 
-        tev.create_image("Test Image", width=100, height=100, channel_names=["R","G","B","Bonus"])
+        tev.create_image("Test Image", width=200, height=300, channel_names=["R","G","B","Bonus"])
         tev.update_image("Test Image", image_data, ["R", "G", "B"])
         tev.update_image("Test Image", bonus_data, ["Bonus"])

--- a/src/python/ipc.py
+++ b/src/python/ipc.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+# This file was developed by Thomáš Iser & Thomas Müller <thomas94@gmx.net>.
+# It is published under the BSD 3-Clause License within the LICENSE file.
+
+"""
+Interfaces with tev's IPC protocol to remote control tev with Python.
+"""
+
+import socket
+import struct
+import numpy as np
+
+class TevIpc:
+    def __init__(self, hostname = "localhost", port = 14158):
+        self._hostname = hostname
+        self._port = port
+        self._socket = None
+
+    def __enter__(self):
+        if self._socket is not None:
+            raise Exception("Communication already started")
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM) # SOCK_STREAM means a TCP socket
+        self._socket.__enter__()
+        self._socket.connect((self._hostname, self._port))
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._socket is None:
+            raise Exception("Communication was not started")
+        self._socket.__exit__(exc_type, exc_val, exc_tb)
+
+    def open_image(self, path: str, channel_selector: str = "", grab_focus = True):
+        if self._socket is None:
+            raise Exception("Communication was not started")
+
+        data_bytes = bytearray()
+        data_bytes.extend(struct.pack("<I", 0)) # reserved for length
+        data_bytes.extend(struct.pack("<b", 7)) # open image (v2)
+        data_bytes.extend(struct.pack("<b", grab_focus)) # grab focus
+        data_bytes.extend(bytes(path, "UTF-8")) # image path
+        data_bytes.extend(struct.pack("<b", 0)) # string terminator
+        data_bytes.extend(bytes(channel_selector, "UTF-8")) # channels to load
+        data_bytes.extend(struct.pack("<b", 0)) # string terminator
+        data_bytes[0:4] = struct.pack("<I", len(data_bytes))
+
+        self._socket.sendall(data_bytes)
+
+    def reload_image(self, name: str, grab_focus = True):
+        if self._socket is None:
+            raise Exception("Communication was not started")
+
+        data_bytes = bytearray()
+        data_bytes.extend(struct.pack("<I", 0)) # reserved for length
+        data_bytes.extend(struct.pack("<b", 1)) # reload image
+        data_bytes.extend(struct.pack("<b", grab_focus)) # grab focus
+        data_bytes.extend(bytes(name, "UTF-8")) # image path
+        data_bytes.extend(struct.pack("<b", 0)) # string terminator
+        data_bytes[0:4] = struct.pack("<I", len(data_bytes))
+
+        self._socket.sendall(data_bytes)
+
+    def close_image(self, name: str):
+        if self._socket is None:
+            raise Exception("Communication was not started")
+
+        data_bytes = bytearray()
+        data_bytes.extend(struct.pack("<I", 0)) # reserved for length
+        data_bytes.extend(struct.pack("<b", 2)) # close image
+        data_bytes.extend(bytes(name, "UTF-8")) # image name
+        data_bytes.extend(struct.pack("<b", 0)) # string terminator
+        data_bytes[0:4] = struct.pack("<I", len(data_bytes))
+
+        self._socket.sendall(data_bytes)
+
+    def create_image(self, name: str, width: int, height: int, channel_names, grab_focus = True):
+        if self._socket is None:
+            raise Exception("Communication was not started")
+
+        data_bytes = bytearray()
+        data_bytes.extend(struct.pack("<I", 0)) # reserved for length
+        data_bytes.extend(struct.pack("<b", 4)) # create image
+        data_bytes.extend(struct.pack("<b", grab_focus)) # grab focus
+        data_bytes.extend(bytes(name, "UTF-8")) # image name
+        data_bytes.extend(struct.pack("<b", 0)) # string terminator
+        data_bytes.extend(struct.pack("<i", width)) # width
+        data_bytes.extend(struct.pack("<i", height)) # height
+        data_bytes.extend(struct.pack("<i", len(channel_names))) # number of channels
+        for cname in channel_names:
+            data_bytes.extend(bytes(cname, "ascii")) # channel name
+            data_bytes.extend(struct.pack("<b", 0)) # string terminator
+        data_bytes[0:4] = struct.pack("<I", len(data_bytes))
+
+        self._socket.sendall(data_bytes)
+
+    def update_image(self, name: str, image, channel_names = ["R", "G", "B", "A"], x = 0, y = 0, grab_focus = False, perform_tiling = True):
+        if self._socket is None:
+            raise Exception("Communication was not started")
+
+        # Break down image into tiles of manageable size for typical TCP packets
+        tile_size = [128, 128] if perform_tiling else image.shape[0:2]
+
+        n_channels = 1 if len(image.shape) < 3 else image.shape[2]
+
+        channel_offsets = [i for i in range(n_channels)]
+        channel_strides = [n_channels for _ in range(n_channels)]
+
+        if len(channel_names) < n_channels:
+            raise Exception("Not enough channel names provided")
+
+        for i in range(0, image.shape[0], tile_size[0]):
+            for j in range(0, image.shape[1], tile_size[1]):
+                tile = image[
+                    i:(min(i+tile_size[0], image.shape[0])),
+                    j:(min(j+tile_size[j], image.shape[1])),
+                    ...
+                ]
+
+                tile_dense = np.full_like(tile, 0.0, dtype="<f")
+                tile_dense[...] = tile[...]
+
+                data_bytes = bytearray()
+                data_bytes.extend(struct.pack("<I", 0)) # reserved for length
+                data_bytes.extend(struct.pack("<b", 6)) # update image (v3)
+                data_bytes.extend(struct.pack("<b", grab_focus)) # grab focus
+                data_bytes.extend(bytes(name, "UTF-8")) # image name
+                data_bytes.extend(struct.pack("<b", 0)) # string terminator
+                data_bytes.extend(struct.pack("<i", n_channels)) # number of channels
+
+                for channel_name in channel_names[0:n_channels]:
+                    data_bytes.extend(bytes(channel_name, "UTF-8")) # channel name
+                    data_bytes.extend(struct.pack("<b", 0)) # string terminator
+                
+                data_bytes.extend(struct.pack("<i", x+j)) # x
+                data_bytes.extend(struct.pack("<i", y+i)) # y
+                data_bytes.extend(struct.pack("<i", tile_dense.shape[1])) # width
+                data_bytes.extend(struct.pack("<i", tile_dense.shape[0])) # height
+
+                for channel_offset in channel_offsets:
+                    data_bytes.extend(struct.pack("<q", channel_offset)) # channel_offset
+                for channel_stride in channel_strides:
+                    data_bytes.extend(struct.pack("<q", channel_stride)) # channel_stride
+
+                data_bytes.extend(tile_dense.tobytes()) # data
+                data_bytes[0:4] = struct.pack("<I", len(data_bytes))
+
+                self._socket.sendall(data_bytes)

--- a/src/python/ipc.py
+++ b/src/python/ipc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# This file was developed by Thomáš Iser & Thomas Müller <thomas94@gmx.net>.
+# This file was developed by Tomáš Iser & Thomas Müller <thomas94@gmx.net>.
 # It is published under the BSD 3-Clause License within the LICENSE file.
 
 """

--- a/src/python/ipc.py
+++ b/src/python/ipc.py
@@ -30,6 +30,9 @@ class TevIpc:
             raise Exception("Communication was not started")
         self._socket.__exit__(exc_type, exc_val, exc_tb)
 
+    """
+        Opens an image from a specified path from the disk of the machine tev is running on.
+    """
     def open_image(self, path: str, channel_selector: str = "", grab_focus = True):
         if self._socket is None:
             raise Exception("Communication was not started")
@@ -46,6 +49,9 @@ class TevIpc:
 
         self._socket.sendall(data_bytes)
 
+    """
+        Reloads the image with specified path from the disk of the machine tev is running on.
+    """
     def reload_image(self, name: str, grab_focus = True):
         if self._socket is None:
             raise Exception("Communication was not started")
@@ -60,6 +66,9 @@ class TevIpc:
 
         self._socket.sendall(data_bytes)
 
+    """
+        Closes a specified image.
+    """
     def close_image(self, name: str):
         if self._socket is None:
             raise Exception("Communication was not started")
@@ -73,7 +82,11 @@ class TevIpc:
 
         self._socket.sendall(data_bytes)
 
-    def create_image(self, name: str, width: int, height: int, channel_names, grab_focus = True):
+    """
+        Create a blank image with a specified size and a specified set of channel names.
+        "R", "G", "B" [, "A"] is what should be used if an image is rendered.
+    """
+    def create_image(self, name: str, width: int, height: int, channel_names  = ["R", "G", "B", "A"], grab_focus = True):
         if self._socket is None:
             raise Exception("Communication was not started")
 
@@ -93,6 +106,11 @@ class TevIpc:
 
         self._socket.sendall(data_bytes)
 
+    """
+        Updates the pixel values of a specified image region and a specified set of channels.
+        The `image` parameter must be laid out in row-major format, i.e. from most to least
+        significant: [col][row][channel], where the channel axis is optional.
+    """
     def update_image(self, name: str, image, channel_names = ["R", "G", "B", "A"], x = 0, y = 0, grab_focus = False, perform_tiling = True):
         if self._socket is None:
             raise Exception("Communication was not started")
@@ -112,7 +130,7 @@ class TevIpc:
             for j in range(0, image.shape[1], tile_size[1]):
                 tile = image[
                     i:(min(i+tile_size[0], image.shape[0])),
-                    j:(min(j+tile_size[j], image.shape[1])),
+                    j:(min(j+tile_size[1], image.shape[1])),
                     ...
                 ]
 


### PR DESCRIPTION
- Adds an extended version of [Thomas Iser's Python IPC implementation](https://gist.github.com/tomasiser/5e3bacd72df30f7efc3037cb95a039d3)
- Fixes #116 by adding information about IPC to the readme (with a link to [Karel Peeters' Rust implementation](https://crates.io/crates/tev_client))
- Fixes #120 by using a global threadpool in most places rather than local threadpools