### PR TITLE
Add a link in README.md pointing to the keyboard shortcut visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Images can be opened via a file dialog or by dragging them into __tev__.
 They can be reloaded, closed, or filtered at any time, so don't worry about opening more images than exactly needed.
 
 Select an image by left-clicking it, and optionally select a reference image to compare the current selection to by right-clicking.
-For convenience, the current selection can be moved with the Up/Down or the 1-9 keys. For a comprehensive list of keyboard shortcuts click the little "?" icon at the top (or press "h").
+For convenience, the current selection can be moved with the Up/Down or the 1-9 keys. For a comprehensive list of keyboard shortcuts click the little "?" icon at the top (or press "h"), and a visualization of the shortcuts can be found [here](https://keycombiner.com/collecting/collections/shared/f050cc02-f23a-425c-b032-b4c3659c7ef4).
 
 If the interface seems overwhelming, you can hover any controls to view an explanatory tooltip.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Images can be opened via a file dialog or by dragging them into __tev__.
 They can be reloaded, closed, or filtered at any time, so don't worry about opening more images than exactly needed.
 
 Select an image by left-clicking it, and optionally select a reference image to compare the current selection to by right-clicking.
-For convenience, the current selection can be moved with the Up/Down or the 1-9 keys. For a comprehensive list of keyboard shortcuts click the little "?" icon at the top (or press "h"), and a visualization of the shortcuts can be found [here](https://keycombiner.com/collecting/collections/shared/f050cc02-f23a-425c-b032-b4c3659c7ef4).
+For convenience, the current selection can be moved with the Up/Down or the 1-9 keys. For a comprehensive list of keyboard shortcuts click the little "?" icon at the top (or press "h") or view [this online visualization](https://keycombiner.com/collecting/collections/shared/f050cc02-f23a-425c-b032-b4c3659c7ef4).
 
 If the interface seems overwhelming, you can hover any controls to view an explanatory tooltip.
 


### PR DESCRIPTION
The motivation behind is that the set of key bindings of tev has really grown and sometimes it's hard to keep track for users and developers (#123, #193, #229). Therefore, I translated the list of hot keys from the help popup, as well as from `ImageViewer.cpp`, to a visualizer I encountered, KeyCombiner, and mentioned it in the README (it's [here](https://keycombiner.com/collecting/collections/shared/f050cc02-f23a-425c-b032-b4c3659c7ef4) for quicker reviewing). It allows viewing the hot keys as a list and see the bindings associated with each modifier (or modifier combination). 

Please feel free to check whether the key bindings are correct and complete. 

PS: 
While doing the translation, I noticed that some of the key bindings are not actually in the help window. For example, the `pageUp` and `pageDown` keys are mapped as `up` or `down` but were not mentioned. We can perhaps update the help window after this PR has been merged. 