### PR TITLE
Wayland support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       APPIMAGE_EXTRACT_AND_RUN: 1# https://github.com/AppImage/AppImageKit/wiki/FUSE#docker
     steps:
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake gcc-10 g++-10 libglu1-mesa-dev xorg-dev zenity zlib1g-dev
+        run: sudo apt-get update && sudo apt-get install -y cmake gcc-10 g++-10 libglu1-mesa-dev xorg-dev zenity zlib1g-dev libwayland-dev wayland-protocols libxkbcommon-dev libffi-dev
       - uses: actions/checkout@v1
         with:
           submodules: recursive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ project(
 )
 set(TEV_VERSION "${CMAKE_PROJECT_VERSION}")
 
+if (APPLE)
+    enable_language(OBJC)
+endif()
+
 if (NOT TEV_DEPLOY)
     set(TEV_VERSION "${TEV_VERSION}dev")
 endif()

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ There are helper functions in [Ipc.cpp](src/Ipc.cpp) (`IpcPacket::set*`) that sh
 
 All that is required for building __tev__ is [CMake](https://cmake.org/) and a C++20-compatible compiler. On Windows, that's Visual Studio 2019 and newer. On Linux and macOS, your system's GCC or Clang compiler is likely sufficient.
 
-Most Linux distributions additionally require _xorg_, _gl_, and _zenity_. On Ubuntu/Debian simply call
+Most Linux distributions additionally require _xorg_, _wayland_, _gl_, and _zenity_. On Ubuntu/Debian simply call
 ```sh
-$ apt-get install cmake xorg-dev libglu1-mesa-dev zenity
+$ apt-get install cmake xorg-dev libglu1-mesa-dev zenity zlib1g-dev libwayland-dev wayland-protocols libxkbcommon-dev libffi-dev
 ```
 
 Once all dependencies are installed, begin by cloning this repository and all its submodules using the following command:

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,7 @@
               gcc
               gdb
               binutils
+              mesa-demos # for glxinfo, eglinfo
             ]
           );
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -26,13 +26,21 @@
             darwin.apple_sdk.frameworks.Cocoa
             darwin.apple_sdk.frameworks.OpenGL
           ] else [
+            pkg-config
             libGL
             perl
+            # X11 libraries
             xorg.libX11
             xorg.libXcursor
             xorg.libXi
             xorg.libXinerama
             xorg.libXrandr
+            # Wayland libraries
+            libxkbcommon
+            libffi
+            wayland
+            wayland-protocols
+            wayland-scanner
           ];
 
         # Common build inputs shared between dev shell and build
@@ -77,6 +85,10 @@
               binutils
             ]
           );
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (with pkgs; [
+            wayland
+            libxkbcommon
+          ]);
         };
 
         apps.default = flake-utils.lib.mkApp {

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -308,10 +308,11 @@ public:
     void enqueue(const fs::path& path, std::string_view channelSelector, bool shallSelect, const std::shared_ptr<Image>& toReplace = nullptr);
     void checkDirectoriesForNewFilesAndLoadThose();
 
-    std::optional<ImageAddition> tryPop() { return mLoadedImages.tryPop(); }
+    std::optional<ImageAddition> tryPop();
+    std::optional<nanogui::Vector2i> firstImageSize() const;
 
     bool publishSortedLoads();
-    bool hasPendingLoads() const { return mLoadCounter != mUnsortedLoadCounter; }
+    bool hasPendingLoads() const;
 
     bool recursiveDirectories() const { return mRecursiveDirectories; }
     void setRecursiveDirectories(bool value) { mRecursiveDirectories = value; }
@@ -326,7 +327,7 @@ private:
     SharedQueue<ImageAddition> mLoadedImages;
 
     std::priority_queue<ImageAddition, std::vector<ImageAddition>, ImageAddition::Comparator> mPendingLoadedImages;
-    std::mutex mPendingLoadedImagesMutex;
+    mutable std::mutex mPendingLoadedImagesMutex;
 
     std::atomic<int> mLoadCounter{0};
     std::atomic<int> mUnsortedLoadCounter{0};

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -44,6 +44,7 @@ namespace tev {
 class ImageViewer : public nanogui::Screen {
 public:
     ImageViewer(
+        const nanogui::Vector2i& size,
         const std::shared_ptr<BackgroundImagesLoader>& imagesLoader,
         const std::shared_ptr<Ipc>& ipc,
         bool maximize,
@@ -288,6 +289,7 @@ private:
     int mDidFitToImage = 0;
 
     nanogui::Vector2i mMaxSize = {8192, 8192};
+    bool mInitialized = false;
 };
 
 } // namespace tev

--- a/include/tev/SharedQueue.h
+++ b/include/tev/SharedQueue.h
@@ -71,6 +71,12 @@ public:
         return result;
     }
 
+    // Only call while holding the mutex!
+    const T& front() const {
+        std::unique_lock lock{mMutex};
+        return mRawQueue.front();
+    }
+
 private:
     std::deque<T> mRawQueue;
     mutable std::mutex mMutex;

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -869,6 +869,25 @@ void BackgroundImagesLoader::checkDirectoriesForNewFilesAndLoadThose() {
     }
 }
 
+optional<ImageAddition> BackgroundImagesLoader::tryPop() {
+    const lock_guard lock{mPendingLoadedImagesMutex};
+    return mLoadedImages.tryPop();
+}
+
+optional<nanogui::Vector2i> BackgroundImagesLoader::firstImageSize() const {
+    const lock_guard lock{mPendingLoadedImagesMutex};
+    if (mLoadedImages.empty()) {
+        return nullopt;
+    }
+
+    const ImageAddition& firstImage = mLoadedImages.front();
+    if (firstImage.images.empty()) {
+        return nullopt;
+    }
+
+    return firstImage.images.front()->size();
+}
+
 bool BackgroundImagesLoader::publishSortedLoads() {
     const lock_guard lock{mPendingLoadedImagesMutex};
     bool pushed = false;
@@ -891,6 +910,11 @@ bool BackgroundImagesLoader::publishSortedLoads() {
     }
 
     return pushed;
+}
+
+bool BackgroundImagesLoader::hasPendingLoads() const {
+    const lock_guard lock{mPendingLoadedImagesMutex};
+    return mLoadCounter != mUnsortedLoadCounter;
 }
 
 } // namespace tev

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -582,7 +582,7 @@ static int mainFunc(span<const string> arguments) {
         // Wait until the first image is loaded to determine the size of the window.
         while (imagesLoader->hasPendingLoads()) {
             if (auto sizeOpt = imagesLoader->firstImageSize()) {
-                size = *sizeOpt;
+                size = nanogui::max(*sizeOpt, size);
                 break;
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -577,8 +577,21 @@ static int mainFunc(span<const string> arguments) {
         return -3;
     }
 
+    nanogui::Vector2i size = {1024, 800};
+    if (imageFiles && !maximize) {
+        // Wait until the first image is loaded to determine the size of the window.
+        while (imagesLoader->hasPendingLoads()) {
+            if (auto sizeOpt = imagesLoader->firstImageSize()) {
+                size = *sizeOpt;
+                break;
+            }
+
+            this_thread::sleep_for(1ms);
+        }
+    }
+
     // sImageViewer is a raw pointer to make sure it will never get deleted. nanogui crashes upon cleanup, so we better not try.
-    sImageViewer = new ImageViewer{imagesLoader, ipc, maximize, !hideUiFlag, capability10bit || capabilityEdr, capabilityEdr};
+    sImageViewer = new ImageViewer{size, imagesLoader, ipc, maximize, !hideUiFlag, capability10bit || capabilityEdr, capabilityEdr};
     imageViewerIsReady = true;
 
     sImageViewer->draw_all();


### PR DESCRIPTION
This PR rebases tev's custom glfw fork onto the latest version in order to support Wayland natively (rather than, as previously, through XWayland). This additionally involves a small nanogui patch to make fractional scaling work correctly in Wayland, as well as a revisit of floating point framebuffers that should make future support of HDR rendering on Wayland (as well as Windows) easier.