### PR TITLE
feat: use tev's rather than jxl's threadpool to parallelize jxl loading

### DIFF
--- a/include/tev/ThreadPool.h
+++ b/include/tev/ThreadPool.h
@@ -116,7 +116,7 @@ public:
             }(taskStart, taskEnd, body, priority, this));
         }
 
-        for (auto& task : tasks) {
+        for (auto&& task : tasks) {
             co_await task;
         }
     }
@@ -124,6 +124,8 @@ public:
     template <typename Int, typename F> void parallelFor(Int start, Int end, F body, int priority) {
         parallelForAsync(start, end, body, priority).get();
     }
+
+    size_t numThreads() const { return mNumThreads; }
 
 private:
     size_t mNumThreads = 0;


### PR DESCRIPTION
This is mostly a latency rather than a throughput improvement since it allows tev to prioritize earlier image loads over later ones (its thread pool keeps track of task priority). When loading very large numbers of images (hundreds to thousands), it might also be a throughput improvement due to keeping thread count low and caches more coherent.