### PR TITLE
Multipart EXR

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -224,12 +224,6 @@ private:
 };
 
 template <typename T>
-T clamp(T value, T min, T max) {
-    TEV_ASSERT(max >= min, "Minimum (%f) may not be larger than maximum (%f).", min, max);
-    return std::max(std::min(value, max), min);
-}
-
-template <typename T>
 T round(T value, T decimals) {
     auto precision = std::pow(static_cast<T>(10), decimals);
     return std::round(value * precision) / precision;

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -65,12 +65,7 @@ struct ImageData {
     }
 
     const Channel* channel(const std::string& channelName) const {
-        auto it = std::find_if(
-            std::begin(channels),
-            std::end(channels),
-            [&channelName](const Channel& c) { return c.name() == channelName; }
-        );
-
+        auto it = std::ranges::find_if(channels, [&channelName](const Channel& c) { return c.name() == channelName; });
         if (it != std::end(channels)) {
             return &(*it);
         } else {
@@ -79,12 +74,7 @@ struct ImageData {
     }
 
     Channel* mutableChannel(const std::string& channelName) {
-        auto it = std::find_if(
-            std::begin(channels),
-            std::end(channels),
-            [&channelName](const Channel& c) { return c.name() == channelName; }
-        );
-
+        auto it = std::ranges::find_if(channels, [&channelName](const Channel& c) { return c.name() == channelName; });
         if (it != std::end(channels)) {
             return &(*it);
         } else {

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -23,6 +23,10 @@ TEV_NAMESPACE_BEGIN
 class ImageLoader;
 
 struct ImageData {
+    ImageData() = default;
+    ImageData(const ImageData&) = delete;
+    ImageData(ImageData&&) = default;
+
     std::vector<Channel> channels;
     std::vector<std::string> layers;
     nanogui::Matrix4f toRec709 = nanogui::Matrix4f{1.0f}; // Identity by default
@@ -100,7 +104,7 @@ struct ImageTexture {
 
 class Image {
 public:
-    Image(int id, const filesystem::path& path, ImageData&& data, const std::string& channelSelector);
+    Image(const filesystem::path& path, ImageData&& data, const std::string& channelSelector);
     virtual ~Image();
 
     const filesystem::path& path() const {
@@ -194,15 +198,15 @@ private:
     int mId;
 };
 
-Task<std::shared_ptr<Image>> tryLoadImage(int imageId, filesystem::path path, std::istream& iStream, std::string channelSelector);
-Task<std::shared_ptr<Image>> tryLoadImage(filesystem::path path, std::istream& iStream, std::string channelSelector);
-Task<std::shared_ptr<Image>> tryLoadImage(int imageId, filesystem::path path, std::string channelSelector);
-Task<std::shared_ptr<Image>> tryLoadImage(filesystem::path path, std::string channelSelector);
+Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(int imageId, filesystem::path path, std::istream& iStream, std::string channelSelector);
+Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(filesystem::path path, std::istream& iStream, std::string channelSelector);
+Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(int imageId, filesystem::path path, std::string channelSelector);
+Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(filesystem::path path, std::string channelSelector);
 
 struct ImageAddition {
     int loadId;
     bool shallSelect;
-    std::shared_ptr<Image> image;
+    std::vector<std::shared_ptr<Image>> images;
 
     struct Comparator {
         bool operator()(const ImageAddition& a, const ImageAddition& b) {

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -35,6 +35,8 @@ struct ImageData {
     Box2i dataWindow;
     Box2i displayWindow;
 
+    std::string partName;
+
     nanogui::Vector2i size() const {
         return dataWindow.size();
     }

--- a/include/tev/SharedQueue.h
+++ b/include/tev/SharedQueue.h
@@ -15,23 +15,23 @@ template <typename T>
 class SharedQueue {
 public:
     bool empty() const {
-        std::lock_guard<std::mutex> lock{mMutex};
+        std::lock_guard lock{mMutex};
         return mRawQueue.empty();
     }
 
     size_t size() const {
-        std::lock_guard<std::mutex> lock{mMutex};
+        std::lock_guard lock{mMutex};
         return mRawQueue.size();
     }
 
     void push(T newElem) {
-        std::lock_guard<std::mutex> lock{mMutex};
+        std::lock_guard lock{mMutex};
         mRawQueue.push_back(newElem);
         mDataCondition.notify_one();
     }
 
     T waitAndPop() {
-        std::unique_lock<std::mutex> lock{mMutex};
+        std::unique_lock lock{mMutex};
 
         while (mRawQueue.empty()) {
             mDataCondition.wait(lock);
@@ -44,7 +44,7 @@ public:
     }
 
     std::optional<T> tryPop() {
-        std::unique_lock<std::mutex> lock{mMutex};
+        std::unique_lock lock{mMutex};
 
         if (mRawQueue.empty()) {
             return {};

--- a/include/tev/imageio/ClipboardImageLoader.h
+++ b/include/tev/imageio/ClipboardImageLoader.h
@@ -13,7 +13,7 @@ TEV_NAMESPACE_BEGIN
 class ClipboardImageLoader : public ImageLoader {
 public:
     bool canLoadFile(std::istream& iStream) const override;
-    Task<ImageData> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
+    Task<std::vector<ImageData>> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
 
     std::string name() const override {
         return "clipboard";

--- a/include/tev/imageio/DdsImageLoader.h
+++ b/include/tev/imageio/DdsImageLoader.h
@@ -13,7 +13,7 @@ TEV_NAMESPACE_BEGIN
 class DdsImageLoader : public ImageLoader {
 public:
     bool canLoadFile(std::istream& iStream) const override;
-    Task<ImageData> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
+    Task<std::vector<ImageData>> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
 
     std::string name() const override {
         return "DDS";

--- a/include/tev/imageio/EmptyImageLoader.h
+++ b/include/tev/imageio/EmptyImageLoader.h
@@ -13,7 +13,7 @@ TEV_NAMESPACE_BEGIN
 class EmptyImageLoader : public ImageLoader {
 public:
     bool canLoadFile(std::istream& iStream) const override;
-    Task<ImageData> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
+    Task<std::vector<ImageData>> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
 
     std::string name() const override {
         return "IPC";

--- a/include/tev/imageio/ExrImageLoader.h
+++ b/include/tev/imageio/ExrImageLoader.h
@@ -13,7 +13,7 @@ TEV_NAMESPACE_BEGIN
 class ExrImageLoader : public ImageLoader {
 public:
     bool canLoadFile(std::istream& iStream) const override;
-    Task<ImageData> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
+    Task<std::vector<ImageData>> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
 
     std::string name() const override {
         return "OpenEXR";

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -22,7 +22,7 @@ public:
     virtual bool canLoadFile(std::istream& iStream) const = 0;
 
     // Return loaded image data as well as whether that data has the alpha channel pre-multiplied or not.
-    virtual Task<ImageData> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const = 0;
+    virtual Task<std::vector<ImageData>> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const = 0;
 
     virtual std::string name() const = 0;
 

--- a/include/tev/imageio/PfmImageLoader.h
+++ b/include/tev/imageio/PfmImageLoader.h
@@ -13,7 +13,7 @@ TEV_NAMESPACE_BEGIN
 class PfmImageLoader : public ImageLoader {
 public:
     bool canLoadFile(std::istream& iStream) const override;
-    Task<ImageData> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
+    Task<std::vector<ImageData>> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
 
     std::string name() const override {
         return "PFM";

--- a/include/tev/imageio/StbiImageLoader.h
+++ b/include/tev/imageio/StbiImageLoader.h
@@ -13,7 +13,7 @@ TEV_NAMESPACE_BEGIN
 class StbiImageLoader : public ImageLoader {
 public:
     bool canLoadFile(std::istream& iStream) const override;
-    Task<ImageData> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
+    Task<std::vector<ImageData>> load(std::istream& iStream, const filesystem::path& path, const std::string& channelSelector, int priority) const override;
 
     std::string name() const override {
         return "STBI";

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -62,12 +62,12 @@ vector<string> split(string text, const string& delim) {
 }
 
 string toLower(string str) {
-    transform(begin(str), end(str), begin(str), [](unsigned char c) { return (char)tolower(c); });
+    ranges::transform(str, begin(str), [](unsigned char c) { return (char)tolower(c); });
     return str;
 }
 
 string toUpper(string str) {
-    transform(begin(str), end(str), begin(str), [](unsigned char c) { return (char)toupper(c); });
+    ranges::transform(str, begin(str), [](unsigned char c) { return (char)toupper(c); });
     return str;
 }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -325,7 +325,7 @@ vector<ChannelGroup> Image::getGroupedChannels(const string& layerName) const {
         auto channelTails = channels;
         // Remove duplicates
         channelTails.erase(unique(begin(channelTails), end(channelTails)), end(channelTails));
-        transform(begin(channelTails), end(channelTails), begin(channelTails), Channel::tail);
+        ranges::transform(channelTails, begin(channelTails), Channel::tail);
         string channelsString = join(channelTails, ",");
 
         string name;
@@ -345,7 +345,7 @@ vector<ChannelGroup> Image::getGroupedChannels(const string& layerName) const {
 
     vector<string> allChannels = mData.channelsInLayer(layerName);
 
-    auto alphaIt = find(begin(allChannels), end(allChannels), alphaChannelName);
+    auto alphaIt = ranges::find(allChannels, alphaChannelName);
     bool hasAlpha = alphaIt != end(allChannels);
     if (hasAlpha) {
         allChannels.erase(alphaIt);
@@ -357,7 +357,7 @@ vector<ChannelGroup> Image::getGroupedChannels(const string& layerName) const {
         vector<string> groupChannels;
         for (const string& channel : group) {
             string name = layerPrefix + channel;
-            auto it = find(begin(allChannels), end(allChannels), name);
+            auto it = ranges::find(allChannels, name);
             if (it != end(allChannels)) {
                 groupChannels.emplace_back(name);
                 allChannels.erase(it);
@@ -436,7 +436,7 @@ void Image::updateChannel(const string& channelName, int x, int y, int width, in
     // Update textures that are cached for this channel
     for (auto& kv : mTextures) {
         auto& imageTexture = kv.second;
-        if (find(begin(imageTexture.channels), end(imageTexture.channels), channelName) == end(imageTexture.channels)) {
+        if (ranges::find(imageTexture.channels, channelName) == end(imageTexture.channels)) {
             continue;
         }
 
@@ -481,9 +481,9 @@ string Image::toString() const {
     sstream << "\nChannels:\n";
 
     auto localLayers = mData.layers;
-    transform(begin(localLayers), end(localLayers), begin(localLayers), [this](string layer) {
+    ranges::transform(localLayers, begin(localLayers), [this](string layer) {
         auto channels = mData.channelsInLayer(layer);
-        transform(begin(channels), end(channels), begin(channels), [](string channel) {
+        ranges::transform(channels, begin(channels), [](string channel) {
             return Channel::tail(channel);
         });
         if (layer.empty()) {
@@ -539,7 +539,7 @@ Task<vector<shared_ptr<Image>>> tryLoadImage(int taskPriority, path path, istrea
                         auto selectorParts = split(channelSelector, ",");
                         if (channelSelector.empty()) {
                             localChannelSelector = i.partName;
-                        } else if (find(begin(selectorParts), end(selectorParts), i.partName) == end(selectorParts)) {
+                        } else if (ranges::find(selectorParts, i.partName) == end(selectorParts)) {
                             localChannelSelector = join(vector<string>{i.partName, channelSelector}, ",");
                         }
                     }

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -587,7 +587,7 @@ Task<vector<shared_ptr<Image>>> tryLoadImage(int taskPriority, path path, string
 }
 
 Task<vector<shared_ptr<Image>>> tryLoadImage(path path, string channelSelector) {
-    co_return co_await tryLoadImage(Image::drawId(), path, channelSelector);
+    co_return co_await tryLoadImage(-Image::drawId(), path, channelSelector);
 }
 
 void BackgroundImagesLoader::enqueue(const path& path, const string& channelSelector, bool shallSelect) {

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -1771,7 +1771,7 @@ void ImageViewer::updateTitle() {
         channels.erase(unique(begin(channels), end(channels)), end(channels));
 
         auto channelTails = channels;
-        transform(begin(channelTails), end(channelTails), begin(channelTails), Channel::tail);
+        ranges::transform(channelTails, begin(channelTails), Channel::tail);
 
         caption = mCurrentImage->shortName();
         caption += " – "s + mCurrentGroup;
@@ -1825,12 +1825,12 @@ int ImageViewer::groupId(const string& groupName) const {
 }
 
 int ImageViewer::imageId(const shared_ptr<Image>& image) const {
-    auto pos = static_cast<size_t>(distance(begin(mImages), find(begin(mImages), end(mImages), image)));
+    auto pos = static_cast<size_t>(distance(begin(mImages), ranges::find(mImages, image)));
     return pos >= mImages.size() ? -1 : (int)pos;
 }
 
 int ImageViewer::imageId(const string& imageName) const {
-    auto pos = static_cast<size_t>(distance(begin(mImages), find_if(begin(mImages), end(mImages), [&](const shared_ptr<Image>& image) {
+    auto pos = static_cast<size_t>(distance(begin(mImages), ranges::find_if(mImages, [&](const shared_ptr<Image>& image) {
         return image->name() == imageName;
     })));
     return pos >= mImages.size() ? -1 : (int)pos;

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -30,7 +30,7 @@ void ThreadPool::startThreads(size_t num) {
     for (size_t i = mThreads.size(); i < mNumThreads; ++i) {
         mThreads.emplace_back([this, i] {
             while (true) {
-                unique_lock<mutex> lock{mTaskQueueMutex};
+                unique_lock lock{mTaskQueueMutex};
 
                 // look for a work item
                 while (i < mNumThreads && mTaskQueue.empty()) {
@@ -53,7 +53,7 @@ void ThreadPool::startThreads(size_t num) {
                 mNumTasksInSystem--;
 
                 {
-                    unique_lock<mutex> localLock{mSystemBusyMutex};
+                    unique_lock localLock{mSystemBusyMutex};
 
                     if (mNumTasksInSystem == 0) {
                         mSystemBusyCondition.notify_all();
@@ -68,7 +68,7 @@ void ThreadPool::shutdownThreads(size_t num) {
     auto numToClose = min(num, mNumThreads);
 
     {
-        lock_guard<mutex> lock{mTaskQueueMutex};
+        lock_guard lock{mTaskQueueMutex};
         mNumThreads -= numToClose;
     }
 
@@ -81,7 +81,7 @@ void ThreadPool::shutdownThreads(size_t num) {
 }
 
 void ThreadPool::waitUntilFinished() {
-    unique_lock<mutex> lock{mSystemBusyMutex};
+    unique_lock lock{mSystemBusyMutex};
 
     if (mNumTasksInSystem == 0) {
         return;
@@ -91,7 +91,7 @@ void ThreadPool::waitUntilFinished() {
 }
 
 void ThreadPool::waitUntilFinishedFor(const chrono::microseconds Duration) {
-    unique_lock<mutex> lock{mSystemBusyMutex};
+    unique_lock lock{mSystemBusyMutex};
 
     if (mNumTasksInSystem == 0) {
         return;
@@ -101,7 +101,7 @@ void ThreadPool::waitUntilFinishedFor(const chrono::microseconds Duration) {
 }
 
 void ThreadPool::flushQueue() {
-    lock_guard<mutex> lock{mTaskQueueMutex};
+    lock_guard lock{mTaskQueueMutex};
 
     mNumTasksInSystem -= mTaskQueue.size();
     while (!mTaskQueue.empty()) {

--- a/src/imageio/EmptyImageLoader.cpp
+++ b/src/imageio/EmptyImageLoader.cpp
@@ -22,8 +22,9 @@ bool EmptyImageLoader::canLoadFile(istream& iStream) const {
     return result;
 }
 
-Task<ImageData> EmptyImageLoader::load(istream& iStream, const path&, const string&, int priority) const {
-    ImageData result;
+Task<vector<ImageData>> EmptyImageLoader::load(istream& iStream, const path&, const string&, int priority) const {
+    vector<ImageData> result(1);
+    ImageData& data = result.front();
 
     string magic;
     Vector2i size;
@@ -51,11 +52,11 @@ Task<ImageData> EmptyImageLoader::load(istream& iStream, const path&, const stri
 
         string channelName = channelNameData.data();
 
-        result.channels.emplace_back(Channel{channelName, size});
-        result.channels.back().setZero();
+        data.channels.emplace_back(Channel{channelName, size});
+        data.channels.back().setZero();
     }
 
-    result.hasPremultipliedAlpha = true;
+    data.hasPremultipliedAlpha = true;
 
     co_return result;
 }

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -91,17 +91,16 @@ bool ExrImageLoader::canLoadFile(istream& iStream) const {
 // Helper class for dealing with the raw channels loaded from an exr file.
 class RawChannel {
 public:
-    RawChannel(string name, Imf::Channel imfChannel)
-    : mName(name), mImfChannel(imfChannel) {
-    }
+    RawChannel(size_t partId, string name, string imfName, Imf::Channel imfChannel, const Vector2i& size)
+    : mPartId{partId}, mName{name}, mImfName{imfName}, mImfChannel{imfChannel}, mSize{size} {}
 
-    void resize(size_t size) {
-        mData.resize(size * bytesPerPixel());
+    void resize() {
+        mData.resize((size_t)mSize.x() * mSize.y() * bytesPerPixel());
     }
 
     void registerWith(Imf::FrameBuffer& frameBuffer, const Imath::Box2i& dw) {
         int width = dw.max.x - dw.min.x + 1;
-        frameBuffer.insert(mName.c_str(), Imf::Slice(
+        frameBuffer.insert(mImfName.c_str(), Imf::Slice(
             mImfChannel.type,
             mData.data() - (dw.min.x + dw.min.y * width) * bytesPerPixel(),
             bytesPerPixel(), bytesPerPixel() * (width/mImfChannel.xSampling),
@@ -135,8 +134,16 @@ public:
         }
     }
 
+    size_t partId() const {
+        return mPartId;
+    }
+
     const string& name() const {
         return mName;
+    }
+
+    const Vector2i& size() const {
+        return mSize;
     }
 
 private:
@@ -150,14 +157,16 @@ private:
         }
     }
 
+    size_t mPartId;
     string mName;
+    string mImfName;
     Imf::Channel mImfChannel;
+    Vector2i mSize;
     vector<char> mData;
 };
 
 Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const path& path, const string& channelSelector, int priority) const {
-    vector<ImageData> result(1);
-    ImageData& data = result.front();
+    vector<ImageData> result;
 
     StdIStream stdIStream{iStream, path.str().c_str()};
     Imf::MultiPartInputFile multiPartFile{stdIStream};
@@ -167,130 +176,149 @@ Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const path& path,
         throw invalid_argument{"EXR image does not contain any parts."};
     }
 
-    // Find the first part containing a channel that matches the given channelSubstr.
-    int partIdx = 0;
-    for (int i = 0; i < numParts; ++i) {
-        Imf::InputPart part{multiPartFile, i};
+    vector<Imf::InputPart> parts;
+    vector<Imf::FrameBuffer> frameBuffers;
+
+    vector<RawChannel> rawChannels;
+
+    // Load all parts that match the channel selector
+    for (int partIdx = 0; partIdx < numParts; ++partIdx) {
+        Imf::InputPart part{multiPartFile, partIdx};
 
         const Imf::ChannelList& imfChannels = part.header().channels();
 
+        auto channelName = [&](Imf::ChannelList::ConstIterator c) {
+            string name = c.name();
+            if (part.header().hasName()) {
+                name = part.header().name() + "."s + name;
+            }
+            return name;
+        };
+
+        bool matched = false;
         for (Imf::ChannelList::ConstIterator c = imfChannels.begin(); c != imfChannels.end(); ++c) {
-            if (matchesFuzzy(c.name(), channelSelector)) {
-                partIdx = i;
-                goto l_foundPart;
+            matched |= matchesFuzzy(channelName(c), channelSelector);
+            if (matched) {
+                break;
             }
         }
-    }
-l_foundPart:
 
-    Imf::InputPart file{multiPartFile, partIdx};
-    Imath::Box2i dataWindow = file.header().dataWindow();
-    Imath::Box2i displayWindow = file.header().displayWindow();
-    Vector2i size = {dataWindow.max.x - dataWindow.min.x + 1 , dataWindow.max.y - dataWindow.min.y + 1};
-
-    if (size.x() == 0 || size.y() == 0) {
-        throw invalid_argument{"EXR image has zero pixels."};
-    }
-
-    // EXR's display- and data windows have inclusive upper ends while tev's upper ends are exclusive.
-    // This allows easy conversion from window to size. Hence the +1.
-    data.dataWindow =    {{dataWindow.min.x,    dataWindow.min.y   }, {dataWindow.max.x+1,    dataWindow.max.y+1   }};
-    data.displayWindow = {{displayWindow.min.x, displayWindow.min.y}, {displayWindow.max.x+1, displayWindow.max.y+1}};
-
-    if (!data.dataWindow.isValid()) {
-        throw invalid_argument{tfm::format(
-            "EXR image has invalid data window: [%d,%d] - [%d,%d]",
-            data.dataWindow.min.x(), data.dataWindow.min.y(), data.dataWindow.max.x(), data.dataWindow.max.y()
-        )};
-    }
-
-    if (!data.displayWindow.isValid()) {
-        throw invalid_argument{tfm::format(
-            "EXR image has invalid display window: [%d,%d] - [%d,%d]",
-            data.displayWindow.min.x(), data.displayWindow.min.y(), data.displayWindow.max.x(), data.displayWindow.max.y()
-        )};
-    }
-
-    // Allocate raw channels on the heap, because it'll be references
-    // by nested parallel for coroutine.
-    auto rawChannels = std::make_unique<vector<RawChannel>>();
-    Imf::FrameBuffer frameBuffer;
-
-    const Imf::ChannelList& imfChannels = file.header().channels();
-
-    using match_t = pair<size_t, Imf::ChannelList::ConstIterator>;
-    vector<match_t> matches;
-    for (Imf::ChannelList::ConstIterator c = imfChannels.begin(); c != imfChannels.end(); ++c) {
-        size_t matchId;
-        if (matchesFuzzy(c.name(), channelSelector, &matchId)) {
-            matches.emplace_back(matchId, c);
+        if (!matched) {
+            continue;
         }
+
+        Imath::Box2i dataWindow = part.header().dataWindow();
+        Vector2i size = {dataWindow.max.x - dataWindow.min.x + 1 , dataWindow.max.y - dataWindow.min.y + 1};
+
+        if (size.x() == 0 || size.y() == 0) {
+            tlog::warning() << "EXR part '" << part.header().name() << "' has zero pixels.";
+            continue;
+        }
+
+        for (Imf::ChannelList::ConstIterator c = imfChannels.begin(); c != imfChannels.end(); ++c) {
+            string name = channelName(c);
+            if (matchesFuzzy(name, channelSelector)) {
+                rawChannels.emplace_back(parts.size(), name, c.name(), c.channel(), size);
+            }
+        }
+
+        parts.emplace_back(part);
+        frameBuffers.emplace_back();
     }
 
-    // Sort matched channels by matched component of the selector, if one exists.
-    if (!channelSelector.empty()) {
-        sort(begin(matches), end(matches), [](const match_t& m1, const match_t& m2) { return m1.first < m2.first; });
-    }
-
-    for (const auto& match : matches) {
-        const auto& c = match.second;
-        rawChannels->emplace_back(c.name(), c.channel());
-    }
-
-    if (rawChannels->empty()) {
+    if (rawChannels.empty()) {
         throw invalid_argument{tfm::format("No channels match '%s'.", channelSelector)};
     }
 
-    co_await gThreadPool->parallelForAsync(0, (int)rawChannels->size(), [c = rawChannels.get(), size](int i) {
-        c->at(i).resize((size_t)size.x() * size.y());
+    co_await gThreadPool->parallelForAsync(0, (int)rawChannels.size(), [&](int i) {
+        rawChannels.at(i).resize();
     }, priority);
 
-    for (size_t i = 0; i < rawChannels->size(); ++i) {
-        rawChannels->at(i).registerWith(frameBuffer, dataWindow);
+    for (auto& rawChannel : rawChannels) {
+        size_t partId = rawChannel.partId();
+        rawChannel.registerWith(frameBuffers.at(partId), parts.at(partId).header().dataWindow());
     }
 
-    file.setFrameBuffer(frameBuffer);
-    file.readPixels(dataWindow.min.y, dataWindow.max.y);
+    // No need for a parallel for loop, because OpenEXR parallelizes internally
+    for (size_t partIdx = 0; partIdx < parts.size(); ++partIdx) {
+        auto& part = parts.at(partIdx);
 
-    for (const auto& rawChannel : *rawChannels) {
-        data.channels.emplace_back(Channel{rawChannel.name(), size});
+        result.emplace_back();
+        ImageData& data = result.back();
+
+        Imath::Box2i dataWindow = part.header().dataWindow();
+        Imath::Box2i displayWindow = part.header().displayWindow();
+
+        // EXR's display- and data windows have inclusive upper ends while tev's upper ends are exclusive.
+        // This allows easy conversion from window to size. Hence the +1.
+        data.dataWindow =    {{dataWindow.min.x,    dataWindow.min.y   }, {dataWindow.max.x+1,    dataWindow.max.y+1   }};
+        data.displayWindow = {{displayWindow.min.x, displayWindow.min.y}, {displayWindow.max.x+1, displayWindow.max.y+1}};
+
+        if (!data.dataWindow.isValid()) {
+            throw invalid_argument{tfm::format(
+                "EXR image has invalid data window: [%d,%d] - [%d,%d]",
+                data.dataWindow.min.x(), data.dataWindow.min.y(), data.dataWindow.max.x(), data.dataWindow.max.y()
+            )};
+        }
+
+        if (!data.displayWindow.isValid()) {
+            throw invalid_argument{tfm::format(
+                "EXR image has invalid display window: [%d,%d] - [%d,%d]",
+                data.displayWindow.min.x(), data.displayWindow.min.y(), data.displayWindow.max.x(), data.displayWindow.max.y()
+            )};
+        }
+
+        part.setFrameBuffer(frameBuffers.at(partIdx));
+        part.readPixels(dataWindow.min.y, dataWindow.max.y);
+
+        data.hasPremultipliedAlpha = true;
+        if (part.header().hasName()) {
+            data.partName = part.header().name();
+        }
+
+        // equality comparison for Imf::Chromaticities instances
+        auto chromaEq = [](const Imf::Chromaticities& a, const Imf::Chromaticities& b) {
+            return
+                (a.red  - b.red).length2() + (a.green - b.green).length2() +
+                (a.blue - b.blue).length2() + (a.white - b.white).length2() < 1e-6f;
+        };
+
+        Imf::Chromaticities rec709; // default rec709 (sRGB) primaries
+
+        // Check if there is a chromaticity header entry and if so,
+        // expose it to the image data for later conversion to sRGB/Rec709.
+        Imf::Chromaticities chroma;
+        if (Imf::hasChromaticities(part.header())) {
+            chroma = Imf::chromaticities(part.header());
+        }
+
+        if (!chromaEq(chroma, rec709)) {
+            Imath::M44f M = Imf::RGBtoXYZ(chroma, 1) * Imf::XYZtoRGB(rec709, 1);
+            for (int m = 0; m < 4; ++m) {
+                for (int n = 0; n < 4; ++n) {
+                    data.toRec709.m[m][n] = M.x[m][n];
+                }
+            }
+        }
+    }
+
+    vector<size_t> channelMapping;
+    for (size_t i = 0; i < rawChannels.size(); ++i) {
+        auto& rawChannel = rawChannels.at(i);
+        auto& data = result.at(rawChannel.partId());
+        channelMapping.emplace_back(data.channels.size());
+        data.channels.emplace_back(Channel{rawChannel.name(), rawChannel.size()});
     }
 
     vector<Task<void>> tasks;
-    for (size_t i = 0; i < rawChannels->size(); ++i) {
-        tasks.emplace_back(rawChannels->at(i).copyTo(data.channels[i], priority));
+    for (size_t i = 0; i < rawChannels.size(); ++i) {
+        auto& rawChannel = rawChannels.at(i);
+        tasks.emplace_back(rawChannel.copyTo(result.at(rawChannel.partId()).channels.at(channelMapping.at(i)), priority));
     }
 
     for (auto& task : tasks) {
         co_await task;
     }
-
-    // equality comparison for Imf::Chromaticities instances
-    auto chromaEq = [](const Imf::Chromaticities& a, const Imf::Chromaticities& b) {
-        return
-            (a.red  - b.red).length2() + (a.green - b.green).length2() +
-            (a.blue - b.blue).length2() + (a.white - b.white).length2() < 1e-6f;
-    };
-
-    Imf::Chromaticities rec709; // default rec709 (sRGB) primaries
-
-    // Check if there is a chromaticity header entry and if so,
-    // expose it to the image data for later conversion to sRGB/Rec709.
-    Imf::Chromaticities chroma;
-    if (Imf::hasChromaticities(file.header())) {
-        chroma = Imf::chromaticities(file.header());
-    }
-
-    if (!chromaEq(chroma, rec709)) {
-        Imath::M44f M = Imf::RGBtoXYZ(chroma, 1) * Imf::XYZtoRGB(rec709, 1);
-        for (int m = 0; m < 4; ++m) {
-            for (int n = 0; n < 4; ++n) {
-                data.toRec709.m[m][n] = M.x[m][n];
-            }
-        }
-    }
-
-    data.hasPremultipliedAlpha = true;
 
     co_return result;
 }

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -195,18 +195,6 @@ Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const path& path,
             return name;
         };
 
-        bool matched = false;
-        for (Imf::ChannelList::ConstIterator c = imfChannels.begin(); c != imfChannels.end(); ++c) {
-            matched |= matchesFuzzy(channelName(c), channelSelector);
-            if (matched) {
-                break;
-            }
-        }
-
-        if (!matched) {
-            continue;
-        }
-
         Imath::Box2i dataWindow = part.header().dataWindow();
         Vector2i size = {dataWindow.max.x - dataWindow.min.x + 1 , dataWindow.max.y - dataWindow.min.y + 1};
 
@@ -215,11 +203,17 @@ Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const path& path,
             continue;
         }
 
+        bool matched = false;
         for (Imf::ChannelList::ConstIterator c = imfChannels.begin(); c != imfChannels.end(); ++c) {
             string name = channelName(c);
             if (matchesFuzzy(name, channelSelector)) {
                 rawChannels.emplace_back(parts.size(), name, c.name(), c.channel(), size);
+                matched = true;
             }
+        }
+
+        if (!matched) {
+            continue;
         }
 
         parts.emplace_back(part);

--- a/src/imageio/ImageLoader.cpp
+++ b/src/imageio/ImageLoader.cpp
@@ -30,7 +30,7 @@ const vector<unique_ptr<ImageLoader>>& ImageLoader::getLoaders() {
         return imageLoaders;
     };
 
-    static const vector<unique_ptr<ImageLoader>> imageLoaders = makeLoaders();
+    static const vector imageLoaders = makeLoaders();
     return imageLoaders;
 }
 

--- a/src/imageio/ImageSaver.cpp
+++ b/src/imageio/ImageSaver.cpp
@@ -22,7 +22,7 @@ const vector<unique_ptr<ImageSaver>>& ImageSaver::getSavers() {
         return imageSavers;
     };
 
-    static const vector<unique_ptr<ImageSaver>> imageSavers = makeSavers();
+    static const vector imageSavers = makeSavers();
     return imageSavers;
 }
 

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -21,8 +21,9 @@ bool PfmImageLoader::canLoadFile(istream& iStream) const {
     return result;
 }
 
-Task<ImageData> PfmImageLoader::load(istream& iStream, const path&, const string& channelSelector, int priority) const {
-    ImageData result;
+Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const path&, const string& channelSelector, int priority) const {
+    vector<ImageData> result(1);
+    ImageData& resultData = result.front();
 
     string magic;
     Vector2i size;
@@ -48,7 +49,7 @@ Task<ImageData> PfmImageLoader::load(istream& iStream, const path&, const string
     bool isPfmLittleEndian = scale < 0;
     scale = abs(scale);
 
-    result.channels = makeNChannels(numChannels, size);
+    resultData.channels = makeNChannels(numChannels, size);
 
     auto numPixels = (size_t)size.x() * size.y();
     if (numPixels == 0) {
@@ -85,12 +86,12 @@ Task<ImageData> PfmImageLoader::load(istream& iStream, const path&, const string
                 }
 
                 // Flip image vertically due to PFM format
-                result.channels[c].at({x, size.y() - (int)y - 1}) = scale * val;
+                resultData.channels[c].at({x, size.y() - (int)y - 1}) = scale * val;
             }
         }
     }, priority);
 
-    result.hasPremultipliedAlpha = false;
+    resultData.hasPremultipliedAlpha = false;
 
     co_return result;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,9 +114,10 @@ void handleIpcPacket(const IpcPacket& packet, const std::shared_ptr<BackgroundIm
                     imageStream << info.channelNames[i].length() << info.channelNames[i];
                 }
 
-                auto image = tryLoadImage(imageString, imageStream, "").get();
-                if (image) {
-                    sImageViewer->addImage(image, info.grabFocus);
+                auto images = tryLoadImage(imageString, imageStream, "").get();
+                if (!images.empty()) {
+                    sImageViewer->addImage(images.front(), info.grabFocus);
+                    TEV_ASSERT(images.size() == 1, "IPC CreateImage should never create more than 1 image at once.");
                 }
             });
 


### PR DESCRIPTION
Makes __tev__ load all parts of multipart EXR images as logically _separate_ images. (As opposed to trying to merge channels and layers with matching resolutions.)

After much thought about this behavior, I believe this is the most general/portable approach. Multipart EXR images are ultimately nothing more than multiple separate EXR images packaged into the same file.

To allow distinguishing the multiple loaded parts, their channels are prefixed by the part name. For example, a multi-part EXR image "image.exr" with parts "part1" and "part2", each of which containing "r", "g", and "b" channels will result in two images being opened:

1. "image.exr:part1" with channels "part1.(r,g,b)"
2. "image.exr:part2" with channels "part2.(r,g,b)"
