### PR TITLE
Use key Tab to show pixel raw bytes

### DIFF
--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -137,9 +137,7 @@ void ImageCanvas::drawPixelValuesAsText(NVGcontext* ctx) {
         nvgTextAlign(ctx, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
 
         auto* glfwWindow = screen()->glfw_window();
-        bool shiftAndControlHeld =
-            (glfwGetKey(glfwWindow, GLFW_KEY_LEFT_SHIFT) || glfwGetKey(glfwWindow, GLFW_KEY_RIGHT_SHIFT)) &&
-            (glfwGetKey(glfwWindow, GLFW_KEY_LEFT_CONTROL) || glfwGetKey(glfwWindow, GLFW_KEY_RIGHT_CONTROL));
+        bool tabHeld = glfwGetKey(glfwWindow, GLFW_KEY_TAB);
 
         Vector2i cur;
         vector<float> values;
@@ -154,7 +152,7 @@ void ImageCanvas::drawPixelValuesAsText(NVGcontext* ctx) {
                     string str;
                     Vector2f pos;
 
-                    if (shiftAndControlHeld) {
+                    if (tabHeld) {
                         float tonemappedValue = Channel::tail(channels[i]) == "A" ? values[i] : toSRGB(values[i]);
                         unsigned char discretizedValue = (char)(tonemappedValue * 255 + 0.5f);
                         str = fmt::format("{:02X}", discretizedValue);


### PR DESCRIPTION
Shift+Ctrl should be held to show pixel raw bytes.
But this keybinding conflicts with others, like reference image selection.
A usage case prevented by this is that: keep showing pixel raw bytes, and switch between images by number keys for comparison.

This commit changes the keybinding to Tab.
@Tom94 Maybe you want another key.
Thanks!