### PR TITLE
HDR display on Windows and Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Image viewer and comparison tool for graphics people.
 - __Lightning fast:__ starts up instantly, loads hundreds of images in seconds.
 - __Accurate:__ understands ICC color profiles and HDR. Displays everything in linear sRGB/Rec.709.
 - __Versatile:__ supports many [file formats](#file-formats), histograms, pixel-peeping, tonemaps, error metrics, etc.
-- __HDR:__ displays true HDR on Apple EDR displays.
+- __HDR:__ displays true HDR on Windows, macOS, and Linux (Wayland only).
 
 ![Screenshot](resources/screenshot.png)
 _A false-color comparison of two multi-layer OpenEXR images of a beach ball. Image courtesy of [openexr-images](https://github.com/openexr/openexr-images)._

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -42,7 +42,7 @@ struct CanvasStatistics {
 
 class ImageCanvas : public nanogui::Canvas {
 public:
-    ImageCanvas(nanogui::Widget* parent, bool supportsHdr, float pixelRatio);
+    ImageCanvas(nanogui::Widget* parent, bool supportsHdr);
 
     bool scroll_event(const nanogui::Vector2i& p, const nanogui::Vector2f& rel) override;
 
@@ -116,6 +116,9 @@ public:
     std::shared_ptr<Lazy<std::shared_ptr<CanvasStatistics>>> canvasStatistics();
 
     void purgeCanvasStatistics(int imageId);
+
+    float pixelRatio() const { return mPixelRatio; }
+    void setPixelRatio(float ratio) { mPixelRatio = ratio; }
 
 private:
     static std::vector<Channel> channelsFromImages(

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -52,6 +52,8 @@ public:
         bool floatBuffer
     );
 
+    bool resize_event(const nanogui::Vector2i& size) override;
+
     bool mouse_button_event(const nanogui::Vector2i& p, int button, bool down, int modifiers) override;
     bool mouse_motion_event(const nanogui::Vector2i& p, const nanogui::Vector2i& rel, int button, int modifiers) override;
 

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -49,8 +49,7 @@ public:
         const std::shared_ptr<Ipc>& ipc,
         bool maximize,
         bool showUi,
-        bool floatBuffer,
-        bool supportsHdr
+        bool floatBuffer
     );
 
     bool mouse_button_event(const nanogui::Vector2i& p, int button, bool down, int modifiers) override;

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -202,8 +202,8 @@ inline float invTransfer(const ETransferCharacteristics transfer, float val) {
             return std::copysign(bt709ToLinear(std::abs(val)), val);
         case ETransferCharacteristics::BT1361Extended: // extended to negative values (weirdly)
             return bt1361ExtendedToLinear(val);
-        case ETransferCharacteristics::BT470M: return std::pow(val, 2.2f);
-        case ETransferCharacteristics::BT470BG: return std::pow(val, 2.8f);
+        case ETransferCharacteristics::BT470M: return std::pow(std::max(val, 0.0f), 2.2f);
+        case ETransferCharacteristics::BT470BG: return std::pow(std::max(val, 0.0f), 2.8f);
         case ETransferCharacteristics::SMPTE240: return smpteSt240ToLinear(val);
         case ETransferCharacteristics::Linear: return val;
         case ETransferCharacteristics::Log100: return val > 0.0f ? std::exp((val - 1.0f) * 2.0f * std::log(10.0f)) : 0.0f;

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -179,7 +179,7 @@ inline float pqToLinear(float val) {
 
     const float tmp = std::pow(std::max(val, 0.0f), invm2);
     const float resultCdm2 = 10000.0f * std::pow(std::max(tmp - c1, 0.0f) / std::max(c2 - c3 * tmp, 1e-5f), invm1);
-    return resultCdm2 / 80.0f; // Convert to linear sRGB units where SDR white (1.0) is 80 cd/m^2
+    return resultCdm2 / 203.0f; // Convert to linear sRGB units where SDR white is 1.0
 }
 
 inline float smpteSt428ToLinear(float val) { return std::pow(val, 2.6f) * (52.37f / 48.0f); }
@@ -189,7 +189,7 @@ inline float hlgToLinear(float val) {
     constexpr float b = 0.28466892f;
     constexpr float c = 0.55991073f;
     const float resultCdm2 = 1000.0f * (val <= 0.5f ? (val * val / 3.0f) : ((std::exp((val - c) / a) + b) / 12.0f));
-    return resultCdm2 / 80.0f; // Convert to linear sRGB units where SDR white (1.0) is 80 cd/m^2
+    return resultCdm2 / 203.0f; // Convert to linear sRGB units where SDR white is 1.0
 }
 
 inline float invTransfer(const ETransferCharacteristics transfer, float val) {

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -36,8 +36,7 @@ using namespace std;
 
 namespace tev {
 
-ImageCanvas::ImageCanvas(Widget* parent, bool supportsHdr, float pixelRatio) :
-    Canvas{parent, 1, false, false, false}, mSupportsHdr{supportsHdr}, mPixelRatio{pixelRatio} {
+ImageCanvas::ImageCanvas(Widget* parent, bool supportsHdr) : Canvas{parent, 1, false, false, false}, mSupportsHdr{supportsHdr} {
     mShader.reset(new UberShader{render_pass()});
     set_draw_border(false);
 }

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -104,7 +104,8 @@ ImageViewer::ImageViewer(
     mSidebarLayout = new Widget{tmp};
     mSidebarLayout->set_layout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 0, 0});
 
-    mImageCanvas = new ImageCanvas{horizontalScreenSplit, mSupportsHdr, pixel_ratio()};
+    mImageCanvas = new ImageCanvas{horizontalScreenSplit, mSupportsHdr};
+    mImageCanvas->setPixelRatio(pixel_ratio());
 
     // Tonemapping sectionim
     {
@@ -503,6 +504,13 @@ ImageViewer::ImageViewer(
     updateLayout();
 
     mInitialized = true;
+}
+
+bool ImageViewer::resize_event(const Vector2i& size) {
+    mImageCanvas->setPixelRatio(pixel_ratio());
+    requestLayoutUpdate();
+
+    return Screen::resize_event(size);
 }
 
 bool ImageViewer::mouse_button_event(const nanogui::Vector2i& p, int button, bool down, int modifiers) {

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -57,7 +57,7 @@ ImageViewer::ImageViewer(
 
     mSupportsHdr = m_float_buffer;
     if (mSupportsHdr) {
-        tlog::success() << "Launching with HDR display support.";
+        tlog::success() << "Obtained floating point frame buffer. Will display HDR if operating system and display support it.";
     }
 
     // At this point we no longer need the standalone console (if it exists).

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -51,16 +51,14 @@ ImageViewer::ImageViewer(
     const shared_ptr<Ipc>& ipc,
     bool maximize,
     bool showUi,
-    bool floatBuffer,
-    bool /*supportsHdr*/
+    bool floatBuffer
 ) :
     nanogui::Screen{size, "tev", true, maximize, false, true, true, floatBuffer}, mImagesLoader{imagesLoader}, mIpc{ipc} {
 
-    if (floatBuffer && !m_float_buffer) {
-        tlog::warning() << "Failed to create floating point frame buffer.";
-    }
-
     mSupportsHdr = m_float_buffer;
+    if (mSupportsHdr) {
+        tlog::success() << "Launching with HDR display support.";
+    }
 
     // At this point we no longer need the standalone console (if it exists).
     toggleConsole();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -554,15 +554,6 @@ static int mainFunc(span<const string> arguments) {
     glfwSetOpenedFilenamesCallback([](const char* imageFile) { sImageViewer->imagesLoader().enqueue(toPath(imageFile), "", false); });
 #endif
 
-    auto [capability10bit, capabilityEdr] = nanogui::test_10bit_edr_support();
-    if (get(ldrFlag)) {
-        capability10bit = false;
-        capabilityEdr = false;
-    }
-
-    tlog::info() << "Launching with " << (capability10bit ? 10 : 8) << " bits of color and " << (capabilityEdr ? "HDR" : "LDR")
-                 << " display support.";
-
     // Do what the maximize flag tells us---if it exists---and maximize if we have images otherwise.
     bool maximize = imageFiles;
     if (maximizeFlagOn) {
@@ -591,7 +582,7 @@ static int mainFunc(span<const string> arguments) {
     }
 
     // sImageViewer is a raw pointer to make sure it will never get deleted. nanogui crashes upon cleanup, so we better not try.
-    sImageViewer = new ImageViewer{size, imagesLoader, ipc, maximize, !hideUiFlag, capability10bit || capabilityEdr, capabilityEdr};
+    sImageViewer = new ImageViewer{size, imagesLoader, ipc, maximize, !hideUiFlag, !get(ldrFlag)};
     imageViewerIsReady = true;
 
     sImageViewer->draw_all();


### PR DESCRIPTION
With this PR, tev can drive HDR displays on Windows and Wayland. (With correct color space and SDR white level matching.)

tev already supported HDR display on macOS for a long time so I'm fairly happy to have this feature finally come to other OSs. 