### PR TITLE
feat(imageviewer): do not resize the window if autofit is enabled

### DIFF
--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -1196,7 +1196,7 @@ void ImageViewer::insertImage(shared_ptr<Image> image, size_t index, bool shallS
     // First image got added, let's select it.
     if ((index == 0 && mImages.size() == 1) || shallSelect) {
         selectImage(image);
-        if (!isMaximized()) {
+        if (!isMaximized() && !autoFitToScreen()) {
             resizeToFit(sizeToFitImage(image));
         }
     }


### PR DESCRIPTION
This will prevent the window from changing its size when a new image is loaded if the user enables autofitting.