### PR TITLE
feat(ui): if possible, cap window resize at current monitor bounds

### DIFF
--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -291,7 +291,7 @@ private:
 
     int mDidFitToImage = 0;
 
-    nanogui::Vector2i mMaxSize = {8192, 8192};
+    nanogui::Vector2i mWorkAreaSize = {8192, 8192};
     bool mInitialized = false;
 
     std::unique_ptr<std::thread> mFileDialogThread;

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -204,6 +204,8 @@ private:
 
     int visibleFooterHeight() { return mFooter->visible() ? mFooter->fixed_height() : 0; }
 
+    void updateCurrentMonitorSize();
+
     SharedQueue<std::function<void(void)>> mTaskQueue;
 
     bool mRequiresFilterUpdate = true;
@@ -291,8 +293,12 @@ private:
 
     int mDidFitToImage = 0;
 
-    nanogui::Vector2i mWorkAreaSize = {8192, 8192};
+    nanogui::Vector2i mMaxWindowSize = {8192, 8192};
+
     bool mInitialized = false;
+
+    bool mMaximizedLaunch = false;
+    bool mMaximizedUnreliable = false;
 
     std::unique_ptr<std::thread> mFileDialogThread;
 };

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1068,8 +1068,6 @@ bool BackgroundImagesLoader::publishSortedLoads() {
     const lock_guard lock{mPendingLoadedImagesMutex};
     bool pushed = false;
     while (!mPendingLoadedImages.empty() && mPendingLoadedImages.top().loadId == mLoadCounter) {
-        ++mLoadCounter;
-
         // null image pointers indicate failed loads. These shouldn't be pushed.
         if (!mPendingLoadedImages.top().images.empty()) {
             mLoadedImages.push(mPendingLoadedImages.top());
@@ -1077,6 +1075,8 @@ bool BackgroundImagesLoader::publishSortedLoads() {
 
         mPendingLoadedImages.pop();
         pushed = true;
+
+        ++mLoadCounter;
     }
 
     if (mLoadCounter == mUnsortedLoadCounter && mLoadCounter - mLoadStartCounter > 1) {


### PR DESCRIPTION
Currently, obtaining the current monitor bounds is limited to

- [x] Wayland
- [x] X11
- [x] Windows
- [x] macOS

Fixes #362 