### PR TITLE
Improve keybindings

### DIFF
--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -78,26 +78,26 @@ HelpWindow::HelpWindow(Widget* parent, bool supportsHdr, function<void()> closeC
 
     addRow(imageSelection, "Left Click",                                        "Select hovered image");
     addRow(imageSelection, "1…9",                                               "Select N-th image");
-    addRow(imageSelection, "Down or S or Ctrl+Tab / Up or W or Ctrl+Shift+Tab", "Select next / previous image");
-    addRow(imageSelection, "Home / End",                                        "Select first / last image");
+    addRow(imageSelection, "Down/Up or S/W or J/K or Ctrl+Tab/Ctrl+Shift+Tab",  "Select next/previous image");
+    addRow(imageSelection, "Home/End",                                        "Select first/last image");
     addRow(imageSelection, "Space",                                             "Toggle playback of images as video");
 
     addRow(imageSelection, "Click & Drag (+Shift/" + COMMAND + ")",   "Translate image");
     addRow(imageSelection, "Click & Drag+C (hold)",                   "Crop image");
-    addRow(imageSelection, "+ / - / Scroll (+Shift/" + COMMAND + ")", "Zoom in / out of image");
+    addRow(imageSelection, "+/- or Scroll (+Shift/" + COMMAND + ")", "Zoom in/out of image");
 
     addRow(imageSelection, COMMAND + "+0", "Zoom to actual size");
-    addRow(imageSelection, COMMAND + "+9 / F", "Zoom to fit");
+    addRow(imageSelection, COMMAND + "+9/F", "Zoom to fit");
     addRow(imageSelection, "N", "Normalize image to [0, 1]");
     addRow(imageSelection, "R", "Reset image parameters");
     if (supportsHdr) {
         addRow(imageSelection, "L", "Display the image as if on an LDR screen");
     }
 
-    addRow(imageSelection, "Shift+Right or Shift+D / Shift+Left or Shift+A", "Select next / previous tonemap");
+    addRow(imageSelection, "Shift+Right/Left or Shift+D/A or Shift+L/H", "Select next/previous tonemap");
 
-    addRow(imageSelection, "E / Shift+E", "Increase / decrease exposure by 0.5");
-    addRow(imageSelection, "O / Shift+O", "Increase / decrease offset by 0.1");
+    addRow(imageSelection, "E/Shift+E", "Increase/decrease exposure by 0.5");
+    addRow(imageSelection, "O/Shift+O", "Increase/decrease offset by 0.1");
 
     addRow(imageSelection, "B (hold)",          "Draw a border around the image");
     addRow(imageSelection, "Shift+Ctrl (hold)", "Display raw bytes on pixels when zoomed-in");
@@ -114,10 +114,10 @@ HelpWindow::HelpWindow(Widget* parent, bool supportsHdr, function<void()> closeC
     addRow(referenceSelection, "Shift (hold)",                                "View currently selected reference");
     addRow(referenceSelection, "Shift+Left Click or Right Click",             "Select hovered image as reference");
     addRow(referenceSelection, "Shift+1…9",                                   "Select N-th image as reference");
-    addRow(referenceSelection, "Shift+Down or Shift+S / Shift+Up or Shift+W", "Select next / previous image as reference");
+    addRow(referenceSelection, "Shift+Down/Up or Shift+S/W or Shift+J/K",     "Select next/previous image as reference");
 
-    addRow(referenceSelection, "Ctrl (hold)",                                "View selected image if reference is selected");
-    addRow(referenceSelection, "Ctrl+Right or Ctrl+D / Ctrl+Left or Ctrl+A", "Select next / previous error metric");
+    addRow(referenceSelection, "Ctrl (hold)",                                 "View selected image if reference is selected");
+    addRow(referenceSelection, "Ctrl+Right/Left or Ctrl+D/A or Ctrl+L/H",     "Select next/previous error metric");
 
     new Label{shortcuts, "Channel group options", "sans-bold", 18};
     auto groupSelection = new Widget{shortcuts};
@@ -125,7 +125,7 @@ HelpWindow::HelpWindow(Widget* parent, bool supportsHdr, function<void()> closeC
 
     addRow(groupSelection, "Left Click",                       "Select hovered channel group");
     addRow(groupSelection, "Ctrl+1…9",                         "Select N-th channel group");
-    addRow(groupSelection, "Right or D or ] / Left or A or [", "Select next / previous channel group");
+    addRow(groupSelection, "Right/Left or D/A or L/H or ]/[",  "Select next/previous channel group");
     addRow(groupSelection, "X",                                "Explode current channel group");
 
     new Label{shortcuts, "Interface", "sans-bold", 18};
@@ -134,7 +134,7 @@ HelpWindow::HelpWindow(Widget* parent, bool supportsHdr, function<void()> closeC
 
     addRow(ui, ALT + "+Enter", "Maximize");
     addRow(ui, COMMAND + "+B", "Toggle GUI");
-    addRow(ui, "H or ?",        "Show help (this window)");
+    addRow(ui, "H or ?",       "Show help (this window)");
     addRow(ui, COMMAND + "+F", "Find image or channel group");
     addRow(ui, "Escape",       "Reset find string");
     addRow(ui, COMMAND + "+Q", "Quit");

--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -135,7 +135,7 @@ HelpWindow::HelpWindow(Widget* parent, bool supportsHdr, function<void()> closeC
     addRow(ui, ALT + "+Enter", "Maximize");
     addRow(ui, COMMAND + "+B", "Toggle GUI");
     addRow(ui, "H or ?",        "Show help (this window)");
-    addRow(ui, COMMAND + "+P", "Find image or channel group");
+    addRow(ui, COMMAND + "+F", "Find image or channel group");
     addRow(ui, "Escape",       "Reset find string");
     addRow(ui, COMMAND + "+Q", "Quit");
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -799,9 +799,8 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
             saveImageDialog();
             return true;
         } else if (
-            key == GLFW_KEY_H || /* question mark on US layout */ (
-                key == GLFW_KEY_SLASH && (modifiers & GLFW_MOD_SHIFT)
-            )
+            // question mark on US layout
+            key == GLFW_KEY_SLASH && (modifiers & GLFW_MOD_SHIFT)
         ) {
             toggleHelpWindow();
             return true;
@@ -821,10 +820,6 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
             return true;
         } else if (key == GLFW_KEY_SPACE) {
             setPlayingBack(!playingBack());
-            return true;
-        } else if (key == GLFW_KEY_L && mSupportsHdr) {
-            mClipToLdrButton->set_pushed(!mClipToLdrButton->pushed());
-            mImageCanvas->setClipToLdr(mClipToLdrButton->pushed());
             return true;
         } else if (key == GLFW_KEY_ESCAPE) {
             setFilter("");
@@ -966,7 +961,7 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
                 removeImage(mCurrentImage);
             }
         } else if (
-            key == GLFW_KEY_UP || key == GLFW_KEY_W || key == GLFW_KEY_PAGE_UP || (
+            key == GLFW_KEY_UP || key == GLFW_KEY_W || key == GLFW_KEY_K || key == GLFW_KEY_PAGE_UP || (
                 key == GLFW_KEY_TAB && (modifiers & GLFW_MOD_CONTROL) && (modifiers & GLFW_MOD_SHIFT)
             )
         ) {
@@ -976,7 +971,7 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
                 selectImage(nextImage(mCurrentImage, Backward));
             }
         } else if (
-            key == GLFW_KEY_DOWN || key == GLFW_KEY_S || key == GLFW_KEY_PAGE_DOWN || (
+            key == GLFW_KEY_DOWN || key == GLFW_KEY_S || key == GLFW_KEY_J || key == GLFW_KEY_PAGE_DOWN || (
                 key == GLFW_KEY_TAB && (modifiers & GLFW_MOD_CONTROL) && !(modifiers & GLFW_MOD_SHIFT)
             )
         ) {
@@ -987,7 +982,7 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
             }
         }
 
-        if (key == GLFW_KEY_RIGHT || key == GLFW_KEY_D || key == GLFW_KEY_RIGHT_BRACKET) {
+        if (key == GLFW_KEY_RIGHT || key == GLFW_KEY_D || key == GLFW_KEY_L || key == GLFW_KEY_RIGHT_BRACKET) {
             if (modifiers & GLFW_MOD_SHIFT) {
                 setTonemap(static_cast<ETonemap>((tonemap() + 1) % NumTonemaps));
             } else if (modifiers & GLFW_MOD_CONTROL) {
@@ -997,7 +992,7 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
             } else {
                 selectGroup(nextGroup(mCurrentGroup, Forward));
             }
-        } else if (key == GLFW_KEY_LEFT || key == GLFW_KEY_A || key == GLFW_KEY_LEFT_BRACKET) {
+        } else if (key == GLFW_KEY_LEFT || key == GLFW_KEY_A || key == GLFW_KEY_H || key == GLFW_KEY_LEFT_BRACKET) {
             if (modifiers & GLFW_MOD_SHIFT) {
                 setTonemap(static_cast<ETonemap>((tonemap() - 1 + NumTonemaps) % NumTonemaps));
             } else if (modifiers & GLFW_MOD_CONTROL) {

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -709,6 +709,9 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
         if (key == GLFW_KEY_0 && (modifiers & SYSTEM_COMMAND_MOD)) {
             mImageCanvas->resetTransform();
             return true;
+        } else if (key == GLFW_KEY_F && (modifiers & SYSTEM_COMMAND_MOD)) {
+            mFilter->request_focus();
+            return true;
         } else if (key == GLFW_KEY_F || (key == GLFW_KEY_9 && (modifiers & SYSTEM_COMMAND_MOD))) {
             if (mCurrentImage) {
                 mImageCanvas->fitImageToScreen(*mCurrentImage);
@@ -794,9 +797,6 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
             return true;
         } else if (key == GLFW_KEY_S && (modifiers & SYSTEM_COMMAND_MOD)) {
             saveImageDialog();
-            return true;
-        } else if (key == GLFW_KEY_P && (modifiers & SYSTEM_COMMAND_MOD)) {
-            mFilter->request_focus();
             return true;
         } else if (
             key == GLFW_KEY_H || /* question mark on US layout */ (


### PR DESCRIPTION
- Use Ctrl+F instead of Ctrl+P to find images
- Use Esc to remove focus from the 'find' textbox again
- Use home row (hjkl) to navigate images.
  - h no longer opens the help menu (users in need of help can click the ? button in the GUI or press ? on the keyboard)
  - l no longer toggles LDR/HDR on macOS (there's rarely a need to explicitly turn *on* clipping)