### PR TITLE
HEIC / AVIF CICP color space support (e.g. non-gainmap HDR)

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -26,6 +26,7 @@
 #include <tinylogger/tinylogger.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <filesystem>
 #include <functional>
@@ -36,28 +37,28 @@
 #include <vector>
 
 #ifdef _WIN32
-#   define NOMINMAX
-#   include <Windows.h>
-#   undef NOMINMAX
-#   pragma warning(disable : 4127) // warning C4127: conditional expression is constant
-#   pragma warning(disable : 4244) // warning C4244: conversion from X to Y, possible loss of data
+#    define NOMINMAX
+#    include <Windows.h>
+#    undef NOMINMAX
+#    pragma warning(disable : 4127) // warning C4127: conditional expression is constant
+#    pragma warning(disable : 4244) // warning C4244: conversion from X to Y, possible loss of data
 #endif
 
 // Define command key for windows/mac/linux
 #ifdef __APPLE__
-#   define SYSTEM_COMMAND_LEFT GLFW_KEY_LEFT_SUPER
-#   define SYSTEM_COMMAND_RIGHT GLFW_KEY_RIGHT_SUPER
+#    define SYSTEM_COMMAND_LEFT GLFW_KEY_LEFT_SUPER
+#    define SYSTEM_COMMAND_RIGHT GLFW_KEY_RIGHT_SUPER
 #else
-#   define SYSTEM_COMMAND_LEFT GLFW_KEY_LEFT_CONTROL
-#   define SYSTEM_COMMAND_RIGHT GLFW_KEY_RIGHT_CONTROL
+#    define SYSTEM_COMMAND_LEFT GLFW_KEY_LEFT_CONTROL
+#    define SYSTEM_COMMAND_RIGHT GLFW_KEY_RIGHT_CONTROL
 #endif
 
 #ifdef __GNUC__
-#   define LIKELY(condition) __builtin_expect(static_cast<bool>(condition), 1)
-#   define UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
+#    define LIKELY(condition) __builtin_expect(static_cast<bool>(condition), 1)
+#    define UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
 #else
-#   define LIKELY(condition) condition
-#   define UNLIKELY(condition) condition
+#    define LIKELY(condition) condition
+#    define UNLIKELY(condition) condition
 #endif
 
 #define TEV_ASSERT(cond, description, ...) \
@@ -65,13 +66,31 @@
         throw std::runtime_error { fmt::format(description, ##__VA_ARGS__) }
 
 #ifndef TEV_VERSION
-#   define TEV_VERSION "undefined"
+#    define TEV_VERSION "undefined"
 #endif
 
 // Make std::filesystem::path formattable.
 template <> struct fmt::formatter<std::filesystem::path> : fmt::formatter<std::string_view> {
     template <typename FormatContext> auto format(const std::filesystem::path& path, FormatContext& ctx) const {
         return formatter<std::string_view>::format(path.string(), ctx);
+    }
+};
+
+template <typename T, size_t N_DIMS> struct fmt::formatter<std::array<T, N_DIMS>> {
+    template <class ParseContext> constexpr ParseContext::iterator parse(ParseContext& ctx) { return ctx.begin(); }
+    template <class FmtContext> FmtContext::iterator format(const std::array<T, N_DIMS>& v, FmtContext& ctx) const {
+        auto&& out = ctx.out();
+
+        fmt::format_to(out, "[");
+        for (size_t i = 0; i < N_DIMS; ++i) {
+            if (i != 0) {
+                fmt::format_to(out, ", ");
+            }
+
+            fmt::format_to(out, "{}", v[i]);
+        }
+
+        return fmt::format_to(ctx.out(), "]");
     }
 };
 

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -182,16 +182,16 @@ inline float pqToLinear(float val) {
     constexpr float invm2 = 32.0f / 2523.0f;
 
     const float tmp = std::pow(std::max(val, 0.0f), invm2);
-    const float result_cdm2 = 10000.0f * std::pow(std::max(tmp - c1, 0.0f) / std::max(c2 - c3 * tmp, 1e-5f), invm1);
-    return result_cdm2 / 80.0f; // Convert to linear sRGB units where SDR white (1.0) is 80 cd/m^2
+    const float resultCdm2 = 10000.0f * std::pow(std::max(tmp - c1, 0.0f) / std::max(c2 - c3 * tmp, 1e-5f), invm1);
+    return resultCdm2 / 80.0f; // Convert to linear sRGB units where SDR white (1.0) is 80 cd/m^2
 }
 
 inline float hlgToLinear(float val) {
     constexpr float a = 0.17883277f;
     constexpr float b = 0.28466892f;
     constexpr float c = 0.55991073f;
-    const float result_cdm2 = 1000.0f * (val <= 0.5f ? (val * val / 3.0f) : ((std::exp((val - c) / a) + b) / 12.0f));
-    return result_cdm2 / 80.0f; // Convert to linear sRGB units where SDR white (1.0) is 80 cd/m^2
+    const float resultCdm2 = 1000.0f * (val <= 0.5f ? (val * val / 3.0f) : ((std::exp((val - c) / a) + b) / 12.0f));
+    return resultCdm2 / 80.0f; // Convert to linear sRGB units where SDR white (1.0) is 80 cd/m^2
 }
 
 inline float invTransfer(const uint8_t transfer, float val) {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -206,14 +206,9 @@ Task<void> ImageData::ensureValid(string_view channelSelector, int taskPriority)
 
     for (const auto& c : channels) {
         if (c.size() != size()) {
-            throw ImageLoadError{fmt::format(
-                "All channels must have the same size as the data window. ({}:{}x{} != {}x{})",
-                c.name(),
-                c.size().x(),
-                c.size().y(),
-                size().x(),
-                size().y()
-            )};
+            throw ImageLoadError{
+                fmt::format("All channels must have the same size as the data window. ({}: {} != {})", c.name(), c.size(), size())
+            };
         }
     }
 

--- a/src/imageio/Colors.cpp
+++ b/src/imageio/Colors.cpp
@@ -389,6 +389,26 @@ Task<void> toLinearSrgbPremul(
 
 // Partial implementation of https://www.itu.int/rec/T-REC-H.273-202407-I/en (no YCbCr conversion)
 namespace ituth273 {
+
+string_view toString(const EColorPrimaries primaries) {
+    switch (primaries) {
+        case EColorPrimaries::BT709: return "bt709";
+        case EColorPrimaries::Unspecified: return "unspecified";
+        case EColorPrimaries::BT470M: return "bt470m";
+        case EColorPrimaries::BT470BG: return "bt470bg";
+        case EColorPrimaries::SMPTE170M: return "smpte170m";
+        case EColorPrimaries::SMPTE240M: return "smpte240m";
+        case EColorPrimaries::Film: return "film";
+        case EColorPrimaries::BT2020: return "bt2020";
+        case EColorPrimaries::SMPTE428: return "smpte428";
+        case EColorPrimaries::SMPTE431: return "smpte431";
+        case EColorPrimaries::SMPTE432: return "smpte432";
+        case EColorPrimaries::Weird: return "weird";
+    }
+
+    return "invalid";
+}
+
 array<Vector2f, 4> chroma(const EColorPrimaries primaries) {
     switch (primaries) {
         default: tlog::warning() << fmt::format("Unknown color primaries {}. Using Rec.709 chroma.", (int)primaries); return rec709Chroma();
@@ -480,6 +500,66 @@ array<Vector2f, 4> chroma(const EColorPrimaries primaries) {
 
     return rec709Chroma(); // Fallback to Rec.709 if unknown
 }
+
+string_view toString(const ETransferCharacteristics transfer) {
+    switch (transfer) {
+        case ETransferCharacteristics::BT709: return "bt709";
+        case ETransferCharacteristics::Unspecified: return "unspecified";
+        case ETransferCharacteristics::BT470M: return "bt470m";
+        case ETransferCharacteristics::BT470BG: return "bt470bg";
+        case ETransferCharacteristics::BT601: return "bt601";
+        case ETransferCharacteristics::SMPTE240: return "smpte240";
+        case ETransferCharacteristics::Linear: return "linear";
+        case ETransferCharacteristics::Log100: return "log100";
+        case ETransferCharacteristics::Log100Sqrt10: return "log100_sqrt10";
+        case ETransferCharacteristics::IEC61966: return "iec61966";
+        case ETransferCharacteristics::BT1361Extended: return "bt1361_extended";
+        case ETransferCharacteristics::SRGB: return "srgb";
+        case ETransferCharacteristics::BT202010bit: return "bt2020_10bit";
+        case ETransferCharacteristics::BT202012bit: return "bt2020_12bit";
+        case ETransferCharacteristics::PQ: return "pq";
+        case ETransferCharacteristics::SMPTE428: return "smpte428";
+        case ETransferCharacteristics::HLG: return "hlg";
+    }
+
+    return "invalid";
+}
+
+bool isTransferImplemented(const ETransferCharacteristics transfer) {
+    switch (transfer) {
+        case ETransferCharacteristics::BT709:
+        case ETransferCharacteristics::BT601:
+        case ETransferCharacteristics::BT202010bit:
+        case ETransferCharacteristics::BT202012bit:
+        case ETransferCharacteristics::IEC61966: // handles negative values by mirroring
+        case ETransferCharacteristics::BT1361Extended: // extended to negative values (weirdly)
+        case ETransferCharacteristics::BT470M:
+        case ETransferCharacteristics::BT470BG:
+        case ETransferCharacteristics::SMPTE240:
+        case ETransferCharacteristics::Linear:
+        case ETransferCharacteristics::Log100:
+        case ETransferCharacteristics::Log100Sqrt10:
+        case ETransferCharacteristics::SRGB:
+        case ETransferCharacteristics::PQ:
+        case ETransferCharacteristics::SMPTE428:
+        case ETransferCharacteristics::HLG:
+        case ETransferCharacteristics::Unspecified: return true;
+    }
+
+    return false;
+}
+
 } // namespace ituth273
+
+LimitedRange limitedRangeForBitsPerPixel(int bitsPerPixel) {
+    switch (bitsPerPixel) {
+        case 8: return {255.0f / 219.0f, 16.0f / 255.0f};
+        case 10: return {1023.0f / 876.0f, 64.0f / 1023.0f};
+        case 12: return {4095.0f / 3504.0f, 256.0f / 4095.0f};
+    }
+
+    tlog::warning() << fmt::format("Unsupported bits per pixel {} with limited range flag.", bitsPerPixel);
+    return {1.0f, 0.0f};
+}
 
 } // namespace tev

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -532,23 +532,15 @@ Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const fs::path& p
             };
 
             if (!data.dataWindow.isValid()) {
-                throw ImageLoadError{fmt::format(
-                    "EXR image has invalid data window: [{},{}] - [{},{}]",
-                    data.dataWindow.min.x(),
-                    data.dataWindow.min.y(),
-                    data.dataWindow.max.x(),
-                    data.dataWindow.max.y()
-                )};
+                throw ImageLoadError{
+                    fmt::format("EXR image has invalid data window: min={}, max={}", data.dataWindow.min, data.dataWindow.max)
+                };
             }
 
             if (!data.displayWindow.isValid()) {
-                throw ImageLoadError{fmt::format(
-                    "EXR image has invalid display window: [{},{}] - [{},{}]",
-                    data.displayWindow.min.x(),
-                    data.displayWindow.min.y(),
-                    data.displayWindow.max.x(),
-                    data.displayWindow.max.y()
-                )};
+                throw ImageLoadError{
+                    fmt::format("EXR image has invalid display window: min={}, max={}", data.displayWindow.min, data.displayWindow.max)
+                };
             }
 
             part.setFrameBuffer(frameBuffers.at(partIdx));

--- a/src/imageio/HeifImageLoader.cpp
+++ b/src/imageio/HeifImageLoader.cpp
@@ -232,17 +232,7 @@ Task<vector<ImageData>>
 
             resultData.toRec709 = chromaToRec709Matrix(chroma);
 
-            tlog::debug() << fmt::format(
-                "Applying NCLX color profile with primaries: red ({}, {}), green ({}, {}), blue ({}, {}), white ({}, {}).",
-                chroma[0].x(),
-                chroma[0].y(),
-                chroma[1].x(),
-                chroma[1].y(),
-                chroma[2].x(),
-                chroma[2].y(),
-                chroma[3].x(),
-                chroma[3].y()
-            );
+            tlog::debug() << fmt::format("Applying NCLX color profile with primaries: {}", chroma);
         }
 
         co_return resultData;

--- a/src/imageio/HeifImageLoader.cpp
+++ b/src/imageio/HeifImageLoader.cpp
@@ -193,9 +193,32 @@ Task<vector<ImageData>>
             }
         }
 
-        // Otherwise, assume the image is in Rec.709/sRGB and convert it to linear space, followed by an optional change in color space if
-        // an NCLX profile is present.
-        co_await toFloat32<uint16_t, true>(
+        // Otherwise, check for an NCLX color profile and, if not present, assume the image is in Rec.709/sRGB.
+        // See: https://github.com/AOMediaCodec/libavif/wiki/CICP
+        heif_color_profile_nclx* nclx = nullptr;
+        if (auto error = heif_image_handle_get_nclx_color_profile(imgHandle, &nclx); error.code != heif_error_Ok) {
+            if (error.code != heif_error_Color_profile_does_not_exist) {
+                tlog::warning() << "Failed to read NCLX color profile: " << error.message;
+            }
+
+            co_await toFloat32<uint16_t, true>(
+                (const uint16_t*)data,
+                numChannels,
+                resultData.channels.front().data(),
+                4,
+                size,
+                hasAlpha,
+                priority,
+                channelScale,
+                bytesPerRow / sizeof(uint16_t)
+            );
+
+            co_return resultData;
+        }
+
+        ScopeGuard nclxGuard{[nclx] { heif_nclx_color_profile_free(nclx); }};
+
+        co_await toFloat32<uint16_t, false>(
             (const uint16_t*)data,
             numChannels,
             resultData.channels.front().data(),
@@ -207,19 +230,45 @@ Task<vector<ImageData>>
             bytesPerRow / sizeof(uint16_t)
         );
 
-        heif_color_profile_nclx* nclx = nullptr;
-        if (auto error = heif_image_handle_get_nclx_color_profile(imgHandle, &nclx); error.code != heif_error_Ok) {
-            if (error.code == heif_error_Color_profile_does_not_exist) {
-                co_return resultData;
-            }
-
-            tlog::warning() << "Failed to read NCLX color profile: " << error.message;
-            co_return resultData;
+        LimitedRange range = LimitedRange::full();
+        if (nclx->full_range_flag == 0) {
+            range = limitedRangeForBitsPerPixel(bitsPerPixel);
         }
 
-        ScopeGuard nclxGuard{[nclx] { heif_nclx_color_profile_free(nclx); }};
+        auto cicpTransfer = static_cast<ituth273::ETransferCharacteristics>(nclx->transfer_characteristics);
+        tlog::debug() << fmt::format(
+            "NCLX: primaries={}, transfer={}, full_range={}",
+            ituth273::toString((ituth273::EColorPrimaries)nclx->color_primaries),
+            ituth273::toString(cicpTransfer),
+            nclx->full_range_flag == 1 ? "yes" : "no"
+        );
 
-        // Only convert if not already in Rec.709/sRGB *and* if primaries are actually specified
+        if (!ituth273::isTransferImplemented(cicpTransfer)) {
+            tlog::warning() << fmt::format("Unsupported transfer '{}' in NCLX. Using sRGB instead.", ituth273::toString(cicpTransfer));
+            cicpTransfer = ituth273::ETransferCharacteristics::SRGB;
+        }
+
+        auto* pixelData = resultData.channels.front().data();
+        const size_t numPixels = size.x() * (size_t)size.y();
+        co_await ThreadPool::global().parallelForAsync<size_t>(
+            0,
+            numPixels,
+            [&](size_t i) {
+                // HEIF/AVIF unfortunately tends to have the alpha channel premultiplied in non-linear space (after application of the
+                // transfer), so we must unpremultiply prior to the color space conversion and transfer function inversion.
+                const float alpha = hasAlpha ? pixelData[i * 4 + 3] : 1.0f;
+                const float factor = resultData.hasPremultipliedAlpha && alpha > 0.0001f ? (1.0f / alpha) : 1.0f;
+                const float invFactor = resultData.hasPremultipliedAlpha && alpha > 0.0001f ? alpha : 1.0f;
+
+                for (size_t c = 0; c < 3; ++c) {
+                    const float val = (pixelData[i * 4 + c] - range.offset) * range.scale;
+                    pixelData[i * 4 + c] = invFactor * ituth273::invTransfer(cicpTransfer, factor * val);
+                }
+            },
+            priority
+        );
+
+        // Only convert color space if not already in Rec.709/sRGB *and* if primaries are actually specified
         if (nclx->color_primaries != heif_color_primaries_ITU_R_BT_709_5 && nclx->color_primaries != heif_color_primaries_unspecified) {
             array<Vector2f, 4> chroma = {
                 {
@@ -232,7 +281,7 @@ Task<vector<ImageData>>
 
             resultData.toRec709 = chromaToRec709Matrix(chroma);
 
-            tlog::debug() << fmt::format("Applying NCLX color profile with primaries: {}", chroma);
+            tlog::warning() << fmt::format("Applying NCLX color profile: primaries={}", chroma);
         }
 
         co_return resultData;

--- a/src/imageio/JpegTurboImageLoader.cpp
+++ b/src/imageio/JpegTurboImageLoader.cpp
@@ -124,7 +124,7 @@ Task<vector<ImageData>> JpegTurboImageLoader::load(istream& iStream, const fs::p
         throw ImageLoadError{fmt::format("Unsupported number of color channels: {}", numColorChannels)};
     }
 
-    tlog::debug() << fmt::format("JPEG image info: {}x{}, {} channels", size.x(), size.y(), numColorChannels);
+    tlog::debug() << fmt::format("JPEG image info: size={}, numColorChannels={}", size, numColorChannels);
 
     // Allocate memory for image data
     auto numPixels = static_cast<size_t>(size.x()) * size.y();
@@ -157,9 +157,7 @@ Task<vector<ImageData>> JpegTurboImageLoader::load(istream& iStream, const fs::p
             tlog::debug() << fmt::format("EXIF image orientation: {}", (int)orientation);
 
             co_await orientToTopLeft(imageData, size, orientation, priority);
-        } catch (const invalid_argument& e) {
-            tlog::warning() << fmt::format("Failed to read EXIF metadata: {}", e.what());
-        }
+        } catch (const invalid_argument& e) { tlog::warning() << fmt::format("Failed to read EXIF metadata: {}", e.what()); }
     }
 
     vector<ImageData> result(1);

--- a/src/imageio/JxlImageLoader.cpp
+++ b/src/imageio/JxlImageLoader.cpp
@@ -257,16 +257,16 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
                 // test images when it did so, so we will do the color space conversion ourselves as long as the color space isn't XYB which
                 // we do not support yet.
                 const auto target = JXL_COLOR_PROFILE_TARGET_DATA;
-                if (JxlColorEncoding local_ce; JXL_DEC_SUCCESS == JxlDecoderGetColorAsEncodedProfile(decoder.get(), target, &local_ce)) {
+                if (JxlColorEncoding localCe; JXL_DEC_SUCCESS == JxlDecoderGetColorAsEncodedProfile(decoder.get(), target, &localCe)) {
                     iccProfile.clear();
-                    if (local_ce.color_space == JXL_COLOR_SPACE_XYB) {
+                    if (localCe.color_space == JXL_COLOR_SPACE_XYB) {
                         ce = nullopt;
                         JxlColorEncodingSetToLinearSRGB(&ce.value(), false /* XYB is never grayscale */);
                         if (JxlDecoderSetPreferredColorProfile(decoder.get(), &ce.value()) != JXL_DEC_SUCCESS) {
                             throw ImageLoadError{"Failed to set up XYB->sRGB conversion."};
                         }
                     } else {
-                        ce = local_ce;
+                        ce = localCe;
                     }
                 } else {
                     // The jxl spec says that color space can *always* unambiguously be determined from an ICC color encoding, so we can

--- a/src/imageio/JxlImageLoader.cpp
+++ b/src/imageio/JxlImageLoader.cpp
@@ -423,8 +423,8 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
                     // If color encoding information is available, we need to use it to convert to linear sRGB. Otherwise, assume the
                     // decoder has already prepared the data in linear sRGB for us.
                     if (ce) {
-                        // Primaries are only valid for RGB data
-                        if (ce->color_space == JXL_COLOR_SPACE_RGB) {
+                        // Primaries are only valid for RGB data. We need to set up a conversion matrix only if we aren't already in sRGB.
+                        if (ce->color_space == JXL_COLOR_SPACE_RGB && ce->primaries != JXL_PRIMARIES_SRGB) {
                             data.toRec709 = chromaToRec709Matrix({
                                 {{(float)ce->primaries_red_xy[0], (float)ce->primaries_red_xy[1]},
                                  {(float)ce->primaries_green_xy[0], (float)ce->primaries_green_xy[1]},

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -133,9 +133,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
         throw ImageLoadError{fmt::format("Unsupported PNG bit depth: {}", bitDepth)};
     }
 
-    tlog::debug() << fmt::format(
-        "PNG image info: {}x{}, {} channels, {} bit depth, color type: {}", size.x(), size.y(), numChannels, bitDepth, colorType
-    );
+    tlog::debug() << fmt::format("PNG image info: size={}, numChannels={}, bitDepth={}, colorType={}", size, numChannels, bitDepth, colorType);
 
     // 16 bit channels are big endian by default, but we want little endian on little endian systems
     if (bitDepth == 16 && std::endian::little == std::endian::native) {

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -317,8 +317,7 @@ Task<void> postprocessLinearRawDng(
         resultData.displayWindow = activeArea;
     }
 
-    tlog::debug(
-    ) << fmt::format("Active area: min=({},{}) max=({},{})", activeArea.min.x(), activeArea.min.y(), activeArea.max.x(), activeArea.max.y());
+    tlog::debug() << fmt::format("Active area: min={} max={}", activeArea.min, activeArea.max);
 
     // Utility var that we'll reuse whenever reading a variable TIFF array
     uint32_t numRead = 0;
@@ -1005,9 +1004,8 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
     }
 
     tlog::debug() << fmt::format(
-        "TIFF info: {}x{}, bps={}, spp={}, photometric={}, planar={}, sampleFormat={}, compression={}",
-        size.x(),
-        size.y(),
+        "TIFF info: size={}, bps={}, spp={}, photometric={}, planar={}, sampleFormat={}, compression={}",
+        size,
         bitsPerSample,
         samplesPerPixel,
         photometric,


### PR DESCRIPTION
- Improves various aspects of CICP related color conversion in existing supported codecs (PNG and JXL)
- Adds CICP based color conversion to AVIF and HEIC
- Adds support for limited / narrow range RGB images