### PR TITLE
Add textbox to edit image caption in the image list

### DIFF
--- a/include/tev/ImageButton.h
+++ b/include/tev/ImageButton.h
@@ -66,12 +66,14 @@ public:
 
     void showTextBox();
     void hideTextBox();
-    bool textBoxVisible() { return mCaptionTextBox->visible(); }
+
+    bool textBoxVisible() const {
+        return mCaptionTextBox->visible();
+    }
 
 private:
     std::string mCaption;
     nanogui::TextBox* mCaptionTextBox;
-
 
     bool mCanBeReference;
 

--- a/include/tev/ImageButton.h
+++ b/include/tev/ImageButton.h
@@ -6,6 +6,7 @@
 #include <tev/Common.h>
 
 #include <nanogui/widget.h>
+#include <nanogui/textbox.h>
 
 #include <string>
 
@@ -23,6 +24,14 @@ public:
 
     const std::string& caption() const {
         return mCaption;
+    }
+
+    void setCaption(const std::string& caption) {
+        mCaption = caption;
+        // Reset drawing state
+        mSizeForWhichCutoffWasComputed = {0};
+        mHighlightBegin = 0;
+        mHighlightEnd = 0;
     }
 
     void setReferenceCallback(const std::function<void(bool)> &callback) {
@@ -55,8 +64,15 @@ public:
 
     void setHighlightRange(size_t begin, size_t end);
 
+    void showTextBox();
+    void hideTextBox();
+    bool textBoxVisible() { return mCaptionTextBox->visible(); }
+
 private:
     std::string mCaption;
+    nanogui::TextBox* mCaptionTextBox;
+
+
     bool mCanBeReference;
 
     bool mIsReference = false;

--- a/include/tev/ImageButton.h
+++ b/include/tev/ImageButton.h
@@ -32,6 +32,10 @@ public:
         mSizeForWhichCutoffWasComputed = {0};
         mHighlightBegin = 0;
         mHighlightEnd = 0;
+
+        if (mCaptionChangeCallback) {
+            mCaptionChangeCallback();
+        }
     }
 
     void setReferenceCallback(const std::function<void(bool)> &callback) {
@@ -48,6 +52,10 @@ public:
 
     void setSelectedCallback(const std::function<void()> &callback) {
         mSelectedCallback = callback;
+    }
+
+    void setCaptionChangeCallback(const std::function<void()> &callback) {
+        mCaptionChangeCallback = callback;
     }
 
     void setIsSelected(bool isSelected) {
@@ -82,6 +90,8 @@ private:
 
     bool mIsSelected = false;
     std::function<void()> mSelectedCallback;
+
+    std::function<void()> mCaptionChangeCallback;
 
     size_t mId = 0;
     size_t mCutoff = 0;

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -104,6 +104,7 @@ public:
     void setGamma(float value);
 
     void normalizeExposureAndOffset();
+
     void resetImage();
 
     ETonemap tonemap() const {

--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -100,6 +100,11 @@ HelpWindow::HelpWindow(Widget* parent, bool supportsHdr, function<void()> closeC
 
     addRow(imageSelection, "B (hold)",          "Draw a border around the image");
     addRow(imageSelection, "Shift+Ctrl (hold)", "Display raw bytes on pixels when zoomed-in");
+#ifdef __APPLE__
+    addRow(imageSelection, "Enter", "Rename the image");
+#else
+    addRow(imageSelection, "F2", "Rename the image");
+#endif
 
     new Label{shortcuts, "Reference options", "sans-bold", 18};
     auto referenceSelection = new Widget{shortcuts};

--- a/src/ImageButton.cpp
+++ b/src/ImageButton.cpp
@@ -4,6 +4,8 @@
 #include <tev/ImageButton.h>
 
 #include <nanogui/opengl.h>
+#include <nanogui/layout.h>
+#include <nanogui/theme.h>
 
 #include <cctype>
 
@@ -14,9 +16,24 @@ namespace tev {
 
 ImageButton::ImageButton(Widget *parent, const string &caption, bool canBeReference)
 : Widget{parent}, mCaption{caption}, mCanBeReference{canBeReference} {
+    this->set_layout(new BoxLayout{Orientation::Vertical, Alignment::Fill});
+    mCaptionTextBox = new TextBox{this, ""};
+    mCaptionTextBox->set_visible(false);
+    mCaptionTextBox->set_editable(true);
+    mCaptionTextBox->set_alignment(TextBox::Alignment::Right);
+    mCaptionTextBox->set_placeholder("Enter caption");
+    mCaptionTextBox->set_callback([this](const string& name) {
+        this->setCaption(name);
+        this->hideTextBox();
+        return true;
+    });
 }
 
 Vector2i ImageButton::preferred_size(NVGcontext *ctx) const {
+    nanogui::Theme* theme = new nanogui::Theme(ctx);
+    theme->m_text_box_font_size = m_font_size + 2;
+    mCaptionTextBox->set_theme(theme);
+
     nvgFontSize(ctx, m_font_size);
     nvgFontFace(ctx, "sans-bold");
     string idString = to_string(mId);
@@ -82,6 +99,9 @@ bool ImageButton::mouse_button_event(const Vector2i &p, int button, bool down, i
 void ImageButton::draw(NVGcontext *ctx) {
     Widget::draw(ctx);
 
+    if (mCaptionTextBox->visible())
+        return;
+
     if (mIsReference) {
         nvgBeginPath(ctx);
         nvgRect(ctx, m_pos.x(), m_pos.y(), m_size.x(), m_size.y());
@@ -102,7 +122,6 @@ void ImageButton::draw(NVGcontext *ctx) {
         nvgFillColor(ctx, mIsSelected ? IMAGE_COLOR : Color(1.0f, 0.1f));
         nvgFill(ctx);
     }
-
 
     string idString = to_string(mId);
 
@@ -207,6 +226,17 @@ void ImageButton::setHighlightRange(size_t begin, size_t end) {
             ++mHighlightEnd;
         }
     }
+}
+
+void ImageButton::showTextBox() {
+    mCaptionTextBox->set_visible(true);
+    mCaptionTextBox->request_focus();
+}
+
+void ImageButton::hideTextBox() {
+    mCaptionTextBox->set_value("");
+    mCaptionTextBox->set_focused(false);
+    mCaptionTextBox->set_visible(false);
 }
 
 }

--- a/src/ImageButton.cpp
+++ b/src/ImageButton.cpp
@@ -17,13 +17,12 @@ namespace tev {
 ImageButton::ImageButton(Widget *parent, const string &caption, bool canBeReference)
 : Widget{parent}, mCaption{caption}, mCanBeReference{canBeReference} {
     this->set_layout(new BoxLayout{Orientation::Vertical, Alignment::Fill});
-    mCaptionTextBox = new TextBox{this, ""};
+    mCaptionTextBox = new TextBox{this, caption};
     mCaptionTextBox->set_visible(false);
     mCaptionTextBox->set_editable(true);
     mCaptionTextBox->set_alignment(TextBox::Alignment::Right);
-    mCaptionTextBox->set_placeholder("Enter caption");
+    mCaptionTextBox->set_placeholder(caption);
     mCaptionTextBox->set_callback([this](const string& name) {
-        this->setCaption(name);
         this->hideTextBox();
         return true;
     });
@@ -42,6 +41,7 @@ Vector2i ImageButton::preferred_size(NVGcontext *ctx) const {
     nvgFontSize(ctx, m_font_size);
     nvgFontFace(ctx, "sans");
     float tw = nvgTextBounds(ctx, 0, 0, mCaption.c_str(), nullptr, nullptr);
+
     return Vector2i(static_cast<int>(tw + idSize) + 15, m_font_size + 6);
 }
 
@@ -231,11 +231,16 @@ void ImageButton::setHighlightRange(size_t begin, size_t end) {
 void ImageButton::showTextBox() {
     mCaptionTextBox->set_visible(true);
     mCaptionTextBox->request_focus();
+    mCaptionTextBox->select_all();
 }
 
 void ImageButton::hideTextBox() {
-    mCaptionTextBox->set_value("");
+    if (!textBoxVisible()) {
+        return;
+    }
+
     mCaptionTextBox->set_focused(false);
+    this->setCaption(mCaptionTextBox->value());
     mCaptionTextBox->set_visible(false);
 }
 

--- a/src/ImageButton.cpp
+++ b/src/ImageButton.cpp
@@ -26,11 +26,14 @@ ImageButton::ImageButton(Widget *parent, const string &caption, bool canBeRefere
         this->hideTextBox();
         return true;
     });
+    mCaptionTextBox->set_corner_radius(0.0f);
+    mCaptionTextBox->set_solid_color(IMAGE_COLOR);
 }
 
 Vector2i ImageButton::preferred_size(NVGcontext *ctx) const {
     nanogui::Theme* theme = new nanogui::Theme(ctx);
-    theme->m_text_box_font_size = m_font_size + 2;
+    theme->m_text_box_font_size = m_font_size;
+    theme->m_text_color = Color(255, 255);
     mCaptionTextBox->set_theme(theme);
 
     nvgFontSize(ctx, m_font_size);

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -1060,6 +1060,10 @@ void ImageViewer::insertImage(shared_ptr<Image> image, size_t index, bool shallS
         }
     });
 
+    button->setCaptionChangeCallback([this]() {
+        mRequiresFilterUpdate = true;
+    });
+
     mImageButtonContainer->add_child((int)index, button);
     mImages.insert(begin(mImages) + index, image);
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -450,20 +450,6 @@ ImageViewer::ImageViewer(const shared_ptr<BackgroundImagesLoader>& imagesLoader,
 bool ImageViewer::mouse_button_event(const nanogui::Vector2i &p, int button, bool down, int modifiers) {
     redraw();
 
-    // Hide caption textbox when the user performed mousedown on any other component
-    if (down) {
-        nanogui::Vector2i relMousePos = (absolute_position() + p) - mImageButtonContainer->absolute_position();
-        auto& buttons = mImageButtonContainer->children();
-        for (size_t i = 0; i < buttons.size(); ++i) {
-            ImageButton* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
-            if (!imgButton->contains(relMousePos)) {
-                imgButton->hideTextBox();
-            } else if (imgButton->textBoxVisible()) {
-                return true;
-            }
-        }
-    }
-
     // Check if the user performed mousedown on an imagebutton so we can mark it as being dragged.
     // This has to occur before Screen::mouse_button_event as the button would absorb the event.
     if (down) {
@@ -474,7 +460,7 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i &p, int button, boo
 
             for (size_t i = 0; i < buttons.size(); ++i) {
                 const auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
-                if (imgButton->contains(relMousePos)) {
+                if (imgButton->contains(relMousePos) && !imgButton->textBoxVisible()) {
                     mDraggedImageButtonId = i;
                     mIsDraggingImageButton = true;
                     mDraggingStartPosition = nanogui::Vector2f(relMousePos - imgButton->position());
@@ -486,6 +472,13 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i &p, int button, boo
 
     if (Screen::mouse_button_event(p, button, down, modifiers)) {
         return true;
+    }
+
+    // Hide caption textbox when the user performed mousedown on any other component
+    if (down) {
+        for (auto& b : mImageButtonContainer->children()) {
+            dynamic_cast<ImageButton*>(b)->hideTextBox();
+        }
     }
 
     if (down && !mIsDraggingImageButton) {


### PR DESCRIPTION
# Overview

This PR adds the ability to edit the caption of the selected image in the image list via a new textbox added to the GUI.

![image](https://user-images.githubusercontent.com/6662561/233288342-c160e9ae-5554-4c59-84dd-761625b60c47.png)

A keybinding for the `Enter` key was added to trigger the focus on the caption text box for users to quickly annotate different images in the list. We also ensure that captions are preserved when reloading an image.

## Example

The following screencast showcases this new feature:

https://user-images.githubusercontent.com/6662561/233287487-238a572e-e0dd-4f35-8934-c159fc3b5899.mov

