### PR TITLE
feat: add CLI flag to disable loading of gainmaps

### DIFF
--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -221,10 +221,10 @@ private:
     int mId;
 };
 
-Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(int imageId, fs::path path, std::istream& iStream, std::string channelSelector);
-Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(fs::path path, std::istream& iStream, std::string channelSelector);
-Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(int imageId, fs::path path, std::string channelSelector);
-Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(fs::path path, std::string channelSelector);
+Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(int imageId, fs::path path, std::istream& iStream, std::string channelSelector, bool applyGainmaps);
+Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(fs::path path, std::istream& iStream, std::string channelSelector, bool applyGainmaps);
+Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(int imageId, fs::path path, std::string channelSelector, bool applyGainmaps);
+Task<std::vector<std::shared_ptr<Image>>> tryLoadImage(fs::path path, std::string channelSelector, bool applyGainmaps);
 
 struct ImageAddition {
     int loadId;
@@ -257,8 +257,10 @@ public:
     bool hasPendingLoads() const { return mLoadCounter != mUnsortedLoadCounter; }
 
     bool recursiveDirectories() const { return mRecursiveDirectories; }
-
     void setRecursiveDirectories(bool value) { mRecursiveDirectories = value; }
+
+    bool applyGainmaps() const { return mApplyGainmaps; }
+    void setApplyGainmaps(bool value) { mApplyGainmaps = value; }
 
 private:
     SharedQueue<ImageAddition> mLoadedImages;
@@ -272,6 +274,8 @@ private:
     bool mRecursiveDirectories = false;
     std::map<fs::path, std::set<std::string>> mDirectories;
     std::set<PathAndChannelSelector> mFilesFoundInDirectories;
+
+    bool mApplyGainmaps = true;
 };
 
 } // namespace tev

--- a/include/tev/imageio/ClipboardImageLoader.h
+++ b/include/tev/imageio/ClipboardImageLoader.h
@@ -27,9 +27,8 @@ namespace tev {
 
 class ClipboardImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::istream& iStream) const override;
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const override;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const override;
 
     std::string name() const override { return "clipboard"; }
 };

--- a/include/tev/imageio/DdsImageLoader.h
+++ b/include/tev/imageio/DdsImageLoader.h
@@ -27,9 +27,8 @@ namespace tev {
 
 class DdsImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::istream& iStream) const override;
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const override;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const override;
 
     std::string name() const override { return "DDS"; }
 };

--- a/include/tev/imageio/EmptyImageLoader.h
+++ b/include/tev/imageio/EmptyImageLoader.h
@@ -27,9 +27,8 @@ namespace tev {
 
 class EmptyImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::istream& iStream) const override;
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const override;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const override;
 
     std::string name() const override { return "IPC"; }
 };

--- a/include/tev/imageio/ExrImageLoader.h
+++ b/include/tev/imageio/ExrImageLoader.h
@@ -27,9 +27,8 @@ namespace tev {
 
 class ExrImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::istream& iStream) const override;
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const override;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const override;
 
     std::string name() const override { return "OpenEXR"; }
 };

--- a/include/tev/imageio/HeifImageLoader.h
+++ b/include/tev/imageio/HeifImageLoader.h
@@ -29,9 +29,8 @@ class HeifImageLoader : public ImageLoader {
 public:
     HeifImageLoader();
 
-    bool canLoadFile(std::istream& iStream) const override;
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const override;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const override;
 
     std::string name() const override { return "HEIF"; }
 };

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -25,19 +25,22 @@
 #include <nanogui/vector.h>
 
 #include <istream>
+#include <stdexcept>
 #include <string>
 
 namespace tev {
 
 class ImageLoader {
 public:
+    class FormatNotSupportedException : public std::runtime_error {
+    public:
+        FormatNotSupportedException(const std::string& message) : std::runtime_error{message} {}
+    };
+
     virtual ~ImageLoader() {}
 
-    virtual bool canLoadFile(std::istream& iStream) const = 0;
-
-    // Return loaded image data as well as whether that data has the alpha channel pre-multiplied or not.
     virtual Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const = 0;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const = 0;
 
     virtual std::string name() const = 0;
 

--- a/include/tev/imageio/PfmImageLoader.h
+++ b/include/tev/imageio/PfmImageLoader.h
@@ -27,9 +27,8 @@ namespace tev {
 
 class PfmImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::istream& iStream) const override;
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const override;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const override;
 
     std::string name() const override { return "PFM"; }
 };

--- a/include/tev/imageio/QoiImageLoader.h
+++ b/include/tev/imageio/QoiImageLoader.h
@@ -27,9 +27,8 @@ namespace tev {
 
 class QoiImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::istream& iStream) const override;
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const override;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const override;
 
     std::string name() const override { return "QOI"; }
 };

--- a/include/tev/imageio/StbiImageLoader.h
+++ b/include/tev/imageio/StbiImageLoader.h
@@ -27,9 +27,8 @@ namespace tev {
 
 class StbiImageLoader : public ImageLoader {
 public:
-    bool canLoadFile(std::istream& iStream) const override;
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const override;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const override;
 
     std::string name() const override { return "STBI"; }
 };

--- a/include/tev/imageio/UltraHdrImageLoader.h
+++ b/include/tev/imageio/UltraHdrImageLoader.h
@@ -29,9 +29,8 @@ class UltraHdrImageLoader : public ImageLoader {
 public:
     UltraHdrImageLoader();
 
-    bool canLoadFile(std::istream& iStream) const override;
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority) const override;
+        load(std::istream& iStream, const fs::path& path, const std::string& channelSelector, int priority, bool applyGainmaps) const override;
 
     std::string name() const override { return "Ultra HDR"; }
 };

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -836,7 +836,7 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
             //     if (!clip::get_text(path)) {
             //         tlog::error() << "Failed to paste text from clipboard.";
             //     } else {
-            //         auto image = tryLoadImage(toPath(path), "");
+            //         auto image = tryLoadImage(toPath(path), "", mImagesLoader->applyGainmaps());
             //         if (image) {
             //             addImage(image, true);
             //         } else {
@@ -854,7 +854,8 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
                     imageStream << "clip" << string(reinterpret_cast<const char*>(&clipImage.spec()), sizeof(clip::image_spec))
                                 << string(clipImage.data(), clipImage.spec().bytes_per_row * clipImage.spec().height);
 
-                    auto images = tryLoadImage(fmt::format("clipboard ({})", ++mClipboardIndex), imageStream, "").get();
+                    auto images =
+                        tryLoadImage(fmt::format("clipboard ({})", ++mClipboardIndex), imageStream, "", mImagesLoader->applyGainmaps()).get();
                     if (images.empty()) {
                         tlog::error() << "Failed to load image from clipboard data.";
                     } else {

--- a/src/imageio/EmptyImageLoader.cpp
+++ b/src/imageio/EmptyImageLoader.cpp
@@ -25,34 +25,23 @@ using namespace std;
 
 namespace tev {
 
-bool EmptyImageLoader::canLoadFile(istream& iStream) const {
-    char b[5];
-    iStream.read(b, sizeof(b));
-
-    bool result = !!iStream && iStream.gcount() == sizeof(b) && string(b, sizeof(b)) == "empty";
-
-    iStream.clear();
-    iStream.seekg(0);
-    return result;
-}
-
-Task<vector<ImageData>> EmptyImageLoader::load(istream& iStream, const fs::path&, const string&, int) const {
-    vector<ImageData> result(1);
-    ImageData& data = result.front();
-
+Task<vector<ImageData>> EmptyImageLoader::load(istream& iStream, const fs::path&, const string&, int, bool) const {
     string magic;
     Vector2i size;
     int nChannels;
     iStream >> magic >> size.x() >> size.y() >> nChannels;
 
-    if (magic != "empty") {
-        throw invalid_argument{fmt::format("Invalid magic empty string {}", magic)};
+    if (!iStream || magic != "empty") {
+        throw FormatNotSupportedException{fmt::format("Invalid magic empty string {}.", magic)};
     }
 
     auto numPixels = (size_t)size.x() * size.y();
     if (numPixels == 0) {
         throw invalid_argument{"Image has zero pixels."};
     }
+
+    vector<ImageData> result(1);
+    ImageData& data = result.front();
 
     for (int i = 0; i < nChannels; ++i) {
         // The following lines decode strings by prefix length. The reason for using sthis encoding is to allow arbitrary characters,

--- a/src/imageio/EmptyImageLoader.cpp
+++ b/src/imageio/EmptyImageLoader.cpp
@@ -26,14 +26,17 @@ using namespace std;
 namespace tev {
 
 Task<vector<ImageData>> EmptyImageLoader::load(istream& iStream, const fs::path&, const string&, int, bool) const {
-    string magic;
-    Vector2i size;
-    int nChannels;
-    iStream >> magic >> size.x() >> size.y() >> nChannels;
+    char magic[6];
+    iStream.read(magic, 6);
+    string magicString(magic, 6);
 
-    if (!iStream || magic != "empty") {
+    if (!iStream || magicString != "empty ") {
         throw FormatNotSupportedException{fmt::format("Invalid magic empty string {}.", magic)};
     }
+
+    Vector2i size;
+    int nChannels;
+    iStream >> size.x() >> size.y() >> nChannels;
 
     auto numPixels = (size_t)size.x() * size.y();
     if (numPixels == 0) {

--- a/src/imageio/GainMap.cpp
+++ b/src/imageio/GainMap.cpp
@@ -27,7 +27,7 @@ namespace tev {
 
 Task<void> applyAppleGainMap(ImageData& image, const ImageData& gainMap, int priority, const AppleMakerNote& amn) {
     auto size = image.channels[0].size();
-    TEV_ASSERT(size == gainMap.channels[0].size(), "Image and gain map must have the same size");
+    TEV_ASSERT(size == gainMap.channels[0].size(), "Image and gain map must have the same size.");
 
     // Apply gain map per https://developer.apple.com/documentation/appkit/applying-apple-hdr-effect-to-your-photos
     float headroom = 1.0f;
@@ -52,7 +52,7 @@ Task<void> applyAppleGainMap(ImageData& image, const ImageData& gainMap, int pri
     }
 
     headroom = pow(2.0f, max(stops, 0.0f));
-    tlog::debug() << fmt::format("Derived gain map headroom {} from maker note entries #33={} and #48={}", headroom, maker33, maker48);
+    tlog::debug() << fmt::format("Derived gain map headroom {} from maker note entries #33={} and #48={}.", headroom, maker33, maker48);
 
     co_await ThreadPool::global().parallelForAsync<int>(
         0,

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -26,21 +26,7 @@ using namespace std;
 
 namespace tev {
 
-bool PfmImageLoader::canLoadFile(istream& iStream) const {
-    char b[2];
-    iStream.read(b, sizeof(b));
-
-    bool result = !!iStream && iStream.gcount() == sizeof(b) && b[0] == 'P' && (b[1] == 'F' || b[1] == 'f');
-
-    iStream.clear();
-    iStream.seekg(0);
-    return result;
-}
-
-Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, const string&, int priority) const {
-    vector<ImageData> result(1);
-    ImageData& resultData = result.front();
-
+Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, const string&, int priority, bool) const {
     string magic;
     Vector2i size;
     float scale;
@@ -55,7 +41,7 @@ Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, 
     } else if (magic == "PF4") {
         numChannels = 4;
     } else {
-        throw invalid_argument{fmt::format("Invalid magic PFM string {}", magic)};
+        throw FormatNotSupportedException{fmt::format("Invalid magic PFM string {}", magic)};
     }
 
     if (!isfinite(scale) || scale == 0) {
@@ -64,6 +50,9 @@ Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, 
 
     bool isPfmLittleEndian = scale < 0;
     scale = abs(scale);
+
+    vector<ImageData> result(1);
+    ImageData& resultData = result.front();
 
     resultData.channels = makeNChannels(numChannels, size);
 

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -27,6 +27,15 @@ using namespace std;
 namespace tev {
 
 Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, const string&, int priority, bool) const {
+    char pf[2];
+    iStream.read(pf, 2);
+    if (!iStream || pf[0] != 'P' || (pf[1] != 'F' && pf[1] != 'f')) {
+        throw FormatNotSupportedException{"Invalid PFM magic string."};
+    }
+
+    iStream.clear();
+    iStream.seekg(0);
+
     string magic;
     Vector2i size;
     float scale;
@@ -41,7 +50,7 @@ Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, 
     } else if (magic == "PF4") {
         numChannels = 4;
     } else {
-        throw FormatNotSupportedException{fmt::format("Invalid magic PFM string {}", magic)};
+        throw FormatNotSupportedException{fmt::format("Invalid PFM magic string {}", magic)};
     }
 
     if (!isfinite(scale) || scale == 0) {

--- a/src/imageio/QoiImageLoader.cpp
+++ b/src/imageio/QoiImageLoader.cpp
@@ -28,27 +28,13 @@ using namespace std;
 
 namespace tev {
 
-bool QoiImageLoader::canLoadFile(istream& iStream) const {
-    char b[4];
-    iStream.read(b, sizeof(b));
-
-    bool result = !!iStream && iStream.gcount() == sizeof(b) && string(b, sizeof(b)) == "qoif";
-
-    iStream.clear();
-    iStream.seekg(0);
-    return result;
-}
-
-Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, const string&, int priority) const {
-    vector<ImageData> result(1);
-    ImageData& resultData = result.front();
-
+Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, const string&, int priority, bool) const {
     char magic[4];
     iStream.read(magic, 4);
     string magicString(magic, 4);
 
     if (magicString != "qoif") {
-        throw invalid_argument{fmt::format("Invalid magic QOI string {}", magicString)};
+        throw FormatNotSupportedException{fmt::format("Invalid magic QOI string {}.", magicString)};
     }
 
     iStream.clear();
@@ -77,6 +63,9 @@ Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, 
     if (numChannels != 4 && numChannels != 3) {
         throw invalid_argument{fmt::format("Invalid number of channels {}.", numChannels)};
     }
+
+    vector<ImageData> result(1);
+    ImageData& resultData = result.front();
 
     resultData.channels = makeNChannels(numChannels, size);
     resultData.hasPremultipliedAlpha = false;

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -26,15 +26,7 @@ using namespace std;
 
 namespace tev {
 
-bool StbiImageLoader::canLoadFile(istream&) const {
-    // Pretend you can load any file and throw exception on failure. TODO: Add proper check.
-    return true;
-}
-
-Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&, const string&, int priority) const {
-    vector<ImageData> result(1);
-    ImageData& resultData = result.front();
-
+Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&, const string&, int priority, bool) const {
     static const stbi_io_callbacks callbacks = {
         // Read
         [](void* context, char* data, int size) {
@@ -70,6 +62,9 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
     }
 
     ScopeGuard dataGuard{[data] { stbi_image_free(data); }};
+
+    vector<ImageData> result(1);
+    ImageData& resultData = result.front();
 
     resultData.channels = makeNChannels(numChannels, size);
     static const int ALPHA_CHANNEL_INDEX = 3;


### PR DESCRIPTION
Also overhauls loading of images: instead of checking for format compatibility in a separate step from loading, both are now handled in the same (ImageLoader::load) function. A special type of exception is instead thrown if the format is deemed to be unsupported, in which case the next loader in will be tried in order. This doesn't just simplify a whole bunch of logic but also avoids loading image data into memory twice when loading Ultra HDR JPEG images.