### PR TITLE
Don't create duplicate images over IPC

### DIFF
--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -42,6 +42,16 @@ public:
     void insertImage(std::shared_ptr<Image> image, size_t index, bool shallSelect = false);
     void moveImageInList(size_t oldIndex, size_t newIndex);
 
+    // Returns true if the ImageViewer contains an image with the given name
+    bool hasImageWithName(const std::string& name) {
+        for (const auto& i: mImages) {
+            if (i->name() == name) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void addImage(std::shared_ptr<Image> image, bool shallSelect = false) {
         insertImage(image, mImages.size(), shallSelect);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,9 @@ void handleIpcPacket(const IpcPacket& packet, const std::shared_ptr<BackgroundIm
 
                 auto images = tryLoadImage(toPath(info.imageName), imageStream, "").get();
                 if (!images.empty()) {
-                    sImageViewer->addImage(images.front(), info.grabFocus);
+                    if (!sImageViewer->hasImageWithName(images.front()->name())) {
+                        sImageViewer->addImage(images.front(), info.grabFocus);
+                    }
                     TEV_ASSERT(images.size() == 1, "IPC CreateImage should never create more than 1 image at once.");
                 }
             });


### PR DESCRIPTION
As discussed here: https://github.com/Tom94/tev/issues/181 this PR adds a check in IPC that skips creating a new image if an image with that name already exists.