### PR TITLE
feat(colors): support CICP tags embedded in ICC profiles

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -470,6 +470,10 @@ inline size_t nBytes(EPixelFormat format) {
     return 0;
 }
 
+inline size_t nBits(EPixelFormat format) {
+    return nBytes(format) * 8;
+}
+
 // Implemented in main.cpp
 void scheduleToMainThread(const std::function<void()>& fun);
 void redrawWindow();


### PR DESCRIPTION
For now, tev's implementation of CICP tags has these tags take precedence over the rest of the ICC profile if present.

Fixes #351 