### PR TITLE
RAM / VRAM frugality

### DIFF
--- a/include/tev/Channel.h
+++ b/include/tev/Channel.h
@@ -39,7 +39,7 @@ public:
     static bool isTopmost(std::string_view fullChannel);
     static bool isAlpha(std::string_view fullChannel);
 
-    static nanogui::Color color(std::string_view fullChannel);
+    static nanogui::Color color(std::string_view fullChannel, bool pastel);
 
     Channel(
         std::string_view name,

--- a/include/tev/Channel.h
+++ b/include/tev/Channel.h
@@ -44,6 +44,7 @@ public:
     Channel(
         std::string_view name,
         const nanogui::Vector2i& size,
+        EPixelFormat desiredPixelFormat,
         std::shared_ptr<std::vector<float>> data = nullptr,
         size_t dataOffset = 0,
         size_t dataStride = 1
@@ -119,9 +120,17 @@ public:
 
     std::shared_ptr<std::vector<float>>& dataBuf() { return mData; }
 
+    void setDesiredPixelFormat(EPixelFormat format) { mDesiredPixelFormat = format; }
+    EPixelFormat desiredPixelFormat() const { return mDesiredPixelFormat; }
+
 private:
     std::string mName;
     nanogui::Vector2i mSize;
+
+    // tev defaults to storing images in fp32 for maximum precision. However, many images only require fp16 to be displayed as good as
+    // losslessly. For such images, loaders can set this to F16 to save memory.
+    EPixelFormat mDesiredPixelFormat = EPixelFormat::F32;
+
     std::shared_ptr<std::vector<float>> mData;
     size_t mDataOffset;
     size_t mDataStride;

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -566,6 +566,13 @@ inline nanogui::Vector2i applyOrientation(EOrientation orientation, const nanogu
     return pos;
 }
 
+enum class EPixelFormat {
+    U8,
+    U16,
+    F16,
+    F32,
+};
+
 // Implemented in main.cpp
 void scheduleToMainThread(const std::function<void()>& fun);
 void redrawWindow();

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -147,7 +147,7 @@ public:
         return result;
     }
 
-    bool isInterleavedRgba(std::span<const std::string> channelNames) const;
+    bool isInterleaved(std::span<const std::string> channelNames, size_t desiredStride) const;
 
     nanogui::Texture* texture(std::span<const std::string> channelNames, EInterpolationMode minFilter, EInterpolationMode magFilter);
 

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -36,6 +36,7 @@ struct CanvasStatistics {
     float maximum;
     float minimum;
     std::vector<float> histogram;
+    std::vector<nanogui::Color> histogramColors;
     int nChannels;
     int histogramZero;
 };

--- a/include/tev/MultiGraph.h
+++ b/include/tev/MultiGraph.h
@@ -55,6 +55,9 @@ public:
     std::span<const float> values() const { return mValues; }
     void setValues(std::span<const float> values) { mValues = {values.begin(), values.end()}; }
 
+    std::span<nanogui::Color> colors() { return mColors; }
+    void setColors(std::span<const nanogui::Color> colors) { mColors = {colors.begin(), colors.end()}; }
+
     void setNChannels(int nChannels) { mNChannels = nChannels; }
 
     virtual nanogui::Vector2i preferred_size(NVGcontext* ctx) const override;
@@ -72,6 +75,7 @@ protected:
     std::string mCaption, mHeader, mFooter;
     nanogui::Color mBackgroundColor, mForegroundColor, mTextColor;
     std::vector<float> mValues;
+    std::vector<nanogui::Color> mColors;
     int mNChannels = 1;
     float mMinimum = 0, mMean = 0, mMaximum = 0;
     int mZeroBin = 0;

--- a/include/tev/UberShader.h
+++ b/include/tev/UberShader.h
@@ -19,12 +19,14 @@
 #pragma once
 
 #include <tev/Box.h>
+#include <tev/Image.h>
 
 #include <nanogui/shader.h>
 #include <nanogui/texture.h>
 #include <nanogui/vector.h>
 
 #include <optional>
+#include <string_view>
 
 namespace tev {
 
@@ -33,31 +35,16 @@ public:
     UberShader(nanogui::RenderPass* renderPass, float ditherScale);
     virtual ~UberShader();
 
-    // Draws just a checkerboard
-    void draw(const nanogui::Vector2f& pixelSize, const nanogui::Vector2f& checkerSize);
-
-    // Draws an image
     void draw(
         const nanogui::Vector2f& pixelSize,
         const nanogui::Vector2f& checkerSize,
-        nanogui::Texture* textureImage,
+        Image* textureImage,
         const nanogui::Matrix3f& transformImage,
-        float exposure,
-        float offset,
-        float gamma,
-        bool clipToLdr,
-        ETonemap tonemap,
-        const std::optional<Box2i>& crop
-    );
-
-    // Draws a difference between a reference and an image
-    void draw(
-        const nanogui::Vector2f& pixelSize,
-        const nanogui::Vector2f& checkerSize,
-        nanogui::Texture* textureImage,
-        const nanogui::Matrix3f& transformImage,
-        nanogui::Texture* textureReference,
+        Image* textureReference,
         const nanogui::Matrix3f& transformReference,
+        std::string_view requestedChannelGroup,
+        EInterpolationMode minFilter,
+        EInterpolationMode magFilter,
         float exposure,
         float offset,
         float gamma,

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -60,13 +60,6 @@ enum class EAlphaKind {
     None,
 };
 
-enum class EPixelFormat {
-    U8,
-    U16,
-    F16,
-    F32,
-};
-
 class ColorProfile {
 public:
     ColorProfile(void* profile) : mProfile{profile} {}

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -124,10 +124,13 @@ public:
     // Returns a list of all supported mime types, sorted by decoding preference.
     static const std::vector<std::string_view>& supportedMimeTypes();
 
-    static std::vector<Channel>
-        makeRgbaInterleavedChannels(int numChannels, bool hasAlpha, const nanogui::Vector2i& size, std::string_view namePrefix = "");
+    static std::vector<Channel> makeRgbaInterleavedChannels(
+        int numChannels, bool hasAlpha, const nanogui::Vector2i& size, EPixelFormat desiredPixelFormat, std::string_view namePrefix = ""
+    );
 
-    static std::vector<Channel> makeNChannels(int numChannels, const nanogui::Vector2i& size, std::string_view namePrefix = "");
+    static std::vector<Channel>
+        makeNChannels(int numChannels, const nanogui::Vector2i& size, EPixelFormat desiredPixelFormat, std::string_view namePrefix = "");
+
     static Task<void> resizeChannelsAsync(const std::vector<Channel>& srcChannels, std::vector<Channel>& dstChannels, int priority);
 };
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -67,8 +67,8 @@ Color Channel::color(string_view channel, bool pastel) {
     return Color(1.0f, 1.0f);
 }
 
-Channel::Channel(string_view name, const nanogui::Vector2i& size, shared_ptr<vector<float>> data, size_t dataOffset, size_t dataStride) :
-    mName{name}, mSize{size} {
+Channel::Channel(string_view name, const nanogui::Vector2i& size, EPixelFormat desiredPixelFormat, shared_ptr<vector<float>> data, size_t dataOffset, size_t dataStride) :
+    mName{name}, mSize{size}, mDesiredPixelFormat{desiredPixelFormat} {
     if (data) {
         mData = data;
         mDataOffset = dataOffset;

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -43,15 +43,25 @@ bool Channel::isTopmost(string_view channel) { return tail(channel) == channel; 
 
 bool Channel::isAlpha(string_view channel) { return toLower(tail(channel)) == "a"; }
 
-Color Channel::color(string_view channel) {
+Color Channel::color(string_view channel, bool pastel) {
     auto lowerChannel = toLower(tail(channel));
 
-    if (channel == "r") {
-        return Color(0.8f, 0.2f, 0.2f, 1.0f);
-    } else if (channel == "g") {
-        return Color(0.2f, 0.8f, 0.2f, 1.0f);
-    } else if (channel == "b") {
-        return Color(0.2f, 0.3f, 1.0f, 1.0f);
+    if (pastel) {
+        if (lowerChannel == "r") {
+            return Color(0.8f, 0.2f, 0.2f, 1.0f);
+        } else if (lowerChannel == "g") {
+            return Color(0.2f, 0.8f, 0.2f, 1.0f);
+        } else if (lowerChannel == "b") {
+            return Color(0.2f, 0.3f, 1.0f, 1.0f);
+        }
+    } else {
+        if (lowerChannel == "r") {
+            return Color(1.0f, 0.0f, 0.0f, 1.0f);
+        } else if (lowerChannel == "g") {
+            return Color(0.0f, 1.0f, 0.0f, 1.0f);
+        } else if (lowerChannel == "b") {
+            return Color(0.0f, 0.0f, 1.0f, 1.0f);
+        }
     }
 
     return Color(1.0f, 1.0f);

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -844,7 +844,7 @@ vector<Channel> ImageCanvas::channelsFromImages(
     vector<Channel> result;
     auto channelNames = image->channelsInGroup(requestedChannelGroup);
     for (size_t i = 0; i < channelNames.size(); ++i) {
-        result.emplace_back(toUpper(Channel::tail(channelNames[i])), image->size());
+        result.emplace_back(toUpper(Channel::tail(channelNames[i])), image->size(), EPixelFormat::F32);
     }
 
     const auto channels = image->channels(channelNames);

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -930,9 +930,15 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
     auto result = make_shared<CanvasStatistics>();
 
     size_t nChannels = result->nChannels = (int)(alphaChannel ? (flattened.size() - 1) : flattened.size());
+    result->histogramColors.resize(nChannels);
 
     for (size_t i = 0; i < nChannels; ++i) {
+        string rgba[] = {"R", "G", "B", "A"};
+        string colorName = nChannels == 1 ? "L" : rgba[min(i, (size_t)3)];
+        result->histogramColors[i] = Channel::color(colorName, false);
+
         const auto& channel = flattened[i];
+
         for (int y = region.min.y(); y < region.max.y(); ++y) {
             for (int x = region.min.x(); x < region.max.x(); ++x) {
                 auto v = channel.at({x, y});

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -138,7 +138,7 @@ void ImageCanvas::drawPixelValuesAsText(NVGcontext* ctx) {
 
         vector<Color> colors;
         for (const auto& channel : channels) {
-            colors.emplace_back(Channel::color(channel));
+            colors.emplace_back(Channel::color(channel, true));
         }
 
         float fontSize = pixelSize.x() / 6;

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -1458,6 +1458,7 @@ void ImageViewer::draw_contents() {
         if (lazyCanvasStatistics->isReady()) {
             auto statistics = lazyCanvasStatistics->get();
             mHistogram->setNChannels(statistics->nChannels);
+            mHistogram->setColors(statistics->histogramColors);
             mHistogram->setValues(statistics->histogram);
             mHistogram->setMinimum(statistics->minimum);
             mHistogram->setMean(statistics->mean);
@@ -1478,6 +1479,7 @@ void ImageViewer::draw_contents() {
         }
     } else {
         mHistogram->setNChannels(1);
+        mHistogram->setColors({{1.0f, 1.0f, 1.0f}});
         mHistogram->setValues({{0.0f}});
         mHistogram->setMinimum(0);
         mHistogram->setMean(0);

--- a/src/MultiGraph.cpp
+++ b/src/MultiGraph.cpp
@@ -58,14 +58,6 @@ void MultiGraph::draw(NVGcontext* ctx) {
     nvgFill(ctx);
 
     if (mValues.size() >= 2) {
-        array<Color, 3> colors = {
-            {
-             Color{255, 0, 0, 200},
-             Color{0, 255, 0, 200},
-             Color{0, 0, 255, 200},
-             }
-        };
-
         nvgSave(ctx);
 
         // Additive blending
@@ -84,7 +76,7 @@ void MultiGraph::draw(NVGcontext* ctx) {
                 nvgLineTo(ctx, vx, vy);
             }
 
-            auto color = i < colors.size() ? colors[i] : mForegroundColor;
+            auto color = i < mColors.size() ? mColors[i] : mForegroundColor;
             nvgLineTo(ctx, m_pos.x() + m_size.x(), m_pos.y() + m_size.y());
             nvgFillColor(ctx, color);
             nvgFill(ctx);

--- a/src/imageio/ClipboardImageLoader.cpp
+++ b/src/imageio/ClipboardImageLoader.cpp
@@ -61,7 +61,8 @@ Task<vector<ImageData>> ClipboardImageLoader::load(istream& iStream, const fs::p
     vector<ImageData> result(1);
     ImageData& resultData = result.front();
 
-    resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size);
+    // Clipboard images are always 32 bit RGBA. Can be comfortably represented as F16.
+    resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F16);
 
     vector<char> data(numBytes);
     iStream.read(reinterpret_cast<char*>(data.data()), numBytes);

--- a/src/imageio/DdsImageLoader.cpp
+++ b/src/imageio/DdsImageLoader.cpp
@@ -214,7 +214,7 @@ Task<vector<ImageData>> DdsImageLoader::load(istream& iStream, const fs::path&, 
     vector<ImageData> result(1);
     ImageData& resultData = result.front();
 
-    resultData.channels = makeRgbaInterleavedChannels(numChannels, DirectX::HasAlpha(metadata.format), size);
+    resultData.channels = makeRgbaInterleavedChannels(numChannels, DirectX::HasAlpha(metadata.format), size, EPixelFormat::F32);
 
     auto numPixels = (size_t)size.x() * size.y();
     if (numPixels == 0) {

--- a/src/imageio/EmptyImageLoader.cpp
+++ b/src/imageio/EmptyImageLoader.cpp
@@ -57,7 +57,7 @@ Task<vector<ImageData>> EmptyImageLoader::load(istream& iStream, const fs::path&
 
         string channelName = channelNameData.data();
 
-        data.channels.emplace_back(Channel{channelName, size}).setZero();
+        data.channels.emplace_back(Channel{channelName, size, EPixelFormat::F32}).setZero();
     }
 
     data.hasPremultipliedAlpha = true;

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -420,6 +420,8 @@ public:
 
     const Vector2i& size() const { return mSize; }
 
+    EPixelFormat desiredPixelFormat() const { return mImfChannel.type == Imf::HALF ? EPixelFormat::F16 : EPixelFormat::F32; }
+
 private:
     int bytesPerPixel() const {
         switch (mImfChannel.type) {
@@ -567,7 +569,7 @@ Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const fs::path& p
             auto& rawChannel = rawChannels.at(i);
             auto& data = result.at(rawChannel.partId());
             channelMapping.emplace_back(data.channels.size());
-            data.channels.emplace_back(Channel{rawChannel.name(), rawChannel.size()});
+            data.channels.emplace_back(Channel{rawChannel.name(), rawChannel.size(), rawChannel.desiredPixelFormat()});
         }
 
         vector<Task<void>> tasks;

--- a/src/imageio/HeifImageLoader.cpp
+++ b/src/imageio/HeifImageLoader.cpp
@@ -181,10 +181,12 @@ Task<vector<ImageData>>
             throw ImageLoadError{"Row size not a multiple of sample size."};
         }
 
+        // HEIF images have a fixed point representation of up to 16 bits per channel in TF space. FP16 is perfectly adequate to represent
+        // such values after conversion to linear space.
         if (numChannels == 1) {
-            resultData.channels.emplace_back(fmt::format("{}L", namePrefix), size);
+            resultData.channels.emplace_back(fmt::format("{}L", namePrefix), size, EPixelFormat::F16);
         } else {
-            resultData.channels = makeRgbaInterleavedChannels(numChannels, hasAlpha, size, namePrefix);
+            resultData.channels = makeRgbaInterleavedChannels(numChannels, hasAlpha, size, EPixelFormat::F16);
         }
 
         const int numInterleavedChannels = numChannels == 1 ? 1 : 4;
@@ -440,10 +442,11 @@ Task<vector<ImageData>>
         scaledResultData.hasPremultipliedAlpha = resultData.hasPremultipliedAlpha;
 
         if (numChannels == 1) {
-            scaledResultData.channels.emplace_back(fmt::format("{}L", namePrefix), targetSize);
+            scaledResultData.channels.emplace_back(fmt::format("{}L", namePrefix), targetSize, EPixelFormat::F16);
         } else {
-            scaledResultData.channels =
-                makeRgbaInterleavedChannels(numChannels, resultData.hasChannel(fmt::format("{}A", namePrefix)), targetSize, namePrefix);
+            scaledResultData.channels = makeRgbaInterleavedChannels(
+                numChannels, resultData.hasChannel(fmt::format("{}A", namePrefix)), targetSize, EPixelFormat::F16, namePrefix
+            );
         }
 
         co_await resizeChannelsAsync(resultData.channels, scaledResultData.channels, priority);

--- a/src/imageio/ImageLoader.cpp
+++ b/src/imageio/ImageLoader.cpp
@@ -103,7 +103,7 @@ const vector<string_view>& ImageLoader::supportedMimeTypes() {
     return mimeTypes;
 }
 
-vector<Channel> ImageLoader::makeRgbaInterleavedChannels(int numChannels, bool hasAlpha, const Vector2i& size, string_view namePrefix) {
+vector<Channel> ImageLoader::makeRgbaInterleavedChannels(int numChannels, bool hasAlpha, const Vector2i& size, EPixelFormat desiredPixelFormat, string_view namePrefix) {
     vector<Channel> channels;
     if (numChannels > 4) {
         throw ImageLoadError{"Image has too many RGBA channels."};
@@ -130,23 +130,23 @@ vector<Channel> ImageLoader::makeRgbaInterleavedChannels(int numChannels, bool h
             string name = fmt::format("{}{}", namePrefix, (c < (int)channelNames.size() ? channelNames[c] : to_string(c)));
 
             // We assume that the channels are interleaved.
-            channels.emplace_back(name, size, data, c, 4);
+            channels.emplace_back(name, size, desiredPixelFormat, data, c, 4);
         }
     } else {
-        channels.emplace_back(fmt::format("{}L", namePrefix), size, data, 0, 4);
+        channels.emplace_back(fmt::format("{}L", namePrefix), size, desiredPixelFormat, data, 0, 4);
     }
 
     if (hasAlpha) {
-        channels.emplace_back(fmt::format("{}A", namePrefix), size, data, 3, 4);
+        channels.emplace_back(fmt::format("{}A", namePrefix), size, desiredPixelFormat, data, 3, 4);
     }
 
     return channels;
 }
 
-vector<Channel> ImageLoader::makeNChannels(int numChannels, const Vector2i& size, string_view namePrefix) {
+vector<Channel> ImageLoader::makeNChannels(int numChannels, const Vector2i& size, EPixelFormat desiredPixelFormat, string_view namePrefix) {
     vector<Channel> channels;
     for (int c = 0; c < numChannels; ++c) {
-        channels.emplace_back(fmt::format("{}{}", namePrefix, to_string(c)), size);
+        channels.emplace_back(fmt::format("{}{}", namePrefix, to_string(c)), size, desiredPixelFormat);
     }
 
     return channels;

--- a/src/imageio/JpegTurboImageLoader.cpp
+++ b/src/imageio/JpegTurboImageLoader.cpp
@@ -167,7 +167,9 @@ Task<vector<ImageData>> JpegTurboImageLoader::load(istream& iStream, const fs::p
         resultData.attributes.emplace_back(exifAttributes.value());
     }
 
-    resultData.channels = makeRgbaInterleavedChannels(numColorChannels, false, size);
+    // This JPEG loader is at most 8 bits per channel (technically, JPEG can hold more, but we don't support that here). Thus easily fits
+    // into F16.
+    resultData.channels = makeRgbaInterleavedChannels(numColorChannels, false, size, EPixelFormat::F16);
 
     // Since JPEG always has no alpha channel, we default to 1, where premultiplied and straight are equivalent.
     resultData.hasPremultipliedAlpha = true;

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -63,7 +63,7 @@ Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, 
     vector<ImageData> result(1);
     ImageData& resultData = result.front();
 
-    resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size);
+    resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32);
 
     auto numPixels = (size_t)size.x() * size.y();
     if (numPixels == 0) {

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -207,7 +207,9 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
             resultData.attributes.emplace_back(exifAttributes.value());
         }
 
-        resultData.channels = makeRgbaInterleavedChannels(numChannels, hasAlpha, size);
+        // PNG images have a fixed point representation of up to 16 bits per channel in TF space. FP16 is perfectly adequate to represent
+        // such values after conversion to linear space.
+        resultData.channels = makeRgbaInterleavedChannels(numChannels, hasAlpha, size, EPixelFormat::F16);
         resultData.orientation = orientation;
         resultData.hasPremultipliedAlpha = false;
 

--- a/src/imageio/QoiImageLoader.cpp
+++ b/src/imageio/QoiImageLoader.cpp
@@ -67,7 +67,8 @@ Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, 
     vector<ImageData> result(1);
     ImageData& resultData = result.front();
 
-    resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size);
+    // QOI images are 8 bit per pixel which easily fits into F16.
+    resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F16);
     resultData.hasPremultipliedAlpha = false;
 
     if (desc.colorspace == QOI_LINEAR) {

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -85,7 +85,8 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
     for (int frameIdx = 0; frameIdx < numFrames; ++frameIdx) {
         ImageData& resultData = result[frameIdx];
 
-        resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size);
+        // Unless the image is a .hdr file, it's 8 bits per channel, so we can comfortably fit it into F16.
+        resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, isHdr ? EPixelFormat::F32 : EPixelFormat::F16);
         resultData.hasPremultipliedAlpha = false;
         if (numFrames > 1) {
             resultData.partName = fmt::format("frames.{}", frameIdx);

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -1093,8 +1093,9 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
 
     // Local scope to prevent use-after-move
     {
-        auto rgbaChannels = ImageLoader::makeRgbaInterleavedChannels(numRgbaChannels, hasAlpha, size);
-        auto extraChannels = ImageLoader::makeNChannels(numNonRgbaChannels, size);
+        const auto desiredPixelFormat = bitsPerSample > 16 ? EPixelFormat::F32 : EPixelFormat::F16;
+        auto rgbaChannels = ImageLoader::makeRgbaInterleavedChannels(numRgbaChannels, hasAlpha, size, desiredPixelFormat);
+        auto extraChannels = ImageLoader::makeNChannels(numNonRgbaChannels, size, desiredPixelFormat);
 
         resultData.channels.insert(resultData.channels.end(), make_move_iterator(rgbaChannels.begin()), make_move_iterator(rgbaChannels.end()));
         resultData.channels.insert(

--- a/src/imageio/WebpImageLoader.cpp
+++ b/src/imageio/WebpImageLoader.cpp
@@ -154,7 +154,8 @@ Task<vector<ImageData>> WebpImageLoader::load(istream& iStream, const fs::path&,
                 resultData.attributes.emplace_back(exifAttributes.value());
             }
 
-            resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size);
+            // WebP is always 8bit per channel, so we can comfortably use F16 for the decoded data.
+            resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F16);
             resultData.hasPremultipliedAlpha = false;
             resultData.partName = fmt::format("frames.{}", frameIdx);
 


### PR DESCRIPTION
- uses fp16 textures instead of fp32 when reasonable
- uses R, RA, and RGB textures when applicable instead of always RGBA
- doesn't put monochromatic auxiliary HEIF channels into interleaved RGBA buffers on the CPU