### PR TITLE
Fix file dialog filter for "All Images"

### DIFF
--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -1910,10 +1910,10 @@ void ImageViewer::openImageDialog() {
 
             vector<string_view> allImages;
             for (const auto& filter : filters) {
-                allImages.push_back(filter.second);
+                allImages.push_back(filter.first);
             }
 
-            filters.emplace(filters.begin(), pair<string, string>{"All images", join(allImages, ",")});
+            filters.emplace(filters.begin(), pair<string, string>{join(allImages, ","), "All images"});
             auto paths = file_dialog(this, FileDialogType::OpenMultiple, filters);
 
             for (size_t i = 0; i < paths.size(); ++i) {


### PR DESCRIPTION
On newer versions of tev, the default filter when opening images doesn't show any available options (at least on Windows):
<img width="1719" height="831" alt="image" src="https://github.com/user-attachments/assets/8947ada9-3cc7-40d1-8354-e1663eb2689a" />

I believe the issue is related to [this commit](https://github.com/Tom94/tev/commit/752dda6f146f33bdc28ff24d745d6b9c84d64fa8), which has swapped the order in the pairs of strings. The corresponding filter for all images wasn't updated, so it was displaying the wrong name and using the wrong filter. 

The behavior seems to be correct when this is updated:
<img width="955" height="893" alt="image" src="https://github.com/user-attachments/assets/dc311fcc-8651-417f-95eb-79ee4b012f78" />

