### PR TITLE
fix: crash selecting larger image than system's max texture size

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -390,6 +390,8 @@ inline bool matchesFuzzyOrRegex(const std::string& text, const std::string& filt
 
 void drawTextWithShadow(NVGcontext* ctx, float x, float y, std::string text, float shadowAlpha = 1.0f);
 
+int maxTextureSize();
+
 inline float toSRGB(float linear, float gamma = 2.4f) {
     static const float a = 0.055f;
     if (linear <= 0.0031308f) {

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -217,6 +217,19 @@ void drawTextWithShadow(NVGcontext* ctx, float x, float y, string text, float sh
     nvgText(ctx, x, y, text.c_str(), NULL);
 }
 
+int maxTextureSize() {
+#if NANOGUI_USE_METAL
+    // There's unfortunately not a nice API to query this in Metal. Thankfully, macs all have had the same limit so far.
+    return 16384;
+#else
+    static struct MaxSize {
+        MaxSize() { glGetIntegerv(GL_MAX_TEXTURE_SIZE, &value); }
+        GLint value;
+    } maxSize;
+    return maxSize.value;
+#endif
+}
+
 int lastError() {
 #ifdef _WIN32
     return GetLastError();

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -346,6 +346,11 @@ bool Image::isInterleavedRgba(const vector<string>& channelNames) const {
 }
 
 Texture* Image::texture(const vector<string>& channelNames, EInterpolationMode minFilter, EInterpolationMode magFilter) {
+    if (size().x() > maxTextureSize() || size().y() > maxTextureSize()) {
+        tlog::error() << fmt::format("{} is too large for Texturing. ({}x{})", mName, size().x(), size().y());
+        return nullptr;
+    }
+
     string lookup = fmt::format("{}-{}-{}", join(channelNames, ","), tev::toString(minFilter), tev::toString(magFilter));
     auto iter = mTextures.find(lookup);
     if (iter != end(mTextures)) {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -699,9 +699,9 @@ string Image::toString() const {
 Task<vector<shared_ptr<Image>>> tryLoadImage(int taskPriority, fs::path path, istream& iStream, string channelSelector, bool applyGainmaps) {
     auto handleException = [&](const exception& e) {
         if (channelSelector.empty()) {
-            tlog::error() << fmt::format("Could not load {}. {}", toString(path), e.what());
+            tlog::error() << fmt::format("Could not load {}: {}", toString(path), e.what());
         } else {
-            tlog::error() << fmt::format("Could not load {}:{}. {}", toString(path), channelSelector, e.what());
+            tlog::error() << fmt::format("Could not load {}:{}: {}", toString(path), channelSelector, e.what());
         }
     };
 

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -604,7 +604,8 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
             // Strips are just tiles with the same width as the image
             tile.width = size.x();
             if (!TIFFGetField(tif, TIFFTAG_ROWSPERSTRIP, &tile.height)) {
-                throw ImageLoadError{"Failed to read rows per strip."};
+                tlog::warning() << "Failed to read rows per strip; assuming image height.";
+                tile.height = size.y();
             }
 
             tile.numX = 1;

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -331,26 +331,27 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
     ScopeGuard tiffGuard{[tif] { TIFFClose(tif); }};
 
     auto readImage = [&]() -> Task<ImageData> {
-        // Read TIFF dimensions and properties
         uint32_t width, height;
-        uint16_t bitsPerSample, samplesPerPixel, photometric, planar, sampleFormat, compression;
-
         if (!TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &width) || !TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &height)) {
             throw ImageLoadError{"Failed to read dimensions."};
         }
 
+
         // Note: libtiff doesn't support variable bits per sample, which is technically allowed by the TIFF 6.0 spec. We assume all samples
         // have the same bit depth.
-        if (!TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bitsPerSample)) {
-            bitsPerSample = 1;
+        uint16_t bitsPerSample;
+        if (!TIFFGetFieldDefaulted(tif, TIFFTAG_BITSPERSAMPLE, &bitsPerSample)) {
+            throw ImageLoadError{"Failed to read bits per sample."};
         }
 
-        if (!TIFFGetField(tif, TIFFTAG_SAMPLESPERPIXEL, &samplesPerPixel)) {
-            samplesPerPixel = 1;
+        uint16_t samplesPerPixel;
+        if (!TIFFGetFieldDefaulted(tif, TIFFTAG_SAMPLESPERPIXEL, &samplesPerPixel)) {
+            throw ImageLoadError{"Failed to read samples per pixel."};
         }
 
-        if (!TIFFGetField(tif, TIFFTAG_SAMPLEFORMAT, &sampleFormat)) {
-            sampleFormat = SAMPLEFORMAT_UINT;
+        uint16_t sampleFormat;
+        if (!TIFFGetFieldDefaulted(tif, TIFFTAG_SAMPLEFORMAT, &sampleFormat)) {
+            throw ImageLoadError{"Failed to read sample format."};
         }
 
         // Interpret untyped data as unsigned integer... let's try displaying it
@@ -362,8 +363,9 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
             throw ImageLoadError{fmt::format("Unsupported sample format: {}", sampleFormat)};
         }
 
-        if (!TIFFGetField(tif, TIFFTAG_COMPRESSION, &compression)) {
-            compression = COMPRESSION_NONE;
+        uint16_t compression;
+        if (!TIFFGetFieldDefaulted(tif, TIFFTAG_COMPRESSION, &compression)) {
+            throw ImageLoadError{"Failed to read compression type."};
         }
 
         // DNG's lossy JPEG compression can be decoded by libtiff's regular JPEG decoder
@@ -380,7 +382,8 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
             throw ImageLoadError{"DNG JXL compression is unsupported."};
         }
 
-        if (!TIFFGetField(tif, TIFFTAG_PHOTOMETRIC, &photometric)) {
+        uint16_t photometric;
+        if (!TIFFGetFieldDefaulted(tif, TIFFTAG_PHOTOMETRIC, &photometric)) {
             throw ImageLoadError{"Failed to read photometric interpretation."};
         }
 
@@ -445,7 +448,8 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
             throw ImageLoadError{fmt::format("Unsupported photometric interpretation: {}", photometric)};
         }
 
-        if (!TIFFGetField(tif, TIFFTAG_PLANARCONFIG, &planar)) {
+        uint16_t planar;
+        if (!TIFFGetFieldDefaulted(tif, TIFFTAG_PLANARCONFIG, &planar)) {
             throw ImageLoadError{"Failed to read planar configuration."};
         }
 
@@ -639,51 +643,49 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
                 throw ImageLoadError{fmt::format("Failed to read tile {}", i)};
             }
 
-            decodeTasks.emplace_back(
-                ThreadPool::global().enqueueCoroutine(
-                    [&, i, td]() -> Task<void> {
-                        uint32_t* const utd = unpackedTile.data() + unpackedTileSize * i;
+            decodeTasks.emplace_back(ThreadPool::global().enqueueCoroutine(
+                [&, i, td]() -> Task<void> {
+                    uint32_t* const utd = unpackedTile.data() + unpackedTileSize * i;
 
-                        size_t planeTile = i % numTilesPerPlane;
-                        size_t tileX = planeTile % tile.numX;
-                        size_t tileY = planeTile / tile.numX;
+                    size_t planeTile = i % numTilesPerPlane;
+                    size_t tileX = planeTile % tile.numX;
+                    size_t tileY = planeTile / tile.numX;
 
-                        int xStart = tileX * tile.width;
-                        int xEnd = min((int)((tileX + 1) * tile.width), size.x());
+                    int xStart = tileX * tile.width;
+                    int xEnd = min((int)((tileX + 1) * tile.width), size.x());
 
-                        int yStart = tileY * tile.height;
-                        int yEnd = min((int)((tileY + 1) * tile.height), size.y());
+                    int yStart = tileY * tile.height;
+                    int yEnd = min((int)((tileY + 1) * tile.height), size.y());
 
-                        co_await ThreadPool::global().parallelForAsync<int>(
-                            yStart,
-                            yEnd,
-                            [&](int y) {
-                                int y0 = y - yStart;
-                                unpackBits(
-                                    td + tile.rowSize * y0, tile.rowSize, bitsPerSample, utd + unpackedTileRowSize * y0, unpackedTileRowSize, handleSign
-                                );
+                    co_await ThreadPool::global().parallelForAsync<int>(
+                        yStart,
+                        yEnd,
+                        [&](int y) {
+                            int y0 = y - yStart;
+                            unpackBits(
+                                td + tile.rowSize * y0, tile.rowSize, bitsPerSample, utd + unpackedTileRowSize * y0, unpackedTileRowSize, handleSign
+                            );
 
-                                if (planar == PLANARCONFIG_CONTIG) {
-                                    for (int x = xStart; x < xEnd; ++x) {
-                                        for (int c = 0; c < samplesPerPixel; ++c) {
-                                            auto pixel = utd[(y0 * tile.width + x - xStart) * samplesPerPixel + c];
-                                            imageData[(y * size.x() + x) * samplesPerPixel + c] = pixel;
-                                        }
-                                    }
-                                } else {
-                                    int c = i / numTilesPerPlane;
-                                    for (int x = xStart; x < xEnd; ++x) {
-                                        auto pixel = utd[y0 * tile.width + x - xStart];
+                            if (planar == PLANARCONFIG_CONTIG) {
+                                for (int x = xStart; x < xEnd; ++x) {
+                                    for (int c = 0; c < samplesPerPixel; ++c) {
+                                        auto pixel = utd[(y0 * tile.width + x - xStart) * samplesPerPixel + c];
                                         imageData[(y * size.x() + x) * samplesPerPixel + c] = pixel;
                                     }
                                 }
-                            },
-                            priority
-                        );
-                    },
-                    priority
-                )
-            );
+                            } else {
+                                int c = i / numTilesPerPlane;
+                                for (int x = xStart; x < xEnd; ++x) {
+                                    auto pixel = utd[y0 * tile.width + x - xStart];
+                                    imageData[(y * size.x() + x) * samplesPerPixel + c] = pixel;
+                                }
+                            }
+                        },
+                        priority
+                    );
+                },
+                priority
+            ));
         }
 
         for (auto&& task : decodeTasks) {
@@ -773,7 +775,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
                 tlog::debug() << "Found active area data; applying...";
                 switch (TIFFFieldDataType(field)) {
                     case TIFF_SHORT:
-                        if (uint16_t* aa; TIFFGetField(tif, TIFFTAG_ACTIVEAREA, &aa)) {
+                        if (uint16_t * aa; TIFFGetField(tif, TIFFTAG_ACTIVEAREA, &aa)) {
                             activeArea.min.y() = aa[0];
                             activeArea.min.x() = aa[1];
                             activeArea.max.y() = aa[2];
@@ -781,7 +783,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
                         }
                         break;
                     case TIFF_LONG:
-                        if (uint32_t* aa; TIFFGetField(tif, TIFFTAG_ACTIVEAREA, &aa)) {
+                        if (uint32_t * aa; TIFFGetField(tif, TIFFTAG_ACTIVEAREA, &aa)) {
                             activeArea.min.y() = aa[0];
                             activeArea.min.x() = aa[1];
                             activeArea.max.y() = aa[2];
@@ -800,7 +802,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
             uint32_t numRead = 0;
 
             // 1. Map colors via linearization table if it exists
-            if (uint16_t* linTable; TIFFGetField(tif, TIFFTAG_LINEARIZATIONTABLE, &linTable)) {
+            if (uint16_t * linTable; TIFFGetField(tif, TIFFTAG_LINEARIZATIONTABLE, &linTable)) {
                 tlog::debug() << "Found linearization table; applying...";
 
                 const float scale = 1.0f / 65535.0f;
@@ -832,7 +834,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
                 uint16_t blackLevelRepeatRows = 1;
                 uint16_t blackLevelRepeatCols = 1;
 
-                if (uint16_t* blackLevelRepeatDim; TIFFGetField(tif, TIFFTAG_BLACKLEVELREPEATDIM, &blackLevelRepeatDim)) {
+                if (uint16_t * blackLevelRepeatDim; TIFFGetField(tif, TIFFTAG_BLACKLEVELREPEATDIM, &blackLevelRepeatDim)) {
                     blackLevelRepeatRows = blackLevelRepeatDim[0];
                     blackLevelRepeatCols = blackLevelRepeatDim[1];
                 }
@@ -844,7 +846,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
                 vector<float> blackLevel(numBlackLevelPixels * samplesPerPixel, 0.0f);
                 switch (TIFFFieldDataType(field)) {
                     case TIFF_SHORT:
-                        if (uint16_t* blackLevelShort; TIFFGetField(tif, TIFFTAG_BLACKLEVEL, &numRead, &blackLevelShort)) {
+                        if (uint16_t * blackLevelShort; TIFFGetField(tif, TIFFTAG_BLACKLEVEL, &numRead, &blackLevelShort)) {
                             if (numRead != blackLevel.size()) {
                                 throw ImageLoadError{"Invalid number of black level pixels."};
                             }
@@ -858,7 +860,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
                         }
                         break;
                     case TIFF_LONG:
-                        if (uint32_t* blackLevelLong; TIFFGetField(tif, TIFFTAG_BLACKLEVEL, &numRead, &blackLevelLong)) {
+                        if (uint32_t * blackLevelLong; TIFFGetField(tif, TIFFTAG_BLACKLEVEL, &numRead, &blackLevelLong)) {
                             if (numRead != blackLevel.size()) {
                                 throw ImageLoadError{"Invalid number of black level pixels."};
                             }
@@ -954,7 +956,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
 
                 switch (TIFFFieldDataType(field)) {
                     case TIFF_SHORT:
-                        if (uint16_t* whiteLevelShort; TIFFGetField(tif, TIFFTAG_WHITELEVEL, &numRead, &whiteLevelShort)) {
+                        if (uint16_t * whiteLevelShort; TIFFGetField(tif, TIFFTAG_WHITELEVEL, &numRead, &whiteLevelShort)) {
                             if (numRead != whiteLevel.size()) {
                                 throw ImageLoadError{"Invalid number of white level pixels."};
                             }
@@ -967,7 +969,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
                         }
                         break;
                     case TIFF_LONG:
-                        if (uint32_t* whiteLevelLong; TIFFGetField(tif, TIFFTAG_WHITELEVEL, &numRead, &whiteLevelLong)) {
+                        if (uint32_t * whiteLevelLong; TIFFGetField(tif, TIFFTAG_WHITELEVEL, &numRead, &whiteLevelLong)) {
                             if (numRead != whiteLevel.size()) {
                                 throw ImageLoadError{"Invalid number of white level pixels."};
                             }
@@ -1047,7 +1049,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
             auto readCameraToXyz = [&](int CCTAG, int CMTAG) {
                 Imath::M33f colorMatrix = Imath::identity33f;
                 if (float* cmt; TIFFGetField(tif, CMTAG, &numRead, &cmt)) {
-                    if (numRead != samplesPerPixel * samplesPerPixel) {
+                    if (numRead != (uint32_t)samplesPerPixel * samplesPerPixel) {
                         throw ImageLoadError{"Invalid number of camera matrix entries."};
                     }
 
@@ -1060,7 +1062,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
 
                 Imath::M33f cameraCalibration = Imath::identity33f;
                 if (float* cct; TIFFGetField(tif, CCTAG, &numRead, &cct)) {
-                    if (numRead != samplesPerPixel * samplesPerPixel) {
+                    if (numRead != (uint32_t)samplesPerPixel * samplesPerPixel) {
                         throw ImageLoadError{"Invalid number of camera calibration entries."};
                     }
 
@@ -1128,7 +1130,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
                 }
             }
 
-            if (uint32_t* dims; TIFFGetField(tif, TIFFTAG_PROFILEHUESATMAPDIMS, &dims)) {
+            if (uint32_t * dims; TIFFGetField(tif, TIFFTAG_PROFILEHUESATMAPDIMS, &dims)) {
                 uint32_t hueDivisions = dims[0];
                 uint32_t satDivisions = dims[1];
                 uint32_t valueDivisions = dims[2];


### PR DESCRIPTION
Instead of crashing, tev will emit an error and display nothing.