### PR TITLE
Fix relative path resolution in background loader

### DIFF
--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -146,7 +146,7 @@ struct ImageAddition {
 
 class BackgroundImagesLoader {
 public:
-    void enqueue(const filesystem::path& path, const std::string& channelSelector, bool shallSelect);
+    void enqueue(filesystem::path path, const std::string& channelSelector, bool shallSelect);
     ImageAddition tryPop() { return mLoadedImages.tryPop(); }
 
 private:


### PR DESCRIPTION
Hi @Tom94,

The worker thread / process used by `BackgroundImagesLoader` does not seem to use the main thread's current working directory.
This leads to relative path resolution when image loading is scheduled by `BackgroundImagesLoader::enqueue()`.

I ran into this issue when using e.g.:

```
tev -n ./image*.exr
```

There's now a bit of code duplication between `tryLoadImage(path, channelSelector)` and `BackgroundImagesLoader::enqueue` (path resolution is done twice). 
Let me know if you'd prefer to avoid it, e.g. by finding a way to set the `cwd` of the worker thread instead (sounds a bit more complicated).