### PR TITLE
fix(imageviewer): label default tonemap as "None" instead of "sRGB"

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -400,19 +400,20 @@ enum EInterpolationMode : int {
 EInterpolationMode toInterpolationMode(std::string_view name);
 std::string toString(EInterpolationMode mode);
 
-enum ETonemap : int {
+enum class ETonemap : int {
+    None = 0,
     SRGB = 0,
     Gamma,
     FalseColor,
     PositiveNegative,
 
     // This enum value should never be used directly. It facilitates looping over all members of this enum.
-    NumTonemaps,
+    Count,
 };
 
 ETonemap toTonemap(std::string_view name);
 
-enum EMetric : int {
+enum class EMetric : int {
     Error = 0,
     AbsoluteError,
     SquaredError,
@@ -420,7 +421,7 @@ enum EMetric : int {
     RelativeSquaredError,
 
     // This enum value should never be used directly. It facilitates looping over all members of this enum.
-    NumMetrics,
+    Count,
 };
 
 EMetric toMetric(std::string_view name);

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -165,8 +165,8 @@ private:
 
     std::unique_ptr<UberShader> mShader;
 
-    ETonemap mTonemap = SRGB;
-    EMetric mMetric = Error;
+    ETonemap mTonemap = ETonemap::None;
+    EMetric mMetric = EMetric::Error;
     std::optional<Box2i> mCrop;
 
     std::map<std::string, std::shared_ptr<Lazy<std::shared_ptr<CanvasStatistics>>>> mCanvasStatistics;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -25,7 +25,6 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
-#include <iostream>
 #include <map>
 #include <regex>
 
@@ -352,16 +351,18 @@ string toString(EInterpolationMode mode) {
 ETonemap toTonemap(string_view name) {
     // Perform matching on uppercase strings
     const auto upperName = toUpper(name);
-    if (upperName == "SRGB") {
-        return SRGB;
+    if (upperName == "NONE") {
+        return ETonemap::None;
+    } else if (upperName == "SRGB") {
+        return ETonemap::SRGB;
     } else if (upperName == "GAMMA") {
-        return Gamma;
+        return ETonemap::Gamma;
     } else if (upperName == "FALSECOLOR" || upperName == "FC") {
-        return FalseColor;
+        return ETonemap::FalseColor;
     } else if (upperName == "POSITIVENEGATIVE" || upperName == "POSNEG" || upperName == "PN" || upperName == "+-") {
-        return PositiveNegative;
+        return ETonemap::PositiveNegative;
     } else {
-        return SRGB;
+        return ETonemap::None;
     }
 }
 
@@ -369,17 +370,17 @@ EMetric toMetric(string_view name) {
     // Perform matching on uppercase strings
     const auto upperName = toUpper(name);
     if (upperName == "E") {
-        return Error;
+        return EMetric::Error;
     } else if (upperName == "AE") {
-        return AbsoluteError;
+        return EMetric::AbsoluteError;
     } else if (upperName == "SE") {
-        return SquaredError;
+        return EMetric::SquaredError;
     } else if (upperName == "RAE") {
-        return RelativeAbsoluteError;
+        return EMetric::RelativeAbsoluteError;
     } else if (upperName == "RSE") {
-        return RelativeSquaredError;
+        return EMetric::RelativeSquaredError;
     } else {
-        return Error;
+        return EMetric::Error;
     }
 }
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -259,7 +259,7 @@ ImageViewer::ImageViewer(
             return button;
         };
 
-        makeTonemapButton("sRGB", [this]() { setTonemap(ETonemap::SRGB); });
+        makeTonemapButton("None", [this]() { setTonemap(ETonemap::SRGB); });
         makeTonemapButton("Gamma", [this]() { setTonemap(ETonemap::Gamma); });
         makeTonemapButton("FC", [this]() { setTonemap(ETonemap::FalseColor); });
         makeTonemapButton("+/-", [this]() { setTonemap(ETonemap::PositiveNegative); });
@@ -267,13 +267,15 @@ ImageViewer::ImageViewer(
         setTonemap(ETonemap::SRGB);
 
         mTonemapButtonContainer->set_tooltip(
-            "Tonemap operator selection:\n\n"
+            "Tonemap selection:\n\n"
 
-            "sRGB\n"
-            "Linear to sRGB conversion\n\n"
+            "None\n"
+            "No tonemapping\n\n"
 
             "Gamma\n"
-            "Inverse power gamma correction\n\n"
+            "Gamma correction + inverse sRGB\n"
+            "Needed when displaying SDR to\n"
+            "gamma-encoded displays.\n\n"
 
             "FC\n"
             "False-color visualization\n\n"
@@ -952,10 +954,10 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
 
         if (key == GLFW_KEY_RIGHT || key == GLFW_KEY_D || key == GLFW_KEY_RIGHT_BRACKET) {
             if (modifiers & GLFW_MOD_SHIFT) {
-                setTonemap(static_cast<ETonemap>((tonemap() + 1) % NumTonemaps));
+                setTonemap(static_cast<ETonemap>(((int)tonemap() + 1) % (int)ETonemap::Count));
             } else if (modifiers & GLFW_MOD_CONTROL) {
                 if (mCurrentReference) {
-                    setMetric(static_cast<EMetric>((metric() + 1) % NumMetrics));
+                    setMetric(static_cast<EMetric>(((int)metric() + 1) % (int)EMetric::Count));
                 }
             } else {
                 selectGroup(nextGroup(mCurrentGroup, Forward));
@@ -964,10 +966,10 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
             return true;
         } else if (key == GLFW_KEY_LEFT || key == GLFW_KEY_A || key == GLFW_KEY_LEFT_BRACKET) {
             if (modifiers & GLFW_MOD_SHIFT) {
-                setTonemap(static_cast<ETonemap>((tonemap() - 1 + NumTonemaps) % NumTonemaps));
+                setTonemap(static_cast<ETonemap>(((int)tonemap() - 1 + (int)ETonemap::Count) % (int)ETonemap::Count));
             } else if (modifiers & GLFW_MOD_CONTROL) {
                 if (mCurrentReference) {
-                    setMetric(static_cast<EMetric>((metric() - 1 + NumMetrics) % NumMetrics));
+                    setMetric(static_cast<EMetric>(((int)metric() - 1 + (int)EMetric::Count) % (int)EMetric::Count));
                 }
             } else {
                 selectGroup(nextGroup(mCurrentGroup, Backward));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,11 +260,11 @@ static int mainFunc(span<const string> arguments) {
         "METRIC",
         "The metric to use when comparing two images. "
         "The available metrics are:\n"
-        "E   - Error\n"
-        "AE  - Absolute Error\n"
-        "SE  - Squared Error\n"
-        "RAE - Relative Absolute Error\n"
-        "RSE - Relative Squared Error\n"
+        "E: Error\n"
+        "AE: Absolute Error\n"
+        "SE: Squared Error\n"
+        "RAE: Relative Absolute Error\n"
+        "RSE: Relative Squared Error\n"
         "Default is E.",
         {'m', "metric"},
     };
@@ -312,13 +312,14 @@ static int mainFunc(span<const string> arguments) {
     ValueFlag<string> tonemapFlag{
         parser,
         "TONEMAP",
-        "The tonemapping algorithm to use. "
-        "The available tonemaps are:\n"
-        "sRGB   - sRGB\n"
-        "Gamma  - Gamma curve\n"
-        "FC     - False Color\n"
-        "PN     - Positive=Green, Negative=Red\n"
-        "Default is sRGB.",
+        "The tonemap to use. Available options are:\n"
+        "None: No tonemapping\n"
+        "Gamma: Gamma curve + inv. sRGB\n"
+        "       Needed when rendering SDR to\n"
+        "       gamma-encoded displays.\n"
+        "FC: False Color\n"
+        "PN: Positive=Green, Negative=Red\n"
+        "Default is None.",
         {'t', "tonemap"},
     };
 


### PR DESCRIPTION
Clarifies that tev's default tone mapping displays images with the colors they were encoded with. While tev *technically* converts the image's colors to sRGB space at some point in the pipeline when this option is set, this is only one step that ultimately leads the image to appear to screen in a different (potentially wide or HDR) color space that has nothing to do with sRGB.

Ergo: change the label to avoid confusing users.

Fixes #368 