### PR TITLE
Convert EXR chromaticities to sRGB/Rec709 upon load

### DIFF
--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -25,6 +25,7 @@ class ImageLoader;
 struct ImageData {
     std::vector<Channel> channels;
     std::vector<std::string> layers;
+    nanogui::Matrix4f toRec709 = nanogui::Matrix4f{1.0f}; // Identity by default
 };
 
 struct ChannelGroup {
@@ -114,6 +115,8 @@ private:
 
     std::vector<std::string> channelsInLayer(std::string layerName) const;
     std::vector<ChannelGroup> getGroupedChannels(const std::string& layerName) const;
+
+    void toRec709();
 
     void alphaOperation(const std::function<void(Channel&, const Channel&)>& func);
 


### PR DESCRIPTION
Adds #139 

Channel groups that contain triplets of "R","G","B" and "r","g","b" are affected.

All other channels (including names such as XYZ) are left as-is under the assumption that the specific values that were stored are to be visualized by tev.

Thanks to @wjakob for helpfully providing a skeleton for the conversion