### PR TITLE
Check for __clang__ instead of __APPLE__ when including <coroutine>

### DIFF
--- a/include/tev/Task.h
+++ b/include/tev/Task.h
@@ -5,7 +5,7 @@
 
 #include <tev/Common.h>
 
-#ifdef __APPLE__
+#ifdef __clang__
 #include <experimental/coroutine>
 #define COROUTINE_NAMESPACE std::experimental
 #else


### PR DESCRIPTION
Hi Thomas!

The latest TEV does not build on Linux when using the Clang compiler (Clang 13 to be precise). Similar to when compiling on MacOS, we need to include `<experimental/coroutine>` instead of `<coroutine>`. This pull request fixes this by checking for the Clang compiler instead of the OS when including this header. I've tested this change on Ubuntu 21.10/Clang 13 and MacOS Big Sur.

Delio