### PR TITLE
WIP: Statistics only over selected regions of the image

### DIFF
--- a/include/tev/Box.h
+++ b/include/tev/Box.h
@@ -54,6 +54,10 @@ struct Box {
         return {nanogui::max(min, other.min), nanogui::min(max, other.max)};
     }
 
+    Box translate(const Vector& offset) const {
+        return {min + offset, max + offset};
+    }
+
     bool operator==(const Box& other) const {
         return min == other.min && max == other.max;
     }

--- a/include/tev/Box.h
+++ b/include/tev/Box.h
@@ -5,7 +5,6 @@
 
 #include <tev/Common.h>
 
-
 namespace tev {
 
 template <typename T, uint32_t N_DIMS>
@@ -20,8 +19,15 @@ struct Box {
     template <typename U>
     Box(const Box<U, N_DIMS>& other) : min{other.min}, max{other.max} {}
 
+    Box(const std::vector<Vector>& points) : Box() {
+        for (const auto& point : points) {
+            min = nanogui::min(min, point);
+            max = nanogui::max(max, point);
+        }
+    }
+
     Vector size() const {
-        return max - min;
+        return nanogui::max(max - min, Vector{(T)0});
     }
 
     Vector middle() const {
@@ -42,6 +48,10 @@ struct Box {
             result &= pos[i] >= min[i] && pos[i] < max[i];
         }
         return result;
+    }
+
+    Box intersect(const Box& other) const {
+        return {nanogui::max(min, other.min), nanogui::min(max, other.max)};
     }
 
     bool operator==(const Box& other) const {

--- a/include/tev/Box.h
+++ b/include/tev/Box.h
@@ -81,6 +81,12 @@ struct Box {
     Vector min, max;
 };
 
+template <typename Stream, typename T, uint32_t N_DIMS, std::enable_if_t<std::is_base_of_v<std::ostream, Stream>, int> = 0>
+Stream& operator<<(Stream& os, const Box<T, N_DIMS>& v) {
+    os << '[' << v.min << ", " << v.max << ']';
+    return os;
+}
+
 using Box2f = Box<float, 2>;
 using Box3f = Box<float, 3>;
 using Box4f = Box<float, 4>;

--- a/include/tev/Box.h
+++ b/include/tev/Box.h
@@ -50,6 +50,18 @@ struct Box {
         return result;
     }
 
+    bool contains_inclusive(const Vector& pos) const {
+        bool result = true;
+        for (uint32_t i = 0; i < N_DIMS; ++i) {
+            result &= pos[i] >= min[i] && pos[i] <= max[i];
+        }
+        return result;
+    }
+
+    bool contains(const Box& other) const {
+        return contains_inclusive(other.min) && contains_inclusive(other.max);
+    }
+
     Box intersect(const Box& other) const {
         return {nanogui::max(min, other.min), nanogui::min(max, other.max)};
     }

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -396,5 +396,6 @@ void redrawWindow();
 
 static const nanogui::Color IMAGE_COLOR = {0.35f, 0.35f, 0.8f, 1.0f};
 static const nanogui::Color REFERENCE_COLOR = {0.7f, 0.4f, 0.4f, 1.0f};
+static const nanogui::Color CROP_COLOR = {0.2f, 0.5f, 0.2f, 1.0f};
 
 }

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -97,24 +97,7 @@ public:
     }
 
     void setCrop(const std::optional<Box2i>& crop) {
-        if (!crop.has_value()) {
-            mCrop = std::nullopt;
-            return;
-        }
-
-        // sanitize the input crop
-        Box2i clean;
-        for (size_t dim = 0; dim < clean.min.Size; dim++) {
-            // order input crop, add one to maximum to make box inclusive
-            clean.min[dim] = std::min(crop->min[dim], crop->max[dim]);
-            clean.max[dim] = std::max(crop->min[dim], crop->max[dim]) + 1;
-
-            // clamp to image extents
-            clean.min[dim] = std::max(0, std::min(mImage->size()[dim], clean.min[dim]));
-            clean.max[dim] = std::max(0, std::min(mImage->size()[dim], clean.max[dim]));
-        }
-
-        mCrop = clean;
+        mCrop = crop;
     }
 
     std::optional<Box2i> getCrop() {

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -55,11 +55,6 @@ public:
     float applyExposureAndOffset(float value) const;
 
     void setImage(std::shared_ptr<Image> image) {
-        if (!mImage || !image || mImage->size() != image->size()) {
-            // only keep crop active if image resolution has stayed the same
-            setCrop(std::nullopt);
-        }
-
         mImage = image;
     }
 
@@ -106,19 +101,19 @@ public:
             mCrop = std::nullopt;
             return;
         }
-        
+
         // sanitize the input crop
         Box2i clean;
         for (size_t dim = 0; dim < clean.min.Size; dim++) {
             // order input crop, add one to maximum to make box inclusive
             clean.min[dim] = std::min(crop->min[dim], crop->max[dim]);
             clean.max[dim] = std::max(crop->min[dim], crop->max[dim]) + 1;
-            
+
             // clamp to image extents
             clean.min[dim] = std::max(0, std::min(mImage->size()[dim], clean.min[dim]));
             clean.max[dim] = std::max(0, std::min(mImage->size()[dim], clean.max[dim]));
         }
-        
+
         mCrop = clean;
     }
 

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -67,6 +67,7 @@ public:
     }
 
     nanogui::Vector2i getImageCoords(const Image& image, nanogui::Vector2i mousePos);
+    nanogui::Vector2i getDisplayWindowCoords(const Image& image, nanogui::Vector2i mousePos);
 
     void getValuesAtNanoPos(nanogui::Vector2i nanoPos, std::vector<float>& result, const std::vector<std::string>& channels);
     std::vector<float> getValuesAtNanoPos(nanogui::Vector2i nanoPos, const std::vector<std::string>& channels) {

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <tev/UberShader.h>
+#include <tev/Box.h>
 #include <tev/Image.h>
 #include <tev/Lazy.h>
-#include <tev/Box.h>
+#include <tev/UberShader.h>
 
 #include <nanogui/canvas.h>
 

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -94,6 +94,34 @@ public:
         mMetric = metric;
     }
 
+    bool isCropped() const {
+        return mIsCropped;
+    }
+
+    void enableCrop() {
+        mIsCropped = true;
+    }
+
+    void disableCrop() {
+        mIsCropped = false;
+    }
+
+    nanogui::Vector2i cropMin() const {
+        return mCropMin;
+    }
+
+    void setCropMin(const nanogui::Vector2i &cropMin) {
+        mCropMin = cropMin;
+    }
+
+    nanogui::Vector2i cropMax() const {
+        return mCropMin;
+    }
+
+    void setCropMax(const nanogui::Vector2i &cropMax) {
+        mCropMax = cropMax;
+    }
+
     static float applyMetric(float value, float reference, EMetric metric);
     float applyMetric(float value, float reference) const {
         return applyMetric(value, reference, mMetric);
@@ -141,6 +169,9 @@ private:
         std::shared_ptr<Image> reference,
         const std::string& requestedChannelGroup,
         EMetric metric,
+        bool isCropped,
+        nanogui::Vector2i cropMin,
+        nanogui::Vector2i cropMax,
         int priority
     );
 
@@ -174,6 +205,9 @@ private:
 
     ETonemap mTonemap = SRGB;
     EMetric mMetric = Error;
+    bool mIsCropped = false;
+    nanogui::Vector2i mCropMin;
+    nanogui::Vector2i mCropMax;
 
     std::map<std::string, std::shared_ptr<Lazy<std::shared_ptr<CanvasStatistics>>>> mCanvasStatistics;
     std::map<int, std::vector<std::string>> mImageIdToCanvasStatisticsKey;

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -255,6 +255,7 @@ private:
     bool mIsDraggingSidebar = false;
     bool mIsDraggingImage = false;
     bool mIsDraggingImageButton = false;
+    bool mIsCroppingImage = false;
     size_t mDraggedImageButtonId;
 
     nanogui::Vector2f mDraggingStartPosition;

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -258,6 +258,7 @@ private:
     bool mIsCroppingImage = false;
     size_t mDraggedImageButtonId;
 
+    nanogui::Vector2i mCroppingStartCoordinates;
     nanogui::Vector2f mDraggingStartPosition;
 
     size_t mClipboardIndex = 0;

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -259,7 +259,7 @@ private:
     size_t mDraggedImageButtonId;
 
     nanogui::Vector2i mCroppingStartCoordinates;
-    nanogui::Vector2f mDraggingStartPosition;
+    nanogui::Vector2i mDraggingStartPosition;
 
     size_t mClipboardIndex = 0;
 

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -252,14 +252,17 @@ private:
 
     HelpWindow* mHelpWindow = nullptr;
 
-    bool mIsDraggingSidebar = false;
-    bool mIsDraggingImage = false;
-    bool mIsDraggingImageButton = false;
-    bool mIsCroppingImage = false;
-    size_t mDraggedImageButtonId;
+    enum class EMouseDragType {
+        None,
+        ImageDrag,
+        ImageCrop,
+        ImageButtonDrag,
+        SidebarDrag,
+    };
 
-    nanogui::Vector2i mCroppingStartCoordinates;
     nanogui::Vector2i mDraggingStartPosition;
+    EMouseDragType mDragType = EMouseDragType::None;
+    size_t mDraggedImageButtonId;
 
     size_t mClipboardIndex = 0;
 

--- a/include/tev/UberShader.h
+++ b/include/tev/UberShader.h
@@ -27,7 +27,10 @@ public:
         float offset,
         float gamma,
         bool clipToLdr,
-        ETonemap tonemap
+        ETonemap tonemap,
+        bool isCropped,
+        const nanogui::Vector2f& cropMin,
+        const nanogui::Vector2f& cropMax
     );
 
     // Draws a difference between a reference and an image.
@@ -43,7 +46,10 @@ public:
         float gamma,
         bool clipToLdr,
         ETonemap tonemap,
-        EMetric metric
+        EMetric metric,
+        bool isCropped,
+        const nanogui::Vector2f& cropMin,
+        const nanogui::Vector2f& cropMax
     );
 
     const nanogui::Color& backgroundColor() {

--- a/include/tev/UberShader.h
+++ b/include/tev/UberShader.h
@@ -8,6 +8,7 @@
 #include <nanogui/vector.h>
 
 #include <tev/Box.h>
+#include <optional>
 
 namespace tev {
 

--- a/include/tev/UberShader.h
+++ b/include/tev/UberShader.h
@@ -3,11 +3,12 @@
 
 #pragma once
 
+#include <tev/Box.h>
+
 #include <nanogui/shader.h>
 #include <nanogui/texture.h>
 #include <nanogui/vector.h>
 
-#include <tev/Box.h>
 #include <optional>
 
 namespace tev {

--- a/include/tev/UberShader.h
+++ b/include/tev/UberShader.h
@@ -7,6 +7,8 @@
 #include <nanogui/texture.h>
 #include <nanogui/vector.h>
 
+#include <tev/Box.h>
+
 namespace tev {
 
 class UberShader {
@@ -28,9 +30,7 @@ public:
         float gamma,
         bool clipToLdr,
         ETonemap tonemap,
-        bool isCropped,
-        const nanogui::Vector2f& cropMin,
-        const nanogui::Vector2f& cropMax
+        const std::optional<Box2i>& crop
     );
 
     // Draws a difference between a reference and an image.
@@ -47,9 +47,7 @@ public:
         bool clipToLdr,
         ETonemap tonemap,
         EMetric metric,
-        bool isCropped,
-        const nanogui::Vector2f& cropMin,
-        const nanogui::Vector2f& cropMax
+        const std::optional<Box2i>& crop
     );
 
     const nanogui::Color& backgroundColor() {

--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -83,7 +83,7 @@ HelpWindow::HelpWindow(Widget* parent, bool supportsHdr, function<void()> closeC
     addRow(imageSelection, "Space",                                             "Toggle playback of images as video");
 
     addRow(imageSelection, "Click & Drag (+Shift/" + COMMAND + ")",   "Translate image");
-    addRow(imageSelection, "Click & Drag+" + ALT,                     "Select region of histogram");
+    addRow(imageSelection, "Click & Drag+C (hold)",                   "Select region of histogram");
     addRow(imageSelection, "+ / - / Scroll (+Shift/" + COMMAND + ")", "Zoom in / out of image");
 
     addRow(imageSelection, COMMAND + "+0", "Zoom to actual size");
@@ -111,7 +111,7 @@ HelpWindow::HelpWindow(Widget* parent, bool supportsHdr, function<void()> closeC
     auto referenceSelection = new Widget{shortcuts};
     referenceSelection->set_layout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 0, 0});
 
-    addRow(referenceSelection, ALT + " (hold)",                               "View currently selected reference");
+    addRow(referenceSelection, "Shift (hold)",                                "View currently selected reference");
     addRow(referenceSelection, "Shift+Left Click or Right Click",             "Select hovered image as reference");
     addRow(referenceSelection, "Shift+1…9",                                   "Select N-th image as reference");
     addRow(referenceSelection, "Shift+Down or Shift+S / Shift+Up or Shift+W", "Select next / previous image as reference");

--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -82,7 +82,8 @@ HelpWindow::HelpWindow(Widget* parent, bool supportsHdr, function<void()> closeC
     addRow(imageSelection, "Home / End",                                        "Select first / last image");
     addRow(imageSelection, "Space",                                             "Toggle playback of images as video");
 
-    addRow(imageSelection, "Click & Drag (+Shift/" + COMMAND + ")", "Translate image");
+    addRow(imageSelection, "Click & Drag (+Shift/" + COMMAND + ")",   "Translate image");
+    addRow(imageSelection, "Click & Drag+" + ALT,                     "Select region of histogram");
     addRow(imageSelection, "+ / - / Scroll (+Shift/" + COMMAND + ")", "Zoom in / out of image");
 
     addRow(imageSelection, COMMAND + "+0", "Zoom to actual size");

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -851,6 +851,8 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
     const Box2i& region,
     int priority
 ) {
+    TEV_ASSERT(Box2i{image->size()}.contains(region), "Region must be contained in image.");
+
     auto flattened = channelsFromImages(image, reference, requestedChannelGroup, metric, priority);
 
     double mean = 0;
@@ -892,7 +894,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
         }
     }
 
-    result->mean = pixelCount > 0 ? float(mean / pixelCount) : 0;
+    result->mean = pixelCount > 0 ? (float)(mean / pixelCount) : 0;
     result->maximum = maximum;
     result->minimum = minimum;
 
@@ -929,7 +931,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
     }
 
     auto regionSize = region.size();
-    auto numPixels = size_t(regionSize.x()) * size_t(regionSize.y());
+    auto numPixels = (size_t)regionSize.x() * regionSize.y();
     std::vector<int> indices(numPixels * nChannels);
 
     vector<Task<void>> tasks;

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -922,7 +922,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
         tasks.emplace_back(
             ThreadPool::global().parallelForAsync<size_t>(0, numPixels, [&, i](size_t j) {
                 int x = (j % regionSize.x()) + region.min.x();
-                int y = (j / regionSize.y()) + region.min.y();
+                int y = (j / regionSize.x()) + region.min.y();
                 indices[j + i * numPixels] = valToBin(channel.at(Vector2i{x, y}));
             }, priority)
         );

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -69,7 +69,7 @@ void ImageCanvas::draw_contents() {
         mShader->draw(
             2.0f * inverse(Vector2f{m_size}) / mPixelRatio,
             Vector2f{20.0f},
-            image->texture(mRequestedChannelGroup),
+            image->texture(mImage->channelsInGroup(mRequestedChannelGroup)),
             // The uber shader operates in [-1, 1] coordinates and requires the _inserve_
             // image transform to obtain texture coordinates in [0, 1]-space.
             inverse(transform(image)),

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -758,10 +758,10 @@ shared_ptr<Lazy<shared_ptr<CanvasStatistics>>> ImageCanvas::canvasStatistics() {
     // the crop window to the image's data window for canvas statistics computation.
     Box2i region = image->dataWindow();
     if (mCrop.has_value()) {
-        region = region.intersect(mCrop.value());
+        region = region.intersect(mCrop.value().translate(image->displayWindow().min));
     }
 
-    region = region.translate(image->displayWindow().min - image->dataWindow().min);
+    region = region.translate(-image->dataWindow().min);
 
     invokeTaskDetached([
         image, reference, requestedChannelGroup, metric,
@@ -769,8 +769,7 @@ shared_ptr<Lazy<shared_ptr<CanvasStatistics>>> ImageCanvas::canvasStatistics() {
     ]() mutable -> Task<void> {
         co_await ThreadPool::global().enqueueCoroutine(priority);
         p.set_value(co_await computeCanvasStatistics(
-            image, reference, requestedChannelGroup, metric,
-            region, priority
+            image, reference, requestedChannelGroup, metric, region, priority
         ));
     });
 

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -739,12 +739,9 @@ shared_ptr<Lazy<shared_ptr<CanvasStatistics>>> ImageCanvas::canvasStatistics() {
         mReference->setStaleIdCallback([this](int id) { purgeCanvasStatistics(id); });
     }
 
-    Box2i region;
+    Box2i region = {image->size()};
     if (mCrop.has_value()) {
-        region = mCrop.value();
-    } else {
-        region.min = Vector2i{0};
-        region.max = image->size();
+        region = region.intersect(mCrop.value());
     }
 
     invokeTaskDetached([

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -215,8 +215,8 @@ void ImageCanvas::drawCoordinateSystem(NVGcontext* ctx) {
         nvgFontSize(ctx, fontSize);
         nvgTextAlign(ctx, (right ? NVG_ALIGN_RIGHT : NVG_ALIGN_LEFT) | (top ? NVG_ALIGN_BOTTOM : NVG_ALIGN_TOP));
         float textWidth = nvgTextBounds(ctx, 0, 0, name.c_str(), nullptr, nullptr);
-        float textAlpha = max(min(1.0f, (((topRight.x() - topLeft.x()) / textWidth) - 2.0f)), 0.0f);
-        float regionAlpha = max(min(1.0f, (((topRight.x() - topLeft.x()) / textWidth) - 1.5f) * 2), 0.0f);
+        float textAlpha = max(min(1.0f, (((topRight.x() - topLeft.x() - textWidth - 5) / 30))), 0.0f);
+        float regionAlpha = max(min(1.0f, (((topRight.x() - topLeft.x() - textWidth - 5) / 30))), 0.0f);
 
         Color textColor = Color(190, 255);
         textColor.a() = textAlpha;
@@ -278,6 +278,9 @@ void ImageCanvas::drawCoordinateSystem(NVGcontext* ctx) {
             drawWindow(mImage->displayWindow(), Color(0.3f, 1.0f), mImage->displayWindow().min.y() <= mImage->dataWindow().min.y(), false, "", flags);
         }
 
+        if (mCrop.has_value()) {
+            drawWindow(mCrop.value(), CROP_COLOR, false, false, "Stats crop", flags);
+        }
     };
 
     // Draw all labels after the regions to ensure no occlusion
@@ -439,6 +442,7 @@ void ImageCanvas::draw(NVGcontext* ctx) {
         // If the coordinate system is in any sort of way non-trivial, or if a hotkey is held, draw it!
         if (
             glfwGetKey(screen()->glfw_window(), GLFW_KEY_B) ||
+            mCrop.has_value() ||
             mImage->dataWindow() != mImage->displayWindow() ||
             mImage->displayWindow().min != Vector2i{0} ||
             (mReference && (mReference->dataWindow() != mImage->dataWindow() || mReference->displayWindow() != mImage->displayWindow()))

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -877,21 +877,20 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
 
     int nChannels = result->nChannels = alphaChannel ? (int)flattened.size() - 1 : (int)flattened.size();
 
-    if (!isCropped) {
+    if (isCropped) {
+        cropMin = {
+            clamp(cropMin.x(), 0, image->size().x()),
+            clamp(cropMin.y(), 0, image->size().y())
+        };
+        cropMax = {
+            clamp(cropMax.x(), 0, image->size().x()),
+            clamp(cropMax.y(), 0, image->size().y())
+        };
+    } else {
         cropMin = Vector2i(0, 0);
         cropMax = image->size();
     }
 
-    cropMin = {
-        clamp(cropMin.x(), 0, image->size().x()),
-        clamp(cropMin.y(), 0, image->size().y())
-    };
-    cropMax = {
-        clamp(cropMax.x(), 0, image->size().x()),
-        clamp(cropMax.y(), 0, image->size().y())
-    };
-
-    int stride = image->size().x();
     int pixelCount = 0;
     for (int i = 0; i < nChannels; ++i) {
         const auto& channel = flattened[i];
@@ -945,7 +944,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
     }
 
     auto cropSize = cropMax - cropMin;
-    auto numPixels = cropSize.x() * cropSize.y();
+    auto numPixels = size_t(cropSize.x()) * size_t(cropSize.y());
     std::vector<int> indices(numPixels * nChannels);
 
     vector<Task<void>> tasks;

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -48,9 +48,15 @@ bool ImageCanvas::scroll_event(const Vector2i& p, const Vector2f& rel) {
 
 void ImageCanvas::draw_contents() {
     auto* glfwWindow = screen()->glfw_window();
-    bool altHeld = glfwGetKey(glfwWindow, GLFW_KEY_LEFT_ALT) || glfwGetKey(glfwWindow, GLFW_KEY_RIGHT_ALT);
-    bool ctrlHeld = glfwGetKey(glfwWindow, GLFW_KEY_LEFT_CONTROL) || glfwGetKey(glfwWindow, GLFW_KEY_RIGHT_CONTROL);
-    Image* image = (mReference && altHeld) ? mReference.get() : mImage.get();
+    bool viewReferenceOnly = glfwGetKey(glfwWindow, GLFW_KEY_LEFT_SHIFT) || glfwGetKey(glfwWindow, GLFW_KEY_RIGHT_SHIFT);
+    bool viewImageOnly = glfwGetKey(glfwWindow, GLFW_KEY_LEFT_CONTROL) || glfwGetKey(glfwWindow, GLFW_KEY_RIGHT_CONTROL);
+    if (viewReferenceOnly && viewImageOnly) {
+        // If both modifiers are pressed at the same time, we want entirely different behavior from
+        // modifying which image is shown. Do nothing here.
+        viewReferenceOnly = viewImageOnly = false;
+    }
+
+    Image* image = (mReference && viewReferenceOnly) ? mReference.get() : mImage.get();
 
     if (!image) {
         mShader->draw(
@@ -65,7 +71,7 @@ void ImageCanvas::draw_contents() {
         imageSpaceCrop = mCrop.value().translate(image->displayWindow().min - image->dataWindow().min);
     }
 
-    if (!mReference || ctrlHeld || image == mReference.get()) {
+    if (!mReference || viewImageOnly || image == mReference.get()) {
         mShader->draw(
             2.0f * inverse(Vector2f{m_size}) / mPixelRatio,
             Vector2f{20.0f},

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -837,7 +837,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
 ) {
     auto flattened = channelsFromImages(image, reference, requestedChannelGroup, metric, priority);
 
-    float mean = 0;
+    double mean = 0;
     float maximum = -numeric_limits<float>::infinity();
     float minimum = numeric_limits<float>::infinity();
 
@@ -876,7 +876,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
         }
     }
 
-    result->mean = pixelCount > 0 ? (mean / pixelCount) : 0;
+    result->mean = pixelCount > 0 ? float(mean / pixelCount) : 0;
     result->maximum = maximum;
     result->minimum = minimum;
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -524,7 +524,7 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i &p, int button, boo
                     // alt/option + left drag to crop
                     auto rel = mouse_pos() - mImageCanvas->position();
                     auto imageCoords = mImageCanvas->getImageCoords(*mCurrentImage, {rel.x(), rel.y()});
-                    
+
                     mIsCroppingImage = true;
                     mCroppingStartCoordinates = imageCoords;
                     mImageCanvas->setCrop(std::nullopt); // single click disables crop
@@ -622,9 +622,13 @@ bool ImageViewer::mouse_motion_event(
     } else if (mIsCroppingImage) {
         auto relMousePos = mouse_pos() - mImageCanvas->position();
         auto imageCoords = mImageCanvas->getImageCoords(*mCurrentImage, {relMousePos.x(), relMousePos.y()});
-        
+
+        // sanitize the input crop
+        Box2i crop = {{mCroppingStartCoordinates, imageCoords}};
+        crop.max += Vector2i{1};
+
         // we do not need to worry about min/max ordering here, as setCrop sanitizes the input for us
-        mImageCanvas->setCrop(Box2i{mCroppingStartCoordinates, imageCoords});
+        mImageCanvas->setCrop(crop);
     }
 
     return false;

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -615,6 +615,14 @@ bool ImageViewer::mouse_motion_event(
         Vector2i relStartMousePos = (absolute_position() + mDraggingStartPosition) - mImageCanvas->absolute_position();
         Vector2i relMousePos = (absolute_position() + p) - mImageCanvas->absolute_position();
 
+        // Require a minimum movement of 3 (nanogui space) pixels to start cropping.
+        // Since this is measured in nanogui / screen space and not image space, this
+        // does not prevent the cropping of smaller image regions. Just zoom in before
+        // cropping smaller regions than 3 image pixels.
+        if (norm(relStartMousePos - relMousePos) < 3) {
+            return false;
+        }
+
         auto startImageCoords = mImageCanvas->getDisplayWindowCoords(*mCurrentImage, relStartMousePos);
         auto imageCoords = mImageCanvas->getDisplayWindowCoords(*mCurrentImage, relMousePos);
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -493,9 +493,9 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i& p, int button, boo
             for (size_t i = 0; i < buttons.size(); ++i) {
                 const auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
                 if (imgButton->contains(relMousePos) && !imgButton->textBoxVisible()) {
-                    mDraggedImageButtonId = i;
-                    mIsDraggingImageButton = true;
                     mDraggingStartPosition = relMousePos - imgButton->position();
+                    mDragType = EMouseDragType::ImageButtonDrag;
+                    mDraggedImageButtonId = i;
                     break;
                 }
             }
@@ -513,30 +513,26 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i& p, int button, boo
         }
     }
 
-    if (down && !mIsDraggingImageButton) {
+    bool isDraggingImageButton = mDragType == EMouseDragType::ImageButtonDrag;
+    if (down && !isDraggingImageButton) {
+        mDraggingStartPosition = p;
         if (canDragSidebarFrom(p)) {
-            mIsDraggingSidebar = true;
-            mDraggingStartPosition = p;
+            mDragType = EMouseDragType::SidebarDrag;
             return true;
         } else if (mImageCanvas->contains(p)) {
-            mIsCroppingImage = modifiers & 4;
-            if (mIsCroppingImage) {
-                mImageCanvas->setCrop(std::nullopt); // single click disables crop
+            mDragType = (modifiers & 4) ? EMouseDragType::ImageCrop : EMouseDragType::ImageDrag;
+            if (mDragType == EMouseDragType::ImageCrop) {
+                mImageCanvas->setCrop(std::nullopt); // alt + single click disables crop
             }
 
-            mIsDraggingImage = !mIsCroppingImage;
-            mDraggingStartPosition = p;
             return true;
         }
     } else {
-        if (mIsDraggingImageButton) {
+        if (isDraggingImageButton) {
             requestLayoutUpdate();
         }
 
-        mIsDraggingSidebar = false;
-        mIsDraggingImage = false;
-        mIsDraggingImageButton = false;
-        mIsCroppingImage = false;
+        mDragType = EMouseDragType::None;
     }
 
     return false;
@@ -557,7 +553,7 @@ bool ImageViewer::mouse_motion_event(
         redraw();
     }
 
-    if (mIsDraggingSidebar || canDragSidebarFrom(p)) {
+    if (mDragType == EMouseDragType::SidebarDrag || canDragSidebarFrom(p)) {
         mSidebarLayout->set_cursor(Cursor::HResize);
         mImageCanvas->set_cursor(Cursor::HResize);
     } else {
@@ -565,73 +561,90 @@ bool ImageViewer::mouse_motion_event(
         mImageCanvas->set_cursor(Cursor::Arrow);
     }
 
-    if (mIsDraggingSidebar) {
-        mSidebar->set_fixed_width(clamp(p.x(), SIDEBAR_MIN_WIDTH, m_size.x() - 10));
-        requestLayoutUpdate();
-    } else if (mIsDraggingImage) {
-        nanogui::Vector2f relativeMovement = {rel};
-        auto* glfwWindow = screen()->glfw_window();
-        // There is no explicit access to the currently pressed modifier keys here, so we
-        // need to directly ask GLFW.
-        if (glfwGetKey(glfwWindow, GLFW_KEY_LEFT_SHIFT) || glfwGetKey(glfwWindow, GLFW_KEY_RIGHT_SHIFT)) {
-            relativeMovement /= 10;
-        } else if (glfwGetKey(glfwWindow, SYSTEM_COMMAND_LEFT) || glfwGetKey(glfwWindow, SYSTEM_COMMAND_RIGHT)) {
-            relativeMovement /= std::log2(1.1f);
-        }
+    switch (mDragType) {
+        case EMouseDragType::SidebarDrag:
+            mSidebar->set_fixed_width(clamp(p.x(), SIDEBAR_MIN_WIDTH, m_size.x() - 10));
+            requestLayoutUpdate();
+            break;
 
-        // If left mouse button is held, move the image with mouse movement
-        if ((button & 1) != 0) {
-            mImageCanvas->translate(relativeMovement);
-        }
-
-        // If middle mouse button is held, zoom in-out with up-down mouse movement
-        if ((button & 4) != 0) {
-            mImageCanvas->scale(relativeMovement.y() / 10.0f, Vector2f{mDraggingStartPosition});
-        }
-    } else if (mIsDraggingImageButton) {
-        auto& buttons = mImageButtonContainer->children();
-        nanogui::Vector2i relMousePos = (absolute_position() + p) - mImageButtonContainer->absolute_position();
-        for (size_t i = 0; i < buttons.size(); ++i) {
-            if (i == mDraggedImageButtonId) {
-                continue;
+        case EMouseDragType::ImageDrag: {
+            nanogui::Vector2f relativeMovement = {rel};
+            auto* glfwWindow = screen()->glfw_window();
+            // There is no explicit access to the currently pressed modifier keys here, so we
+            // need to directly ask GLFW.
+            if (glfwGetKey(glfwWindow, GLFW_KEY_LEFT_SHIFT) || glfwGetKey(glfwWindow, GLFW_KEY_RIGHT_SHIFT)) {
+                relativeMovement /= 10;
+            } else if (glfwGetKey(glfwWindow, SYSTEM_COMMAND_LEFT) || glfwGetKey(glfwWindow, SYSTEM_COMMAND_RIGHT)) {
+                relativeMovement /= std::log2(1.1f);
             }
-            auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
-            if (imgButton->contains(relMousePos)) {
-                nanogui::Vector2i pos = imgButton->position();
-                pos.y() += ((int)mDraggedImageButtonId - (int)i) * imgButton->size().y();
-                imgButton->set_position(pos);
-                imgButton->mouse_enter_event(relMousePos, false);
 
-                moveImageInList(mDraggedImageButtonId, i);
-                mDraggedImageButtonId = i;
-                break;
+            // If left mouse button is held, move the image with mouse movement
+            if ((button & 1) != 0) {
+                mImageCanvas->translate(relativeMovement);
             }
+
+            // If middle mouse button is held, zoom in-out with up-down mouse movement
+            if ((button & 4) != 0) {
+                mImageCanvas->scale(relativeMovement.y() / 10.0f, Vector2f{mDraggingStartPosition});
+            }
+
+            break;
         }
 
-        dynamic_cast<ImageButton*>(buttons[mDraggedImageButtonId])->set_position(
-            relMousePos - mDraggingStartPosition
-        );
-    } else if (mIsCroppingImage) {
-        Vector2i relStartMousePos = (absolute_position() + mDraggingStartPosition) - mImageCanvas->absolute_position();
-        Vector2i relMousePos = (absolute_position() + p) - mImageCanvas->absolute_position();
+        case EMouseDragType::ImageCrop: {
+            Vector2i relStartMousePos = (absolute_position() + mDraggingStartPosition) - mImageCanvas->absolute_position();
+            Vector2i relMousePos = (absolute_position() + p) - mImageCanvas->absolute_position();
 
-        // Require a minimum movement of 3 (nanogui space) pixels to start cropping.
-        // Since this is measured in nanogui / screen space and not image space, this
-        // does not prevent the cropping of smaller image regions. Just zoom in before
-        // cropping smaller regions than 3 image pixels.
-        if (norm(relStartMousePos - relMousePos) < 3) {
-            return false;
+            // Require a minimum movement of 3 (nanogui space) pixels to start cropping.
+            // Since this is measured in nanogui / screen space and not image space, this
+            // does not prevent the cropping of smaller image regions. Just zoom in before
+            // cropping smaller regions than 3 image pixels.
+            if (norm(relStartMousePos - relMousePos) < 3) {
+                return false;
+            }
+
+            auto startImageCoords = mImageCanvas->getDisplayWindowCoords(*mCurrentImage, relStartMousePos);
+            auto imageCoords = mImageCanvas->getDisplayWindowCoords(*mCurrentImage, relMousePos);
+
+            // sanitize the input crop
+            Box2i crop = {{startImageCoords, imageCoords}};
+            crop.max += Vector2i{1};
+
+            // we do not need to worry about min/max ordering here, as setCrop sanitizes the input for us
+            mImageCanvas->setCrop(crop);
+
+            break;
         }
 
-        auto startImageCoords = mImageCanvas->getDisplayWindowCoords(*mCurrentImage, relStartMousePos);
-        auto imageCoords = mImageCanvas->getDisplayWindowCoords(*mCurrentImage, relMousePos);
+        case EMouseDragType::ImageButtonDrag: {
+            auto& buttons = mImageButtonContainer->children();
+            nanogui::Vector2i relMousePos = (absolute_position() + p) - mImageButtonContainer->absolute_position();
+            for (size_t i = 0; i < buttons.size(); ++i) {
+                if (i == mDraggedImageButtonId) {
+                    continue;
+                }
+                auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
+                if (imgButton->contains(relMousePos)) {
+                    nanogui::Vector2i pos = imgButton->position();
+                    pos.y() += ((int)mDraggedImageButtonId - (int)i) * imgButton->size().y();
+                    imgButton->set_position(pos);
+                    imgButton->mouse_enter_event(relMousePos, false);
 
-        // sanitize the input crop
-        Box2i crop = {{startImageCoords, imageCoords}};
-        crop.max += Vector2i{1};
+                    moveImageInList(mDraggedImageButtonId, i);
+                    mDraggedImageButtonId = i;
+                    break;
+                }
+            }
 
-        // we do not need to worry about min/max ordering here, as setCrop sanitizes the input for us
-        mImageCanvas->setCrop(crop);
+            dynamic_cast<ImageButton*>(buttons[mDraggedImageButtonId])->set_position(
+                relMousePos - mDraggingStartPosition
+            );
+
+            break;
+        }
+
+        case EMouseDragType::None:
+            break;
     }
 
     return false;
@@ -1085,14 +1098,14 @@ void ImageViewer::draw_contents() {
     if (mRequiresLayoutUpdate) {
         nanogui::Vector2i oldDraggedImageButtonPos{0, 0};
         auto& buttons = mImageButtonContainer->children();
-        if (mIsDraggingImageButton) {
+        if (mDragType == EMouseDragType::ImageButtonDrag) {
             oldDraggedImageButtonPos = dynamic_cast<ImageButton*>(buttons[mDraggedImageButtonId])->position();
         }
 
         updateLayout();
         mRequiresLayoutUpdate = false;
 
-        if (mIsDraggingImageButton) {
+        if (mDragType == EMouseDragType::ImageButtonDrag) {
             dynamic_cast<ImageButton*>(buttons[mDraggedImageButtonId])->set_position(oldDraggedImageButtonPos);
         }
     }
@@ -1140,7 +1153,7 @@ void ImageViewer::insertImage(shared_ptr<Image> image, size_t index, bool shallS
         throw invalid_argument{"Image may not be null."};
     }
 
-    if (mIsDraggingImageButton && index <= mDraggedImageButtonId) {
+    if (mDragType == EMouseDragType::ImageButtonDrag && index <= mDraggedImageButtonId) {
         ++mDraggedImageButtonId;
     }
 
@@ -1221,11 +1234,11 @@ void ImageViewer::removeImage(shared_ptr<Image> image) {
         return;
     }
 
-    if (mIsDraggingImageButton) {
+    if (mDragType == EMouseDragType::ImageButtonDrag) {
         // If we're currently dragging the to-be-removed image, stop.
         if ((size_t)id == mDraggedImageButtonId) {
             requestLayoutUpdate();
-            mIsDraggingImageButton = false;
+            mDragType = EMouseDragType::None;
         } else if ((size_t)id < mDraggedImageButtonId) {
             --mDraggedImageButtonId;
         }
@@ -1748,8 +1761,8 @@ void ImageViewer::toggleMaximized() {
 }
 
 void ImageViewer::setUiVisible(bool shouldBeVisible) {
-    if (!shouldBeVisible) {
-        mIsDraggingSidebar = false;
+    if (!shouldBeVisible && mDragType == EMouseDragType::SidebarDrag) {
+        mDragType = EMouseDragType::None;
     }
 
     mSidebar->set_visible(shouldBeVisible);

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -521,7 +521,7 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i &p, int button, boo
         } else if (mImageCanvas->contains(p)) {
             if ((modifiers & 4) != 0) {
                 if (button == 0) {
-                    // control + left click, start crop
+                    // alt/option + left click, start crop
                     auto rel = mouse_pos() - mImageCanvas->position();
                     auto imageCoords = mImageCanvas->getImageCoords(*mCurrentImage, {rel.x(), rel.y()});
                     
@@ -530,7 +530,7 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i &p, int button, boo
                     mImageCanvas->setCropMax(imageCoords);
                     mImageCanvas->enableCrop();
                 } else {
-                    // control + right click, disable crop
+                    // alt/option + right click, disable crop
                     mIsCroppingImage = false;
                     mImageCanvas->disableCrop();
                 }

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -513,6 +513,8 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i& p, int button, boo
         }
     }
 
+    auto* glfwWindow = screen()->glfw_window();
+
     bool isDraggingImageButton = mDragType == EMouseDragType::ImageButtonDrag;
     if (down && !isDraggingImageButton) {
         mDraggingStartPosition = p;
@@ -520,7 +522,7 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i& p, int button, boo
             mDragType = EMouseDragType::SidebarDrag;
             return true;
         } else if (mImageCanvas->contains(p)) {
-            mDragType = (modifiers & 4) ? EMouseDragType::ImageCrop : EMouseDragType::ImageDrag;
+            mDragType = glfwGetKey(glfwWindow, GLFW_KEY_C) ? EMouseDragType::ImageCrop : EMouseDragType::ImageDrag;
             if (mDragType == EMouseDragType::ImageCrop) {
                 mImageCanvas->setCrop(std::nullopt); // alt + single click disables crop
             }

--- a/src/UberShader.cpp
+++ b/src/UberShader.cpp
@@ -21,7 +21,7 @@ UberShader::UberShader(RenderPass* renderPass) {
         precision highp float;)";
 #   endif
         auto vertexShader = preamble +
-            R"(
+            R"glsl(
             uniform vec2 pixelSize;
             uniform vec2 checkerSize;
 
@@ -43,10 +43,10 @@ UberShader::UberShader(RenderPass* renderPass) {
                 referenceUv = position * referenceScale + referenceOffset;
 
                 gl_Position = vec4(position, 1.0, 1.0);
-            })";
+            })glsl";
 
         auto fragmentShader = preamble +
-            R"(
+            R"glsl(
             #define SRGB        0
             #define GAMMA       1
             #define FALSE_COLOR 2
@@ -192,7 +192,7 @@ UberShader::UberShader(RenderPass* renderPass) {
                 );
 
                 gl_FragColor.rgb = clamp(gl_FragColor.rgb, clipToLdr ? 0.0 : -64.0, clipToLdr ? 1.0 : 64.0);
-            })";
+            })glsl";
 #elif defined(NANOGUI_USE_METAL)
         auto vertexShader =
             R"(using namespace metal;

--- a/src/UberShader.cpp
+++ b/src/UberShader.cpp
@@ -168,13 +168,13 @@ UberShader::UberShader(RenderPass* renderPass) {
                     return;
                 }
 
-                float cropAlpha = 1.f;
+                float cropAlpha = 1.0;
                 if (isCropped) {
                     if (imageUv.x < cropMin.x
                     || imageUv.x > cropMax.x
                     || imageUv.y < cropMin.y
                     || imageUv.y > cropMax.y)
-                        cropAlpha = 0.3f;
+                        cropAlpha = 0.3;
                 }
 
                 vec4 imageVal = sample(image, imageUv);

--- a/src/UberShader.cpp
+++ b/src/UberShader.cpp
@@ -353,7 +353,7 @@ UberShader::UberShader(RenderPass* renderPass) {
                     return float4(checker, 1.0f);
                 }
 
-                float cropAlpha = 1.f;
+                float cropAlpha = 1.0f;
                 if (isCropped) {
                     if (vert.imageUv.x < cropMin.x
                     || vert.imageUv.x > cropMax.x


### PR DESCRIPTION
Hi there,

this PR adds the possibility to hold alt/option while drag clicking to mark a region in the image over which statistics in the MultiGraph should be computed. To reset the region to the full image, you can hold alt/option and right click. This is useful to quickly compare averages/histograms of specific regions only, or look at the error between two images in a specific region only.

⚠️ I added the necessary code to the OpenGL backend, but was not able to test it, since `#version 110` is not supported on my system (same for GLES). The Metal backend is working.

Let me know if you're interested in such a feature at all. In that case could also invest some time to find an OpenGL system to test on.

Thanks!