### PR TITLE
Add tonemapper that hashes to a random color

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -373,6 +373,7 @@ enum ETonemap : int {
     Gamma,
     FalseColor,
     PositiveNegative,
+    Hash,
 
     // This enum value should never be used directly.
     // It facilitates looping over all members of this enum.

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -232,6 +232,8 @@ ETonemap toTonemap(string name) {
         return FalseColor;
     } else if (name == "POSITIVENEGATIVE" || name == "POSNEG" || name == "PN" ||name == "+-") {
         return PositiveNegative;
+    } else if (name == "HASH") {
+        return Hash;
     } else {
         return SRGB;
     }

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -558,6 +558,17 @@ Vector3f ImageCanvas::applyTonemap(const Vector3f& value, float gamma, ETonemap 
                 result = {-2.0f * mean(min(value, Vector3f{0.0f})), 2.0f * mean(max(value, Vector3f{0.0f})), 0.0f};
                 break;
             }
+        case ETonemap::Hash:
+            {
+                static const auto fract = [](float x){ return x - floor(x); };
+                result = value;
+                result *= {abs(result.x()) < 1024.0f ? 1.0f : 1.0f / 1024.0f, abs(result.y()) < 1024.0f ? 1.0f : 1.0f / 1024.0f, abs(result.z()) < 1024.0f ? 1.0f : 1.0f / 1024.0f};
+                result *= {abs(result.x()) < 1024.0f ? 1.0f : 1.0f / 1024.0f, abs(result.y()) < 1024.0f ? 1.0f : 1.0f / 1024.0f, abs(result.z()) < 1024.0f ? 1.0f : 1.0f / 1024.0f};
+                result *= {abs(result.x()) < 1024.0f ? 1.0f : 1.0f / 1024.0f, abs(result.y()) < 1024.0f ? 1.0f : 1.0f / 1024.0f, abs(result.z()) < 1024.0f ? 1.0f : 1.0f / 1024.0f};
+                result = abs(fract(dot(result, Vector3f{115.191742f, 64.0546951f, 124.512291f})) - 0.5f) * Vector3f{1368.46143f, 1523.2019f, 1034.50476f};
+                result = {2.0f * abs(fract(result.x()) - 0.5f), 2.0f * abs(fract(result.y()) - 0.5f), 2.0f * abs(fract(result.z()) - 0.5f)};
+                break;
+            }
         default:
             throw runtime_error{"Invalid tonemap selected."};
     }

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -25,7 +25,7 @@ using namespace std;
 
 namespace tev {
 
-static const int SIDEBAR_MIN_WIDTH = 230;
+static const int SIDEBAR_MIN_WIDTH = 245;
 static const float CROP_MIN_SIZE = 3;
 
 ImageViewer::ImageViewer(
@@ -214,7 +214,7 @@ ImageViewer::ImageViewer(
     // Tonemap options
     {
         mTonemapButtonContainer = new Widget{mSidebarLayout};
-        mTonemapButtonContainer->set_layout(new GridLayout{Orientation::Horizontal, 4, Alignment::Fill, 5, 2});
+        mTonemapButtonContainer->set_layout(new GridLayout{Orientation::Horizontal, 5, Alignment::Fill, 5, 2});
 
         auto makeTonemapButton = [&](const string& name, function<void()> callback) {
             auto button = new Button{mTonemapButtonContainer, name};
@@ -228,6 +228,7 @@ ImageViewer::ImageViewer(
         makeTonemapButton("Gamma", [this]() { setTonemap(ETonemap::Gamma); });
         makeTonemapButton("FC",    [this]() { setTonemap(ETonemap::FalseColor); });
         makeTonemapButton("+/-",   [this]() { setTonemap(ETonemap::PositiveNegative); });
+        makeTonemapButton("Hash",  [this]() { setTonemap(ETonemap::Hash); });
 
         setTonemap(ETonemap::SRGB);
 
@@ -244,7 +245,10 @@ ImageViewer::ImageViewer(
             "False-color visualization\n\n"
 
             "+/-\n"
-            "Positive=Green, Negative=Red"
+            "Positive=Green, Negative=Red\n\n"
+
+            "Hash\n"
+            "Hash values to random colors"
         );
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,6 +233,7 @@ int mainFunc(const vector<string>& arguments) {
         "Gamma  - Gamma curve\n"
         "FC     - False Color\n"
         "PN     - Positive=Green, Negative=Red\n"
+        "Hash   - Hash values to random colors\n"
         "Default is sRGB.",
         {'t', "tonemap"},
     };


### PR DESCRIPTION
Hi Thomas,

Thanks for this fantastic image viewer.  I have gotten a lot of use out of it over the last few years.

This PR adds a new tonemapping option that simply hashes input values to random(ish) colors.

### Rationale:

My primary motivation was in viewing uint id channels (e.g., obj id, prim id, or mat id), where it's useful to show a solid block of color for each id but to decorrelate the colors of adjacent id values.  However, in testing it on non-id images, I found that it was also useful for revealing regions of constant color -- in particular clipped blacks and whites on LDR images.

### Hash:

The hash function itself is based on a popular hash function for shaders floating around on the web.  I have modified it to map a vec3 to a vec3.  I have also replaced the constants with random floating point values whose mantissas are prime numbers with not-too-clumpy bit patterns (no three 0's or 1's in a row), just to add what I hope is a bit better mixing.

I would have preferred to have used one of the better hash functions from [this JCGT paper](https://jcgt.org/published/0009/03/02/), but I also did not want to add a dependency on a shader version that supports something like [floatBitsToUint()](https://registry.khronos.org/OpenGL-Refpages/gl4/html/floatBitsToInt.xhtml).  For a simple visual decorrelation, I think this is sufficient.

### Testing:

I have tested this both on an NVIDIA card under Fedora (KDE Plasma on Wayland) with the OpenGL and GLES backends, and on AMD integrated graphics under Windows (Ubuntu on WSL2) with just the OpenGL backend.

*I have **not*** tested it on native Windows with MSVC, nor on a Mac with Metal.  However, I have tried to match the style of the rest of the Metal shader, so hopefully it just works.
