### PR TITLE
__tev__ startup improvements

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -283,6 +283,7 @@ void toggleConsole();
 
 // Implemented in main.cpp
 void scheduleToMainThread(const std::function<void()>& fun);
+void redrawWindow();
 
 enum ETonemap : int {
     SRGB = 0,

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -128,8 +128,8 @@ namespace nanogui {
 
     template <typename Value, size_t Size>
     bool operator==(const Matrix<Value, Size>& a, const Matrix<Value, Size>& b) {
-        for (int m = 0; m < Size; ++m) {
-            for (int n = 0; n < Size; ++n) {
+        for (size_t m = 0; m < Size; ++m) {
+            for (size_t n = 0; n < Size; ++n) {
                 if (a.m[m][n] != b.m[m][n]) {
                     return false;
                 }

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -65,7 +65,12 @@ struct ImageData {
     }
 
     const Channel* channel(const std::string& channelName) const {
-        auto it = std::ranges::find_if(channels, [&channelName](const Channel& c) { return c.name() == channelName; });
+        auto it = std::find_if(
+            std::begin(channels),
+            std::end(channels),
+            [&channelName](const Channel& c) { return c.name() == channelName; }
+        );
+
         if (it != std::end(channels)) {
             return &(*it);
         } else {
@@ -74,7 +79,12 @@ struct ImageData {
     }
 
     Channel* mutableChannel(const std::string& channelName) {
-        auto it = std::ranges::find_if(channels, [&channelName](const Channel& c) { return c.name() == channelName; });
+        auto it = std::find_if(
+            std::begin(channels),
+            std::end(channels),
+            [&channelName](const Channel& c) { return c.name() == channelName; }
+        );
+
         if (it != std::end(channels)) {
             return &(*it);
         } else {

--- a/include/tev/Ipc.h
+++ b/include/tev/Ipc.h
@@ -231,6 +231,8 @@ public:
         return mIsPrimaryInstance;
     }
 
+    bool attemptToBecomePrimaryInstance();
+
     void sendToPrimaryInstance(const IpcPacket& message);
     void receiveFromSecondaryInstance(std::function<void(const IpcPacket&)> callback);
 
@@ -267,6 +269,10 @@ private:
     };
 
     std::list<SocketConnection> mSocketConnections;
+
+    std::string mIp;
+    std::string mPort;
+    std::string mLockName;
 };
 
 TEV_NAMESPACE_END

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -62,12 +62,12 @@ vector<string> split(string text, const string& delim) {
 }
 
 string toLower(string str) {
-    ranges::transform(str, begin(str), [](unsigned char c) { return (char)tolower(c); });
+    transform(begin(str), end(str), begin(str), [](unsigned char c) { return (char)tolower(c); });
     return str;
 }
 
 string toUpper(string str) {
-    ranges::transform(str, begin(str), [](unsigned char c) { return (char)toupper(c); });
+    transform(begin(str), end(str), begin(str), [](unsigned char c) { return (char)toupper(c); });
     return str;
 }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -325,7 +325,7 @@ vector<ChannelGroup> Image::getGroupedChannels(const string& layerName) const {
         auto channelTails = channels;
         // Remove duplicates
         channelTails.erase(unique(begin(channelTails), end(channelTails)), end(channelTails));
-        ranges::transform(channelTails, begin(channelTails), Channel::tail);
+        transform(begin(channelTails), end(channelTails), begin(channelTails), Channel::tail);
         string channelsString = join(channelTails, ",");
 
         string name;
@@ -345,7 +345,7 @@ vector<ChannelGroup> Image::getGroupedChannels(const string& layerName) const {
 
     vector<string> allChannels = mData.channelsInLayer(layerName);
 
-    auto alphaIt = ranges::find(allChannels, alphaChannelName);
+    auto alphaIt = find(begin(allChannels), end(allChannels), alphaChannelName);
     bool hasAlpha = alphaIt != end(allChannels);
     if (hasAlpha) {
         allChannels.erase(alphaIt);
@@ -357,7 +357,7 @@ vector<ChannelGroup> Image::getGroupedChannels(const string& layerName) const {
         vector<string> groupChannels;
         for (const string& channel : group) {
             string name = layerPrefix + channel;
-            auto it = ranges::find(allChannels, name);
+            auto it = find(begin(allChannels), end(allChannels), name);
             if (it != end(allChannels)) {
                 groupChannels.emplace_back(name);
                 allChannels.erase(it);
@@ -436,7 +436,7 @@ void Image::updateChannel(const string& channelName, int x, int y, int width, in
     // Update textures that are cached for this channel
     for (auto& kv : mTextures) {
         auto& imageTexture = kv.second;
-        if (ranges::find(imageTexture.channels, channelName) == end(imageTexture.channels)) {
+        if (find(begin(imageTexture.channels), end(imageTexture.channels), channelName) == end(imageTexture.channels)) {
             continue;
         }
 
@@ -481,9 +481,9 @@ string Image::toString() const {
     sstream << "\nChannels:\n";
 
     auto localLayers = mData.layers;
-    ranges::transform(localLayers, begin(localLayers), [this](string layer) {
+    transform(begin(localLayers), end(localLayers), begin(localLayers), [this](string layer) {
         auto channels = mData.channelsInLayer(layer);
-        ranges::transform(channels, begin(channels), [](string channel) {
+        transform(begin(channels), end(channels), begin(channels), [](string channel) {
             return Channel::tail(channel);
         });
         if (layer.empty()) {
@@ -539,7 +539,7 @@ Task<vector<shared_ptr<Image>>> tryLoadImage(int taskPriority, path path, istrea
                         auto selectorParts = split(channelSelector, ",");
                         if (channelSelector.empty()) {
                             localChannelSelector = i.partName;
-                        } else if (ranges::find(selectorParts, i.partName) == end(selectorParts)) {
+                        } else if (find(begin(selectorParts), end(selectorParts), i.partName) == end(selectorParts)) {
                             localChannelSelector = join(vector<string>{i.partName, channelSelector}, ",");
                         }
                     }

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -604,7 +604,7 @@ void BackgroundImagesLoader::enqueue(const path& path, const string& channelSele
         }
 
         if (publishSortedLoads()) {
-            glfwPostEmptyEvent();
+            redrawWindow();
         }
     });
 }

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -61,8 +61,8 @@ Task<void> ImageData::convertToRec709(int priority) {
         Channel* b = nullptr;
 
         if (!(
-            (r = mutableChannel(layerPrefix + "R")) && (g = mutableChannel(layerPrefix + "G")) && (b = mutableChannel(layerPrefix + "B")) ||
-            (r = mutableChannel(layerPrefix + "r")) && (g = mutableChannel(layerPrefix + "g")) && (b = mutableChannel(layerPrefix + "b"))
+            ((r = mutableChannel(layerPrefix + "R")) && (g = mutableChannel(layerPrefix + "G")) && (b = mutableChannel(layerPrefix + "B"))) ||
+            ((r = mutableChannel(layerPrefix + "r")) && (g = mutableChannel(layerPrefix + "g")) && (b = mutableChannel(layerPrefix + "b")))
         )) {
             // No RGB-triplet found
             continue;

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -297,7 +297,7 @@ void ImageCanvas::draw(NVGcontext* ctx) {
 
         // If the coordinate system is in any sort of way non-trivial, draw it!
         if (mImage->dataWindow() != mImage->displayWindow() || mImage->displayWindow().min != Vector2i{0} ||
-            mReference && (mReference->dataWindow() != mImage->dataWindow() || mReference->displayWindow() != mImage->displayWindow())) {
+            (mReference && (mReference->dataWindow() != mImage->dataWindow() || mReference->displayWindow() != mImage->displayWindow()))) {
             drawCoordinateSystem(ctx);
         }
     }

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -1771,7 +1771,7 @@ void ImageViewer::updateTitle() {
         channels.erase(unique(begin(channels), end(channels)), end(channels));
 
         auto channelTails = channels;
-        ranges::transform(channelTails, begin(channelTails), Channel::tail);
+        transform(begin(channelTails), end(channelTails), begin(channelTails), Channel::tail);
 
         caption = mCurrentImage->shortName();
         caption += " – "s + mCurrentGroup;
@@ -1825,12 +1825,12 @@ int ImageViewer::groupId(const string& groupName) const {
 }
 
 int ImageViewer::imageId(const shared_ptr<Image>& image) const {
-    auto pos = static_cast<size_t>(distance(begin(mImages), ranges::find(mImages, image)));
+    auto pos = static_cast<size_t>(distance(begin(mImages), find(begin(mImages), end(mImages), image)));
     return pos >= mImages.size() ? -1 : (int)pos;
 }
 
 int ImageViewer::imageId(const string& imageName) const {
-    auto pos = static_cast<size_t>(distance(begin(mImages), ranges::find_if(mImages, [&](const shared_ptr<Image>& image) {
+    auto pos = static_cast<size_t>(distance(begin(mImages), find_if(begin(mImages), end(mImages), [&](const shared_ptr<Image>& image) {
         return image->name() == imageName;
     })));
     return pos >= mImages.size() ? -1 : (int)pos;

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -907,7 +907,7 @@ void ImageViewer::draw_contents() {
         bool isShown = image == mCurrentImage || image == mCurrentReference;
 
         // If the image is no longer shown, bump ID immediately. Otherwise, wait until canvas statistics were ready for over 200 ms.
-        if (!isShown || (std::chrono::steady_clock::now() - mImageCanvas->canvasStatistics()->becameReadyAt()) > std::chrono::milliseconds{200}) {
+        if (!isShown || (std::chrono::steady_clock::now() - mImageCanvas->canvasStatistics()->becameReadyAt()) > 200ms) {
             image->bumpId();
             auto localIt = it;
             ++it;

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -963,7 +963,7 @@ void ImageViewer::draw_contents() {
             );
         }
     } else {
-        mHistogram->setNChannels({1});
+        mHistogram->setNChannels(1);
         mHistogram->setValues({0.0f});
         mHistogram->setMinimum(0);
         mHistogram->setMean(0);

--- a/src/Ipc.cpp
+++ b/src/Ipc.cpp
@@ -301,7 +301,7 @@ static int closeSocket(Ipc::socket_t socket) {
 #endif
 }
 
-Ipc::Ipc(const string& hostname) {
+Ipc::Ipc(const string& hostname) : mSocketFd{INVALID_SOCKET} {
     mLockName = ".tev-lock."s + hostname;
 
     auto parts = split(hostname, ":");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,12 @@ void scheduleToMainThread(const std::function<void()>& fun) {
     }
 }
 
+void redrawWindow() {
+    if (sImageViewer) {
+        sImageViewer->redraw();
+    }
+}
+
 void handleIpcPacket(const IpcPacket& packet, const std::shared_ptr<BackgroundImagesLoader>& imagesLoader) {
     switch (packet.type()) {
         case IpcPacket::OpenImage:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -290,9 +290,14 @@ int mainFunc(const vector<string>& arguments) {
     const string hostname = hostnameFlag ? get(hostnameFlag) : "127.0.0.1:14158";
     auto ipc = make_shared<Ipc>(hostname);
 
+    // If we don't have any images to load, create new windows regardless of flag.
+    // (In this case, the user likely wants to open a new instance of tev rather
+    // than focusing the existing one.)
+    bool newWindow = newWindowFlag || !imageFiles;
+
     // If we're not the primary instance and did not request to open a new window,
     // simply send the to-be-opened images to the primary instance.
-    if (!ipc->isPrimaryInstance() && !newWindowFlag) {
+    if (!ipc->isPrimaryInstance() && !newWindow) {
         string channelSelector;
         for (auto imageFile : get(imageFiles)) {
             if (!imageFile.empty() && imageFile[0] == ':') {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -379,7 +379,7 @@ int mainFunc(const vector<string>& arguments) {
                     }
                 });
 
-                this_thread::sleep_for(chrono::milliseconds{10});
+                this_thread::sleep_for(10ms);
             }
         } catch (const runtime_error& e) {
             tlog::warning() << "Uncaught exception in IPC thread: " << e.what();


### PR DESCRIPTION
- Fixes several issues with the size as well as flickering of the __tev__ window upon startup.
- Reduces the time delay of opening images that are sent over by secondary __tev__ instances.
- Allows secondary __tev__ instances to become primary as soon as the previously primary instance is closed.