### PR TITLE
Various performance improvements

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -120,6 +120,9 @@ if (TEV_USE_LIBHEIF)
 
     add_library(lcms2 STATIC ${LCMS_SRCS} ${LCMS_HDRS})
     set_target_properties(lcms2 PROPERTIES PUBLIC_HEADER "${LCMS_HDRS}")
+
+    # We don't use the SSE2 components of CMS in tev; disable to simplify ARM compilation
+    target_compile_definitions(lcms2 PRIVATE -DCMS_DONT_USE_SSE2=1)
     target_include_directories(lcms2 PUBLIC
         "${CMAKE_CURRENT_SOURCE_DIR}/Little-CMS/include"
         # "${CMAKE_CURRENT_SOURCE_DIR}/Little-CMS/plugins/fast_float/include"

--- a/include/tev/Channel.h
+++ b/include/tev/Channel.h
@@ -35,14 +35,6 @@ public:
 
     const std::string& name() const { return mName; }
 
-    float eval(size_t index) const {
-        if (index >= numPixels()) {
-            return 0;
-        }
-
-        return at(index * mDataStride);
-    }
-
     float eval(nanogui::Vector2i index) const {
         if (index.x() < 0 || index.x() >= mSize.x() || index.y() < 0 || index.y() >= mSize.y()) {
             return 0;

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -46,7 +46,7 @@
 
 #define TEV_ASSERT(cond, description, ...) \
     if (UNLIKELY(!(cond)))                 \
-        throw std::runtime_error{fmt::format(description, ##__VA_ARGS__)};
+        throw std::runtime_error{fmt::format(description, ##__VA_ARGS__)}
 
 #ifndef TEV_VERSION
 #   define TEV_VERSION "undefined"

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -111,6 +111,14 @@ public:
     bool hasChannel(const std::string& channelName) const { return mData.hasChannel(channelName); }
 
     const Channel* channel(const std::string& channelName) const { return mData.channel(channelName); }
+    std::vector<const Channel*> channels(const std::vector<std::string>& channelNames) const {
+        std::vector<const Channel*> result;
+        for (const auto& channelName : channelNames) {
+            result.push_back(channel(channelName));
+        }
+
+        return result;
+    }
 
     bool isInterleavedRgba(const std::vector<std::string>& channelNames) const;
 

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -112,6 +112,8 @@ public:
 
     const Channel* channel(const std::string& channelName) const { return mData.channel(channelName); }
 
+    bool isInterleavedRgba(const std::vector<std::string>& channelNames) const;
+
     nanogui::Texture* texture(const std::string& channelGroupName);
     nanogui::Texture* texture(const std::vector<std::string>& channelNames);
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -4,7 +4,7 @@
 #include <tev/Channel.h>
 #include <tev/ThreadPool.h>
 
-#include <numeric>
+#include <memory>
 
 using namespace nanogui;
 using namespace std;
@@ -42,8 +42,17 @@ Color Channel::color(string channel) {
     return Color(1.0f, 1.0f);
 }
 
-Channel::Channel(const std::string& name, const nanogui::Vector2i& size) : mName{name}, mSize{size} {
-    mData.resize((size_t)mSize.x() * mSize.y());
+Channel::Channel(const string& name, const nanogui::Vector2i& size, shared_ptr<vector<float>> data, size_t dataOffset, size_t dataStride) :
+    mName{name}, mSize{size} {
+    if (data) {
+        mData = data;
+        mDataOffset = dataOffset;
+        mDataStride = dataStride;
+    } else {
+        mData = make_shared<vector<float>>((size_t)size.x() * size.y());
+        mDataOffset = 0;
+        mDataStride = 1;
+    }
 }
 
 Task<void> Channel::divideByAsync(const Channel& other, int priority) {

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -461,7 +461,7 @@ void ImageCanvas::draw(NVGcontext* ctx) {
             nvgStrokeWidth(ctx, 3.0f);
 
             size_t saveCounter = 0;
-            for (const auto& command : mImage->vgCommands()) {
+            for (const auto& command : commands) {
                 if (command.type == VgCommand::EType::Save) {
                     ++saveCounter;
                 } else if (command.type == VgCommand::EType::Restore) {

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -581,7 +581,7 @@ Vector3f ImageCanvas::applyTonemap(const Vector3f& value, float gamma, ETonemap 
         case ETonemap::FalseColor: {
             static const auto falseColor = [](float linear) {
                 static const auto& fcd = colormap::turbo();
-                int start = 4 * clamp((int)(linear * (fcd.size() / 4)), 0, (int)fcd.size() / 4 - 1);
+                int start = 4 * clamp((int)(linear * (int)(fcd.size() / 4)), 0, (int)fcd.size() / 4 - 1);
                 return Vector3f{fcd[start], fcd[start + 1], fcd[start + 2]};
             };
 
@@ -917,7 +917,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
 
     auto result = make_shared<CanvasStatistics>();
 
-    size_t nChannels = result->nChannels = alphaChannel ? flattened.size() - 1 : flattened.size();
+    size_t nChannels = result->nChannels = (int)(alphaChannel ? (flattened.size() - 1) : flattened.size());
 
     for (size_t i = 0; i < nChannels; ++i) {
         const auto& channel = flattened[i];
@@ -1021,7 +1021,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
     co_return result;
 }
 
-Vector2f ImageCanvas::pixelOffset(const Vector2i& size) const {
+Vector2f ImageCanvas::pixelOffset(const Vector2i& /*size*/) const {
     // Translate by half of a pixel to avoid pixel boundaries aligning perfectly with texels. The translation only needs to happen for axes
     // with even resolution. Odd-resolution axes are implicitly shifted by half a pixel due to the centering operation. Additionally, add
     // 0.1111111 such that our final position is almost never 0 modulo our pixel ratio, which again avoids aligned pixel boundaries with

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -847,7 +847,7 @@ vector<Channel> ImageCanvas::channelsFromImages(
             [&](int i) {
                 const auto* channel = image->channel(channelNames[i]);
                 for (size_t j = 0; j < channel->numPixels(); ++j) {
-                    result[i].at(j) = channel->eval(j);
+                    result[i].at(j) = channel->at(j);
                 }
             },
             priority
@@ -992,7 +992,9 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
         nChannels,
         [&](size_t i) {
             for (size_t j = 0; j < numPixels; ++j) {
-                result->histogram[indices[j + i * numPixels] + i * NUM_BINS] += alphaChannel ? alphaChannel->eval(j) : 1;
+                int x = (j % regionSize.x()) + region.min.x();
+                int y = (j / regionSize.x()) + region.min.y();
+                result->histogram[indices[j + i * numPixels] + i * NUM_BINS] += alphaChannel ? alphaChannel->at({x, y}) : 1;
             }
         },
         priority

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -16,7 +16,7 @@ bool StbiImageLoader::canLoadFile(istream&) const {
     return true;
 }
 
-Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&, const string& channelSelector, int priority) const {
+Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&, const string&, int priority) const {
     vector<ImageData> result(1);
     ImageData& resultData = result.front();
 
@@ -57,7 +57,7 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
     ScopeGuard dataGuard{[data] { stbi_image_free(data); }};
 
     resultData.channels = makeNChannels(numChannels, size);
-    int alphaChannelIndex = 3;
+    static const int ALPHA_CHANNEL_INDEX = 3;
 
     auto numPixels = (size_t)size.x() * size.y();
     if (isHdr) {
@@ -81,7 +81,7 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
                 auto typedData = reinterpret_cast<unsigned char*>(data);
                 size_t baseIdx = i * numChannels;
                 for (int c = 0; c < numChannels; ++c) {
-                    if (c == alphaChannelIndex) {
+                    if (c == ALPHA_CHANNEL_INDEX) {
                         resultData.channels[c].at(i) = (typedData[baseIdx + c]) / 255.0f;
                     } else {
                         resultData.channels[c].at(i) = toLinear((typedData[baseIdx + c]) / 255.0f);


### PR DESCRIPTION
This PR improves performance in a number of areas:
- All non-EXR images are now stored in interleaved RGBA fashion, meaning they
  - Load faster from disk
  - Display faster when first selected in the UI

A bunch of multi-threaded image processing code has also been converted from parallelizing over channels to parallelizing over pixels, leading both to additional parallelization as well as more coherent memory traversal if the image is represented in interleaved RGBA. Histograms in particular should now compute quite a bit faster.

All of these optimizations are going to be predominantly noticeable when dealing with large images (>4K). Smaller images were already processed pretty much instantaneously before.