### PR TITLE
Fix crash on Windows 8 upon displaying certain files' timestamps

### DIFF
--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -468,15 +468,11 @@ void Image::updateChannel(const string& channelName, int x, int y, int width, in
 
 template <typename T>
 time_t to_time_t(T timePoint) {
-    // TODO: clean up this mess once all compilers support clock_cast.
-#ifdef _WIN32
-    return chrono::system_clock::to_time_t(chrono::clock_cast<chrono::system_clock>(timePoint));
-#elif __APPLE__
+    // `clock_cast` appears to throw errors on some systems, so we're using this slightly hacky
+    // inaccurate/random time conversion (now() is not called simultaneously for both clocks)
+    // in order to convert to system time.
     using namespace chrono;
     return system_clock::to_time_t(time_point_cast<system_clock::duration>(timePoint - T::clock::now() + system_clock::now()));
-#else
-    return chrono::system_clock::to_time_t(T::clock::to_sys(timePoint));
-#endif
 }
 
 string Image::toString() const {


### PR DESCRIPTION
Fixes #172 