### PR TITLE
Non experimental coroutines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+charset = utf-8
 trim_trailing_whitespace = true
 
 [*.yml]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
   build_macos:
     name: Build on macOS
-    runs-on: macos-11
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,10 @@ jobs:
         with:
           submodules: recursive
       - name: Build
-        run: scripts/create-dmg.sh
+        run: |
+          export CC=$(brew --prefix llvm@15)/bin/clang
+          export CXX=$(brew --prefix llvm@15)/bin/clang++
+          scripts/create-dmg.sh
       - name: Upload .dmg
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,10 +49,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build
-        run: |
-          export CC=$(brew --prefix llvm@15)/bin/clang
-          export CXX=$(brew --prefix llvm@15)/bin/clang++
-          scripts/create-dmg.sh
+        run: scripts/create-dmg.sh
       - name: Upload .dmg
         uses: actions/upload-artifact@v3
         with:

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -54,7 +54,7 @@
 
 // Make std::filesystem::path formattable.
 template <>
-struct fmt::formatter<std::filesystem::path>: formatter<std::string_view> {
+struct fmt::formatter<std::filesystem::path> : fmt::formatter<std::string_view> {
     template <typename FormatContext>
     auto format(const std::filesystem::path& path, FormatContext& ctx) {
         return formatter<std::string_view>::format(path.string(), ctx);

--- a/include/tev/ThreadPool.h
+++ b/include/tev/ThreadPool.h
@@ -55,7 +55,7 @@ public:
             bool await_ready() const noexcept { return false; }
 
             // Suspend and enqueue coroutine continuation onto the threadpool
-            void await_suspend(COROUTINE_NAMESPACE::coroutine_handle<> coroutine) noexcept {
+            void await_suspend(std::coroutine_handle<> coroutine) noexcept {
                 mPool->enqueueTask(coroutine, mPriority);
             }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -162,11 +162,11 @@ Task<void> ImageData::ensureValid(const string& channelSelector, int taskPriorit
         sort(begin(matches), end(matches));
 
         // Prune and sort channels by the channel selector
-        vector<Channel> tmp = move(channels);
+        vector<Channel> tmp = std::move(channels);
         channels.clear();
 
         for (const auto& match : matches) {
-            channels.emplace_back(move(tmp[match.second]));
+            channels.emplace_back(std::move(tmp[match.second]));
         }
 
         if (channels.empty()) {
@@ -367,7 +367,7 @@ vector<ChannelGroup> Image::getGroupedChannels(const string& layerName) const {
             name = layer + "(" + channelsString + ")";
         }
 
-        return ChannelGroup{name, move(channels)};
+        return ChannelGroup{name, std::move(channels)};
     };
 
     string alphaChannelName = layerName + "A";
@@ -403,7 +403,7 @@ vector<ChannelGroup> Image::getGroupedChannels(const string& layerName) const {
                 groupChannels.emplace_back(alphaChannelName);
             }
 
-            result.emplace_back(createChannelGroup(layerName, move(groupChannels)));
+            result.emplace_back(createChannelGroup(layerName, std::move(groupChannels)));
         }
     }
 

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -43,7 +43,7 @@ void ThreadPool::startThreads(size_t num) {
                     break;
                 }
 
-                function<void()> task{move(mTaskQueue.top().fun)};
+                function<void()> task{std::move(mTaskQueue.top().fun)};
                 mTaskQueue.pop();
 
                 // Unlock the lock, so we can process the task without blocking other threads


### PR DESCRIPTION
The latest Apple Clang no longer requires an experimental namespace around coroutines (and warns about its removal). Once GitHub's macOS CI runners get updated, this PR will be merged to squash the warnings.