### PR TITLE
File/directory watcher

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -180,7 +180,6 @@ inline int codePointLength(char first) {
 }
 
 std::string ensureUtf8(const std::string& str);
-std::wstring utf8to16(const std::string& utf16);
 std::string utf16to8(const std::wstring& utf16);
 fs::path toPath(const std::string& utf8);
 std::string toString(const fs::path& path);

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -186,12 +186,15 @@ std::string toString(const fs::path& path);
 
 template <typename F>
 void forEachFileInDir(bool recursive, const fs::path& path, F&& callback) {
+    // Ignore errors in case a directory no longer exists.
+    // Simply don't invoke the loop body in that case.
+    std::error_code ec;
     if (recursive) {
-        for (auto const& entry : fs::recursive_directory_iterator{path}) {
+        for (auto const& entry : fs::recursive_directory_iterator{path, ec}) {
             callback(entry);
         }
     } else {
-        for (auto const& entry : fs::directory_iterator{path}) {
+        for (auto const& entry : fs::directory_iterator{path, ec}) {
             callback(entry);
         }
     }

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -184,6 +184,19 @@ std::string utf16to8(const std::wstring& utf16);
 fs::path toPath(const std::string& utf8);
 std::string toString(const fs::path& path);
 
+template <typename F>
+void forEachFileInDir(bool recursive, const fs::path& path, F&& callback) {
+    if (recursive) {
+        for (auto const& entry : fs::recursive_directory_iterator{path}) {
+            callback(entry);
+        }
+    } else {
+        for (auto const& entry : fs::directory_iterator{path}) {
+            callback(entry);
+        }
+    }
+}
+
 template <typename T>
 class ScopeGuard {
 public:

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -220,6 +220,7 @@ struct ImageAddition {
     int loadId;
     bool shallSelect;
     std::vector<std::shared_ptr<Image>> images;
+    std::shared_ptr<Image> toReplace;
 
     struct Comparator {
         bool operator()(const ImageAddition& a, const ImageAddition& b) {
@@ -230,7 +231,7 @@ struct ImageAddition {
 
 class BackgroundImagesLoader {
 public:
-    void enqueue(const fs::path& path, const std::string& channelSelector, bool shallSelect);
+    void enqueue(const fs::path& path, const std::string& channelSelector, bool shallSelect, const std::shared_ptr<Image>& toReplace = nullptr);
     std::optional<ImageAddition> tryPop() { return mLoadedImages.tryPop(); }
 
     bool publishSortedLoads();

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -249,6 +249,14 @@ public:
         return mLoadCounter != mUnsortedLoadCounter;
     }
 
+    bool recursiveDirectories() const {
+        return mRecursiveDirectories;
+    }
+
+    void setRecursiveDirectories(bool value) {
+        mRecursiveDirectories = value;
+    }
+
 private:
     SharedQueue<ImageAddition> mLoadedImages;
 
@@ -261,6 +269,9 @@ private:
 
     std::atomic<int> mLoadCounter{0};
     std::atomic<int> mUnsortedLoadCounter{0};
+
+    bool mRecursiveDirectories = false;
+    std::set<fs::path> mDirectories;
 };
 
 TEV_NAMESPACE_END

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -113,6 +113,14 @@ public:
         return mPath;
     }
 
+    fs::file_time_type fileLastModified() const {
+        return mFileLastModified;
+    }
+
+    void setFileLastModified(fs::file_time_type value) {
+        mFileLastModified = value;
+    }
+
     const std::string& channelSelector() const {
         return mChannelSelector;
     }

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -239,9 +239,20 @@ struct ImageAddition {
     };
 };
 
+struct PathAndChannelSelector {
+    fs::path path;
+    std::string channelSelector;
+
+    bool operator<(const PathAndChannelSelector& other) const {
+        return path == other.path ? (channelSelector < other.channelSelector) : (path < other.path);
+    }
+};
+
 class BackgroundImagesLoader {
 public:
     void enqueue(const fs::path& path, const std::string& channelSelector, bool shallSelect, const std::shared_ptr<Image>& toReplace = nullptr);
+    void checkDirectoriesForNewFilesAndLoadThose();
+
     std::optional<ImageAddition> tryPop() { return mLoadedImages.tryPop(); }
 
     bool publishSortedLoads();
@@ -271,7 +282,8 @@ private:
     std::atomic<int> mUnsortedLoadCounter{0};
 
     bool mRecursiveDirectories = false;
-    std::set<fs::path> mDirectories;
+    std::map<fs::path, std::set<std::string>> mDirectories;
+    std::set<PathAndChannelSelector> mFilesFoundInDirectories;
 };
 
 TEV_NAMESPACE_END

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -106,7 +106,7 @@ struct ImageTexture {
 
 class Image {
 public:
-    Image(const fs::path& path, ImageData&& data, const std::string& channelSelector);
+    Image(const fs::path& path, fs::file_time_type fileLastModified, ImageData&& data, const std::string& channelSelector);
     virtual ~Image();
 
     const fs::path& path() const {
@@ -196,6 +196,8 @@ private:
     std::vector<ChannelGroup> getGroupedChannels(const std::string& layerName) const;
 
     fs::path mPath;
+    fs::file_time_type mFileLastModified;
+
     std::string mChannelSelector;
 
     std::string mName;

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -113,8 +113,11 @@ public:
     nanogui::Vector2i sizeToFitAllImages();
     bool setFilter(const std::string& filter);
 
-    bool useRegex();
+    bool useRegex() const;
     void setUseRegex(bool value);
+
+    bool watchFilesForChanges() const;
+    void setWatchFilesForChanges(bool value);
 
     void maximize();
     bool isMaximized();
@@ -141,14 +144,6 @@ public:
 
     BackgroundImagesLoader& imagesLoader() const {
         return *mImagesLoader;
-    }
-
-    bool watchFilesForChanges() const {
-        return mWatchFilesForChanges;
-    }
-
-    void setWatchFilesForChanges(bool value) {
-        mWatchFilesForChanges = value;
     }
 
 private:
@@ -218,6 +213,9 @@ private:
     nanogui::TextBox* mFilter;
     nanogui::Button* mRegexButton;
 
+    nanogui::Button* mWatchFilesForChangesButton;
+    std::chrono::steady_clock::time_point mLastFileChangesCheck = {};
+
     // Buttons which require a current image to be meaningful.
     std::vector<nanogui::Button*> mCurrentImageButtons;
 
@@ -253,9 +251,6 @@ private:
     nanogui::Button* mClipToLdrButton;
 
     int mDidFitToImage = 0;
-
-    bool mWatchFilesForChanges = false;
-    std::chrono::steady_clock::time_point mLastFileChangesCheck = {};
 };
 
 TEV_NAMESPACE_END

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -16,6 +16,7 @@
 #include <nanogui/slider.h>
 #include <nanogui/textbox.h>
 
+#include <chrono>
 #include <memory>
 #include <set>
 #include <vector>
@@ -58,6 +59,7 @@ public:
         reloadImage(imageByName(imageName), shallSelect);
     }
     void reloadAllImages();
+    void reloadImagesWhoseFileChanged();
 
     void updateImage(
         const std::string& imageName,
@@ -74,19 +76,19 @@ public:
 
     void selectReference(const std::shared_ptr<Image>& image);
 
-    float exposure() {
+    float exposure() const {
         return mExposureSlider->value();
     }
 
     void setExposure(float value);
 
-    float offset() {
+    float offset() const {
         return mOffsetSlider->value();
     }
 
     void setOffset(float value);
 
-    float gamma() {
+    float gamma() const {
         return mGammaSlider->value();
     }
 
@@ -95,13 +97,13 @@ public:
     void normalizeExposureAndOffset();
     void resetImage();
 
-    ETonemap tonemap() {
+    ETonemap tonemap() const {
         return mImageCanvas->tonemap();
     }
 
     void setTonemap(ETonemap tonemap);
 
-    EMetric metric() {
+    EMetric metric() const {
         return mImageCanvas->metric();
     }
 
@@ -139,6 +141,14 @@ public:
 
     BackgroundImagesLoader& imagesLoader() const {
         return *mImagesLoader;
+    }
+
+    bool watchFilesForChanges() const {
+        return mWatchFilesForChanges;
+    }
+
+    void setWatchFilesForChanges(bool value) {
+        mWatchFilesForChanges = value;
     }
 
 private:
@@ -243,6 +253,9 @@ private:
     nanogui::Button* mClipToLdrButton;
 
     int mDidFitToImage = 0;
+
+    bool mWatchFilesForChanges = false;
+    std::chrono::steady_clock::time_point mLastFileChangesCheck = {};
 };
 
 TEV_NAMESPACE_END

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -51,6 +51,8 @@ public:
     }
     void removeAllImages();
 
+    void replaceImage(std::shared_ptr<Image> image, std::shared_ptr<Image> replacement, bool shallSelect);
+
     void reloadImage(std::shared_ptr<Image> image, bool shallSelect = false);
     void reloadImage(const std::string& imageName, bool shallSelect = false) {
         reloadImage(imageByName(imageName), shallSelect);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -44,12 +44,6 @@ string ensureUtf8(const string& str) {
     return temp;
 }
 
-wstring utf8to16(const string& utf8) {
-    wstring utf16;
-    utf8::utf8to16(begin(utf8), end(utf8), back_inserter(utf16));
-    return utf16;
-}
-
 string utf16to8(const wstring& utf16) {
     string utf8;
     utf8::utf16to8(begin(utf16), end(utf16), back_inserter(utf8));
@@ -57,23 +51,19 @@ string utf16to8(const wstring& utf16) {
 }
 
 fs::path toPath(const string& utf8) {
-#ifdef _WIN32
-    // To be on the safe side, use Windows' native
-    // wide char encoding to construct the path object.
-    return utf8to16(utf8);
-#else
+    // tev's strings are always utf8 encoded, however fs::path does
+    // not know this. Therefore: convert the string to a std::u8string
+    // and pass _that_ string to the fs::path constructor, which will
+    // then take care of converting the utf8 string to the native
+    // file name encoding.
     return toU8string(utf8);
-#endif
 }
 
 string toString(const fs::path& path) {
-#ifdef _WIN32
-    // To be on the safe side, use Windows' native
-    // wide char encoding and convert to UTF8 manually.
-    return utf16to8(path.wstring());
-#else
+    // Conversely to `toPath`, ensure that the returned string is
+    // utf8 encoded by requesting a std::u8string from the path
+    // object and then convert _that_ string to a regular char string.
     return fromU8string(path.u8string());
-#endif
 }
 
 vector<string> split(string text, const string& delim) {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -644,7 +644,7 @@ void BackgroundImagesLoader::enqueue(const fs::path& path, const string& channel
         bool first = true;
         forEachFileInDir(mRecursiveDirectories, canonicalPath, [&](auto const& entry) {
             if (!entry.is_directory()) {
-                mFilesFoundInDirectories.emplace(entry, channelSelector);
+                mFilesFoundInDirectories.emplace(PathAndChannelSelector{entry, channelSelector});
                 enqueue(entry, channelSelector, first ? shallSelect : false);
                 first = false;
             }

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -479,12 +479,22 @@ void Image::updateChannel(const string& channelName, int x, int y, int width, in
     }
 }
 
+template <typename T>
+time_t to_time_t(T timePoint) {
+#ifdef _WIN32
+    return chrono::system_clock::to_time_t(chrono::clock_cast<chrono::system_clock>(timePoint));
+#else
+    using namespace chrono;
+    return system_clock::to_time_t(time_point_cast<system_clock::duration>(timePoint - T::clock::now() + system_clock::now()));
+#endif
+}
+
 string Image::toString() const {
     stringstream sstream;
     sstream << mName << "\n\n";
 
     {
-        time_t cftime = chrono::system_clock::to_time_t(clock_cast<chrono::system_clock>(mFileLastModified));
+        time_t cftime = to_time_t(mFileLastModified);
         sstream << "Last modified:\n" << asctime(localtime(&cftime)) << "\n";
     }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -533,9 +533,14 @@ Task<vector<shared_ptr<Image>>> tryLoadImage(int taskPriority, fs::path path, is
             throw invalid_argument{tfm::format("Image %s could not be opened.", path)};
         }
 
-        fs::file_time_type fileLastModified = {};
+        fs::file_time_type fileLastModified = fs::file_time_type::clock::now();
         if (fs::exists(path)) {
-            fileLastModified = fs::last_write_time(path);
+            // Unlikely, but the file could have been deleted, moved, or something
+            // else might have happened to it that makes obtaining its last modified
+            // time impossible. Ignore such errors.
+            try {
+                fileLastModified = fs::last_write_time(path);
+            } catch (...) {}
         }
 
         std::string loadMethod;

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -515,9 +515,9 @@ string Image::toString() const {
 Task<vector<shared_ptr<Image>>> tryLoadImage(int taskPriority, fs::path path, istream& iStream, string channelSelector) {
     auto handleException = [&](const exception& e) {
         if (channelSelector.empty()) {
-            tlog::error() << tfm::format("Could not load %s. %s", path, e.what());
+            tlog::error() << tfm::format("Could not load %s. %s", toString(path), e.what());
         } else {
-            tlog::error() << tfm::format("Could not load \"%s:%s\". %s", path.string(), channelSelector, e.what());
+            tlog::error() << tfm::format("Could not load %s:%s. %s", toString(path), channelSelector, e.what());
         }
     };
 
@@ -580,7 +580,7 @@ Task<vector<shared_ptr<Image>>> tryLoadImage(int taskPriority, fs::path path, is
                 auto end = chrono::system_clock::now();
                 chrono::duration<double> elapsedSeconds = end - start;
 
-                tlog::success() << tfm::format("Loaded %s via %s after %.3f seconds.", path, loadMethod, elapsedSeconds.count());
+                tlog::success() << tfm::format("Loaded %s via %s after %.3f seconds.", toString(path), loadMethod, elapsedSeconds.count());
 
                 co_return images;
             }

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -481,11 +481,14 @@ void Image::updateChannel(const string& channelName, int x, int y, int width, in
 
 template <typename T>
 time_t to_time_t(T timePoint) {
+    // TODO: clean up this mess once all compilers support clock_cast.
 #ifdef _WIN32
     return chrono::system_clock::to_time_t(chrono::clock_cast<chrono::system_clock>(timePoint));
-#else
+#elif __APPLE__
     using namespace chrono;
     return system_clock::to_time_t(time_point_cast<system_clock::duration>(timePoint - T::clock::now() + system_clock::now()));
+#else
+    return chrono::system_clock::to_time_t(T::clock::to_sys(timePoint));
 #endif
 }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -479,18 +479,12 @@ void Image::updateChannel(const string& channelName, int x, int y, int width, in
     }
 }
 
-template <typename T>
-time_t to_time_t(T time_point) {
-    using namespace chrono;
-    return system_clock::to_time_t(time_point_cast<system_clock::duration>(time_point - T::clock::now() + system_clock::now()));
-}
-
 string Image::toString() const {
     stringstream sstream;
     sstream << mName << "\n\n";
 
     {
-        time_t cftime = to_time_t(mFileLastModified);
+        time_t cftime = chrono::system_clock::to_time_t(clock_cast<chrono::system_clock>(mFileLastModified));
         sstream << "Last modified:\n" << asctime(localtime(&cftime)) << "\n";
     }
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -401,7 +401,7 @@ ImageViewer::ImageViewer(const shared_ptr<BackgroundImagesLoader>& imagesLoader,
                 reloadAllImages();
             }, 0, tfm::format("Reload All (%s+Shift+R or %s+F5)", HelpWindow::COMMAND, HelpWindow::COMMAND)));
 
-            mWatchFilesForChangesButton = makeImageButton("W", true, [this] {}, 0, "Watch for file changes and reload automatically");
+            mWatchFilesForChangesButton = makeImageButton("W", true, {}, 0, "Watch image files for changes and reload them automatically.");
             mWatchFilesForChangesButton->set_flags(Button::Flags::ToggleButton);
             mWatchFilesForChangesButton->set_change_callback([this](bool value) {
                 setWatchFilesForChanges(value);

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -401,7 +401,7 @@ ImageViewer::ImageViewer(const shared_ptr<BackgroundImagesLoader>& imagesLoader,
                 reloadAllImages();
             }, 0, tfm::format("Reload All (%s+Shift+R or %s+F5)", HelpWindow::COMMAND, HelpWindow::COMMAND)));
 
-            mWatchFilesForChangesButton = makeImageButton("W", true, {}, 0, "Watch image files for changes and reload them automatically.");
+            mWatchFilesForChangesButton = makeImageButton("W", true, {}, 0, "Watch image files and directories for changes and reload them automatically.");
             mWatchFilesForChangesButton->set_flags(Button::Flags::ToggleButton);
             mWatchFilesForChangesButton->set_change_callback([this](bool value) {
                 setWatchFilesForChanges(value);
@@ -888,6 +888,7 @@ void ImageViewer::draw_contents() {
         auto now = chrono::steady_clock::now();
         if (now - mLastFileChangesCheck > 100ms) {
             reloadImagesWhoseFileChanged();
+            mImagesLoader->checkDirectoriesForNewFilesAndLoadThose();
             mLastFileChangesCheck = now;
         }
     }

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -1158,7 +1158,6 @@ void ImageViewer::replaceImage(shared_ptr<Image> image, shared_ptr<Image> replac
 }
 
 void ImageViewer::reloadImage(shared_ptr<Image> image, bool shallSelect) {
-    int currentId = imageId(mCurrentImage);
     int id = imageId(image);
     if (id == -1) {
         return;

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -374,7 +374,7 @@ ImageViewer::ImageViewer(const shared_ptr<BackgroundImagesLoader>& imagesLoader,
         // Save, refresh, load, close
         {
             auto tools = new Widget{mSidebarLayout};
-            tools->set_layout(new GridLayout{Orientation::Horizontal, 5, Alignment::Fill, 5, 1});
+            tools->set_layout(new GridLayout{Orientation::Horizontal, 6, Alignment::Fill, 5, 1});
 
             auto makeImageButton = [&](const string& name, bool enabled, function<void()> callback, int icon = 0, string tooltip = "") {
                 auto button = new Button{tools, name, icon};
@@ -399,7 +399,13 @@ ImageViewer::ImageViewer(const shared_ptr<BackgroundImagesLoader>& imagesLoader,
 
             mAnyImageButtons.push_back(makeImageButton("A", false, [this] {
                 reloadAllImages();
-            }, FA_RECYCLE, tfm::format("Reload All (%s+Shift+R or %s+F5)", HelpWindow::COMMAND, HelpWindow::COMMAND)));
+            }, 0, tfm::format("Reload All (%s+Shift+R or %s+F5)", HelpWindow::COMMAND, HelpWindow::COMMAND)));
+
+            mWatchFilesForChangesButton = makeImageButton("W", true, [this] {}, 0, "Watch for file changes and reload automatically");
+            mWatchFilesForChangesButton->set_flags(Button::Flags::ToggleButton);
+            mWatchFilesForChangesButton->set_change_callback([this](bool value) {
+                setWatchFilesForChanges(value);
+            });
 
             mCurrentImageButtons.push_back(makeImageButton("", false, [this] {
                 auto* glfwWindow = screen()->glfw_window();
@@ -878,7 +884,7 @@ void ImageViewer::draw_contents() {
     clear();
 
     // If watching files for changes, do so every 100ms
-    if (mWatchFilesForChanges) {
+    if (watchFilesForChanges()) {
         auto now = chrono::steady_clock::now();
         if (now - mLastFileChangesCheck > 100ms) {
             reloadImagesWhoseFileChanged();
@@ -1525,13 +1531,21 @@ bool ImageViewer::setFilter(const string& filter) {
     return true;
 }
 
-bool ImageViewer::useRegex() {
+bool ImageViewer::useRegex() const {
     return mRegexButton->pushed();
 }
 
 void ImageViewer::setUseRegex(bool value) {
     mRegexButton->set_pushed(value);
     mRequiresFilterUpdate = true;
+}
+
+bool ImageViewer::watchFilesForChanges() const {
+    return mWatchFilesForChangesButton->pushed();
+}
+
+void ImageViewer::setWatchFilesForChanges(bool value) {
+    mWatchFilesForChangesButton->set_pushed(value);
 }
 
 void ImageViewer::maximize() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,6 +225,13 @@ int mainFunc(const vector<string>& arguments) {
         {'t', "tonemap"},
     };
 
+    Flag recursiveFlag{
+        parser,
+        "RECURSIVE",
+        "Recursively traverse directories when loading images from them.",
+        {'r', "recursive"},
+    };
+
     Flag versionFlag{
         parser,
         "VERSION",
@@ -328,6 +335,9 @@ int mainFunc(const vector<string>& arguments) {
     Imf::setGlobalThreadCount(thread::hardware_concurrency());
 
     shared_ptr<BackgroundImagesLoader> imagesLoader = make_shared<BackgroundImagesLoader>();
+    if (recursiveFlag) {
+        imagesLoader->setRecursiveDirectories(true);
+    }
 
     // Spawn a background thread that opens images passed via stdin.
     // To allow whitespace characters in filenames, we use the convention that

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -502,6 +502,7 @@ TEV_NAMESPACE_END
 
 #ifdef _WIN32
 int wmain(int argc, wchar_t* argv[]) {
+    SetConsoleOutputCP(CP_UTF8);
 #else
 int main(int argc, char* argv[]) {
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,6 +232,13 @@ int mainFunc(const vector<string>& arguments) {
         {'v', "version"},
     };
 
+    Flag watchFlag{
+        parser,
+        "WATCH",
+        "Watch image files for changes and automatically reload them.",
+        {'w', "watch"},
+    };
+
     PositionalList<string> imageFiles{
         parser,
         "images",
@@ -482,6 +489,7 @@ int mainFunc(const vector<string>& arguments) {
     if (metricFlag)   { sImageViewer->setMetric(toMetric(get(metricFlag))); }
     if (offsetFlag)   { sImageViewer->setOffset(get(offsetFlag)); }
     if (tonemapFlag)  { sImageViewer->setTonemap(toTonemap(get(tonemapFlag))); }
+    if (watchFlag)    { sImageViewer->setWatchFilesForChanges(true); }
 
     // Refresh only every 250ms if there are no user interactions.
     // This makes an idling tev surprisingly energy-efficient. :)


### PR DESCRIPTION
C++17's `std::filesystem` makes programming a file system watcher really simple. So this PR adds such capability to __tev__
- __tev__ can now open directories. This will load all images within the directory, optionally recursively when then `-r`/`--recursive` CLI option is present.
- __tev__ can now monitor opened files for changes and reload them, as well as monitor opened directories for new files and open those. This can be enabled by the `-w`/`--watch` CLI option and a new UI button.
- This PR also includes a fix for unicode rendering in Windows terminals.
- This PR also makes manual reloading of files (by pressing Ctrl+R / Ctrl+Shift+R or the respective UI buttons) asynchronous.