### PR TITLE
Fix black pixels upon too bright HDR colors

### DIFF
--- a/src/UberShader.cpp
+++ b/src/UberShader.cpp
@@ -170,11 +170,7 @@ UberShader::UberShader(RenderPass* renderPass) {
                         applyTonemap(applyExposureAndOffset(imageVal.rgb), vec4(checker, 1.0 - imageVal.a)),
                         1.0
                     );
-
-                    if (clipToLdr) {
-                        gl_FragColor.rgb = clamp(gl_FragColor.rgb, 0.0, 1.0);
-                    }
-
+                    gl_FragColor.rgb = clamp(gl_FragColor.rgb, clipToLdr ? 0.0 : -64.0, clipToLdr ? 1.0 : 64.0);
                     return;
                 }
 
@@ -187,9 +183,7 @@ UberShader::UberShader(RenderPass* renderPass) {
                     1.0
                 );
 
-                if (clipToLdr) {
-                    gl_FragColor.rgb = clamp(gl_FragColor.rgb, 0.0, 1.0);
-                }
+                gl_FragColor.rgb = clamp(gl_FragColor.rgb, clipToLdr ? 0.0 : -64.0, clipToLdr ? 1.0 : 64.0);
             })";
 #elif defined(NANOGUI_USE_METAL)
         auto vertexShader =
@@ -355,9 +349,7 @@ UberShader::UberShader(RenderPass* renderPass) {
                         ),
                         1.0f
                     );
-                    if (clipToLdr) {
-                        color.rgb = clamp(color.rgb, 0.0f, 1.0f);
-                    }
+                    color.rgb = clamp(color.rgb, clipToLdr ? 0.0f : -64.0f, clipToLdr ? 1.0f : 64.0f);
                     return color;
                 }
 
@@ -377,9 +369,7 @@ UberShader::UberShader(RenderPass* renderPass) {
                     ),
                     1.0f
                 );
-                if (clipToLdr) {
-                    color.rgb = clamp(color.rgb, 0.0f, 1.0f);
-                }
+                color.rgb = clamp(color.rgb, clipToLdr ? 0.0f : -64.0f, clipToLdr ? 1.0f : 64.0f);
                 return color;
             })";
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,7 +242,7 @@ int mainFunc(const vector<string>& arguments) {
     Flag watchFlag{
         parser,
         "WATCH",
-        "Watch image files for changes and automatically reload them.",
+        "Watch image files and directories for changes and automatically reload them.",
         {'w', "watch"},
     };
 


### PR DESCRIPTION
Fixes https://github.com/Tom94/tev/issues/166 by clamping shaded pixel values to [-64,64]. While this value may seem somewhat low, I've verified that it doesn't lead to visible clipping on my M1 Max macbook even at low screen brightness values coupled with high exposures. (At least this screen seems to internally cap brightness ~16).