### PR TITLE
Added link flag for Clang libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,49 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "
     endif()
 endif()
 
+
+# ---------------------------------------------------------------------------
+# Prefer libc++ in conjunction with Clang
+# ---------------------------------------------------------------------------
+
+include(CheckCXXSourceRuns)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+macro(CHECK_CXX_COMPILER_AND_LINKER_FLAGS _RESULT _CXX_FLAGS _LINKER_FLAGS)
+  set(CMAKE_REQUIRED_FLAGS ${_CXX_FLAGS})
+  set(CMAKE_REQUIRED_LIBRARIES ${_LINKER_FLAGS})
+  set(CMAKE_REQUIRED_QUIET TRUE)
+  check_cxx_source_runs("#include <iostream>\nint main(int argc, char **argv) { std::cout << \"test\"; return 0; }"
+                        ${_RESULT})
+  set(CMAKE_REQUIRED_FLAGS "")
+  set(CMAKE_REQUIRED_LIBRARIES "")
+endmacro()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
+  CHECK_CXX_COMPILER_AND_LINKER_FLAGS(HAS_LIBCPP "-stdlib=libc++" "-stdlib=libc++")
+  if (APPLE OR HAS_LIBCPP)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -D_LIBCPP_VERSION")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
+    message(STATUS "TEV: using libc++.")
+  else()
+    CHECK_CXX_COMPILER_AND_LINKER_FLAGS(HAS_LIBCPP_AND_CPPABI "-stdlib=libc++" "-stdlib=libc++ -lc++abi")
+    if (HAS_LIBCPP_AND_CPPABI)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -D_LIBCPP_VERSION")
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
+      message(STATUS "TEV: using libc++ and libc++abi.")
+    else()
+      message(FATAL_ERROR "When Clang is used to compile TEV, libc++ "
+          "must be available -- GCC's libstdc++ is not supported! (please install "
+          "the libc++ development headers, provided e.g. by the packages "
+          "'libc++-dev' and 'libc++abi-dev' on Debian/Ubuntu).")
+    endif()
+  endif()
+endif()
+
+
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/dependencies)
 
 add_compile_options(${NANOGUI_NATIVE_FLAGS})


### PR DESCRIPTION
Hi :wave: ,

While compiling using `Clang` it is needed to link to `libc++` (the same happens with the `nanogui` dependency). 
The following small addition just check if is the case and set the flags accordingly (code is from @wjakob).

I would like to take this opportunity to thank you for this very useful piece of software!