### PR TITLE
fix(task): `waitAll` exception handling & task completion

### DIFF
--- a/include/tev/Task.h
+++ b/include/tev/Task.h
@@ -45,12 +45,6 @@ private:
     std::atomic<int> mCounter;
 };
 
-template <typename T> void waitAll(std::span<T> futures) {
-    for (auto&& f : futures) {
-        f.get();
-    }
-}
-
 struct DetachedTask {
     struct promise_type {
         DetachedTask get_return_object() noexcept { return {}; }
@@ -231,5 +225,8 @@ template <typename F, typename... Args> Task<void> invokeTask(F&& executor, Args
     auto exec = std::move(executor);
     co_await exec(args...);
 }
+
+void waitAll(std::span<Task<void>> futures);
+Task<void> awaitAll(std::span<Task<void>> futures);
 
 } // namespace tev

--- a/include/tev/ThreadPool.h
+++ b/include/tev/ThreadPool.h
@@ -117,9 +117,7 @@ public:
             }(taskStart, taskEnd, body, priority, this));
         }
 
-        for (auto&& task : tasks) {
-            co_await task;
-        }
+        co_await awaitAll(tasks);
     }
 
     template <typename Int, typename F> void parallelFor(Int start, Int end, F body, int priority) {

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -1018,10 +1018,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
             priority
         )
     );
-
-    for (auto& task : tasks) {
-        co_await task;
-    }
+    co_await awaitAll(tasks);
 
     co_await ThreadPool::global().parallelForAsync<size_t>(
         0,

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -20,4 +20,44 @@
 
 namespace tev {
 
+void waitAll(std::span<Task<void>> futures) {
+    std::exception_ptr eptr = {};
+
+    for (auto&& f : futures) {
+        try {
+            f.get();
+        } catch (const std::exception& e) {
+            if (eptr) {
+                tlog::error() << "Multiple exceptions in waitAll(). Rethrowing first and logging others: " << e.what();
+            } else {
+                eptr = std::current_exception();
+            }
+        }
+    }
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+}
+
+Task<void> awaitAll(std::span<Task<void>> futures) {
+    std::exception_ptr eptr = {};
+
+    for (auto&& f : futures) {
+        try {
+            co_await f;
+        } catch (const std::exception& e) {
+            if (eptr) {
+                tlog::error() << "Multiple exceptions in awaitAll(). Rethrowing first and logging others: " << e.what();
+            } else {
+                eptr = std::current_exception();
+            }
+        }
+    }
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+}
+
 }

--- a/src/imageio/JxlImageLoader.cpp
+++ b/src/imageio/JxlImageLoader.cpp
@@ -190,7 +190,7 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
         // This is janky, because it doesn't follow the coroutine paradigm. But it is the only way to get the thread pool to cooperate
         // with the JXL API that expects a non-coroutine function here. We will offload the JxlImageLoader::load() function into a
         // wholly separate thread to avoid blocking the thread pool as a consequence.
-        waitAll<Task<void>>(tasks);
+        waitAll(tasks);
         return 0;
     };
 

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -1295,10 +1295,7 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
         uint8_t* const td = tileData.data() + tile.size * i;
 
         if (readTile(tif, (uint32_t)i, td, tile.size) < 0) {
-            for (auto&& task : decodeTasks) {
-                co_await task;
-            }
-
+            co_await awaitAll(decodeTasks);
             throw ImageLoadError{fmt::format("Failed to read tile {}", i)};
         }
 
@@ -1362,9 +1359,7 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
         );
     }
 
-    for (auto&& task : decodeTasks) {
-        co_await task;
-    }
+    co_await awaitAll(decodeTasks);
 
     float intConversionScale = 1.0f;
     ETiffKind kind = ETiffKind::U32;


### PR DESCRIPTION
`waitAll` as well as a new function `awaitAll` (analogous using co_await instead of get()) now handle all exceptions thrown by the awaited tasks and ensure all awaited tasks finish (even if one or more throw an exception) before returning to the caller.