### PR TITLE
Specify UTF-8 charset for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,10 @@ if (MSVC)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
     endif()
 
+    # tev uses UTF-8 chars. Specify UTF-8 charset explicitly.
+    # "/utf-8" is equivalent to "/source-charset:utf-8 /execution-charset:utf-8".
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8")
+
     # Disable warnings that are present in dependencies and irrelevant to us
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4100") # unused arguments
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5054") # deprecated enum & operator


### PR DESCRIPTION
On Windows systems with non-English locales, the UTF-8 chars may cause "Error C2001: Newline in constant".

2 solutions:
    Save the file with UTF-8 with BOM (byte-order mark).
    Specify UTF-8 charset for compilation. Used by this commit.

See discussions here:
    https://github.com/libusb/libusb/issues/207#issuecomment-288664124