### PR TITLE
fix: gracefully shutdown threadpool when tev exits

### DIFF
--- a/include/tev/ThreadPool.h
+++ b/include/tev/ThreadPool.h
@@ -81,6 +81,7 @@ public:
 
     void startThreads(size_t num);
     void shutdownThreads(size_t num);
+    void shutdown() { shutdownThreads(mThreads.size()); }
 
     size_t numTasksInSystem() const { return mNumTasksInSystem; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -610,6 +610,9 @@ static int mainFunc(const vector<string>& arguments) {
     // Refresh only every 250ms if there are no user interactions. This makes an idling tev surprisingly energy-efficient. :)
     nanogui::mainloop(250);
 
+    ThreadPool::global().flushQueue();
+    ThreadPool::global().shutdown();
+
     return 0;
 }
 


### PR DESCRIPTION
Previously, tev would sometimes crash when shutdown while images are still loading in the background or histograms are still being computed.