### PR TITLE
Linux AppImage packaging v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,47 +249,8 @@ else()
         install(FILES resources/icon-${RES}.png DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/${RES}x${RES}/apps" RENAME tev.png)
     endforeach()
 
-    file(GENERATE
-        OUTPUT "${PROJECT_BINARY_DIR}/appimage-generate.cmake"
-        CONTENT [[
-include(CMakePrintHelpers)
-cmake_print_variables(CPACK_TEMPORARY_DIRECTORY)
-cmake_print_variables(CPACK_TOPLEVEL_DIRECTORY)
-cmake_print_variables(CPACK_PACKAGE_DIRECTORY)
-cmake_print_variables(CPACK_PACKAGE_FILE_NAME)
-
-find_program(LINUXDEPLOY_EXECUTABLE
-    NAMES linuxdeploy linuxdeploy-x86_64.AppImage
-    PATHS ${CPACK_PACKAGE_DIRECTORY}/linuxdeploy
-)
-
-if (NOT LINUXDEPLOY_EXECUTABLE)
-    message(STATUS "Downloading linuxdeploy")
-    set(LINUXDEPLOY_EXECUTABLE ${CPACK_PACKAGE_DIRECTORY}/linuxdeploy/linuxdeploy)
-    file(DOWNLOAD
-        https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-        ${LINUXDEPLOY_EXECUTABLE}
-        INACTIVITY_TIMEOUT 10
-        LOG ${CPACK_PACKAGE_DIRECTORY}/linuxdeploy/download.log
-        STATUS LINUXDEPLOY_DOWNLOAD
-    )
-    execute_process(COMMAND chmod +x ${LINUXDEPLOY_EXECUTABLE} COMMAND_ECHO STDOUT)
-endif()
-
-execute_process(COMMAND
-    ${CMAKE_COMMAND} -E env
-    OUTPUT=${CPACK_PACKAGE_FILE_NAME}.appimage
-    VERSION=$<IF:$<BOOL:${CPACK_PACKAGE_VERSION}>,${CPACK_PACKAGE_VERSION},0.1.0>
-    ${LINUXDEPLOY_EXECUTABLE}
-    --appdir=${CPACK_TEMPORARY_DIRECTORY}
-    --output=appimage
-    # --verbosity=2
-)
-    ]])
-
     list(APPEND CPACK_GENERATOR External)
-
-    set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_BINARY_DIR}/appimage-generate.cmake")
+    set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_SOURCE_DIR}/scripts/create-appimage.cmake")
     set(CPACK_EXTERNAL_ENABLE_STAGING YES)
     set(CPACK_PACKAGE_FILE_NAME ${PROJECT_NAME})
     set(CPACK_PACKAGING_INSTALL_PREFIX /usr) # requirement by AppDir specification

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ There are helper functions in [Ipc.cpp](src/Ipc.cpp) (`IpcPacket::set*`) that sh
 
 ### macOS / Windows
 
-Pre-built binaries for Windows (32-bit and 64-bit) and macOS (64-bit) are available on the [releases page](https://github.com/Tom94/tev/releases).
+Pre-built binaries for Windows (32-bit and 64-bit) and macOS (64-bit, arm) are available on the [releases page](https://github.com/Tom94/tev/releases).
 
 On macOS, __tev__ can also be installed via homebrew:
 ```bash
@@ -89,6 +89,7 @@ brew install --cask tev
 
 ### Linux
 
+- Pre-built portable Linux binaries (64-bit) are available on the [releases page](https://github.com/Tom94/tev/releases). See [how to run AppImages](https://appimage.org/).
 - Archlinux: available on the [Arch User Repository](https://aur.archlinux.org/packages/tev/)
 
 ## Building tev

--- a/scripts/create-appimage.cmake
+++ b/scripts/create-appimage.cmake
@@ -1,0 +1,34 @@
+include(CMakePrintHelpers)
+cmake_print_variables(CPACK_TEMPORARY_DIRECTORY)
+cmake_print_variables(CPACK_TOPLEVEL_DIRECTORY)
+cmake_print_variables(CPACK_PACKAGE_DIRECTORY)
+cmake_print_variables(CPACK_PACKAGE_FILE_NAME)
+cmake_print_variables(CMAKE_SYSTEM_PROCESSOR)
+cmake_print_variables(PROJECT_BINARY_DIR)
+
+find_program(LINUXDEPLOY_EXECUTABLE
+    NAMES linuxdeploy linuxdeploy-${CMAKE_SYSTEM_PROCESSOR}.AppImage
+    PATHS ${CPACK_PACKAGE_DIRECTORY}/dependencies/)
+
+if (NOT LINUXDEPLOY_EXECUTABLE)
+    message(Warning "Couldn't build linuxdeploy. Downloading pre-build binary instead.")
+    set(LINUXDEPLOY_EXECUTABLE ${CPACK_PACKAGE_DIRECTORY}/dependencies/linuxdeploy-${CMAKE_SYSTEM_PROCESSOR}.AppImage)
+    file(DOWNLOAD 
+        https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${CMAKE_SYSTEM_PROCESSOR}.AppImage
+        ${LINUXDEPLOY_EXECUTABLE}
+        INACTIVITY_TIMEOUT 10
+        LOG ${CPACK_PACKAGE_DIRECTORY}/linuxdeploy/download.log
+        STATUS LINUXDEPLOY_DOWNLOAD)
+    execute_process(COMMAND chmod +x ${LINUXDEPLOY_EXECUTABLE} COMMAND_ECHO STDOUT)
+endif()
+
+execute_process(
+COMMAND
+    ${CMAKE_COMMAND} -E env
+    OUTPUT=${CPACK_PACKAGE_FILE_NAME}.appimage
+    VERSION=${CPACK_PACKAGE_VERSION}
+    ${LINUXDEPLOY_EXECUTABLE}
+    --appdir=${CPACK_TEMPORARY_DIRECTORY}
+    --output=appimage
+    #    --verbosity=2
+)


### PR DESCRIPTION
I finally got around to finish my work on the AppImage packaging (following up on #194, #164).
This at least adds support for `x86` builds, for `arm` there are still some downstream problems (linuxdeploy/linuxdeploy#189) in `linuxdeploy` itself.

The three commits:
 1.  Cleaning up the CMake a bit by moving the CPack script to a separate file. Then using the host architecture instead of the previously hardcoded `x86_64`.
 2. & 3. are adding `linuxdeploy` (`continuous` branch) as a submodule and building it as a dependency of tev. It takes quite some additional time to build that, and some sub-sub dependencies are still being downloaded as binaries from github. 


The first commit is worth merging IMHO, the other two are up to your consideration. It *should* work on its own as well - the (potentially) downloaded binary has the same name as the one build from sources. 