### PR TITLE
Permit comparison of images with mismatching channels

### DIFF
--- a/include/tev/Box.h
+++ b/include/tev/Box.h
@@ -36,6 +36,14 @@ struct Box {
         return result;
     }
 
+    bool contains(const Vector& pos) const {
+        bool result = true;
+        for (uint32_t i = 0; i < N_DIMS; ++i) {
+            result &= pos[i] >= min[i] && pos[i] < max[i];
+        }
+        return result;
+    }
+
     bool operator==(const Box& other) const {
         return min == other.min && max == other.max;
     }

--- a/include/tev/Channel.h
+++ b/include/tev/Channel.h
@@ -16,6 +16,16 @@ TEV_NAMESPACE_BEGIN
 
 class Channel {
 public:
+    static std::pair<std::string, std::string> split(const std::string& fullChannel);
+
+    static std::string tail(const std::string& fullChannel);
+    static std::string head(const std::string& fullChannel);
+
+    static bool isTopmost(const std::string& fullChannel);
+    static bool isAlpha(const std::string& fullChannel);
+
+    static nanogui::Color color(std::string fullChannel);
+
     Channel(const std::string& name, const nanogui::Vector2i& size);
 
     const std::string& name() const {
@@ -89,15 +99,6 @@ public:
     void setZero() { memset(mData.data(), 0, mData.size()*sizeof(float)); }
 
     void updateTile(int x, int y, int width, int height, const std::vector<float>& newData);
-
-    static std::pair<std::string, std::string> split(const std::string& fullChannel);
-
-    static std::string tail(const std::string& fullChannel);
-    static std::string head(const std::string& fullChannel);
-
-    static bool isTopmost(const std::string& fullChannel);
-
-    static nanogui::Color color(std::string fullChannel);
 
 private:
     std::string mName;

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -144,9 +144,14 @@ public:
 
     std::vector<std::string> channelsInGroup(const std::string& groupName) const;
     std::vector<std::string> getSortedChannels(const std::string& layerName) const;
+    std::vector<std::string> getExistingChannels(const std::vector<std::string>& requestedChannels) const;
 
     nanogui::Vector2i size() const {
         return mData.size();
+    }
+
+    bool contains(const nanogui::Vector2i& pos) const {
+        return pos.x() >= 0 && pos.y() >= 0 && pos.x() < mData.size().x() && pos.y() < mData.size().y();
     }
 
     const Box2i& dataWindow() const {

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -11,6 +11,45 @@ using namespace std;
 
 TEV_NAMESPACE_BEGIN
 
+pair<string, string> Channel::split(const string& channel) {
+    size_t dotPosition = channel.rfind(".");
+    if (dotPosition != string::npos) {
+        return {channel.substr(0, dotPosition + 1), channel.substr(dotPosition + 1)};
+    }
+
+    return {"", channel};
+}
+
+string Channel::tail(const string& channel) {
+    return split(channel).second;
+}
+
+string Channel::head(const string& channel) {
+    return split(channel).first;
+}
+
+bool Channel::isTopmost(const string& channel) {
+    return tail(channel) == channel;
+}
+
+bool Channel::isAlpha(const string& channel) {
+    return toLower(tail(channel)) == "a";
+}
+
+Color Channel::color(string channel) {
+    channel = toLower(tail(channel));
+
+    if (channel == "r") {
+        return Color(0.8f, 0.2f, 0.2f, 1.0f);
+    } else if (channel == "g") {
+        return Color(0.2f, 0.8f, 0.2f, 1.0f);
+    } else if (channel == "b") {
+        return Color(0.2f, 0.3f, 1.0f, 1.0f);
+    }
+
+    return Color(1.0f, 1.0f);
+}
+
 Channel::Channel(const std::string& name, const nanogui::Vector2i& size)
 : mName{name}, mSize{size} {
     mData.resize((size_t)mSize.x() * mSize.y());
@@ -43,41 +82,6 @@ void Channel::updateTile(int x, int y, int width, int height, const vector<float
             at({x + posX, y + posY}) = newData[posX + posY * width];
         }
     }
-}
-
-pair<string, string> Channel::split(const string& channel) {
-    size_t dotPosition = channel.rfind(".");
-    if (dotPosition != string::npos) {
-        return {channel.substr(0, dotPosition + 1), channel.substr(dotPosition + 1)};
-    }
-
-    return {"", channel};
-}
-
-string Channel::tail(const string& channel) {
-    return split(channel).second;
-}
-
-string Channel::head(const string& channel) {
-    return split(channel).first;
-}
-
-bool Channel::isTopmost(const string& channel) {
-    return tail(channel) == channel;
-}
-
-Color Channel::color(string channel) {
-    channel = toLower(tail(channel));
-
-    if (channel == "r") {
-        return Color(0.8f, 0.2f, 0.2f, 1.0f);
-    } else if (channel == "g") {
-        return Color(0.2f, 0.8f, 0.2f, 1.0f);
-    } else if (channel == "b") {
-        return Color(0.2f, 0.3f, 1.0f, 1.0f);
-    }
-
-    return Color(1.0f, 1.0f);
 }
 
 TEV_NAMESPACE_END


### PR DESCRIPTION
Compares only the matching channels and treats the mismatching channels' reference values as 0 for colors and 1 for alpha.

Also removes the (previously only partially supported) special treatment of images that only contain alpha channels. This behavior needs to be re-thought and universally implemented in the future.

Fixes #198 