### PR TITLE
feat(imageviewer): add white level override setting

### DIFF
--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -91,14 +91,17 @@ public:
     void setCrop(const std::optional<Box2i>& crop) { mCrop = crop; }
     Box2i cropInImageCoords() const;
 
-    auto backgroundColor() { return mShader->backgroundColor(); }
-    void setBackgroundColor(const nanogui::Color& color) { mShader->setBackgroundColor(color); }
-
     void fitImageToScreen(const Image& image);
     void resetTransform();
 
+    std::optional<float> whiteLevelOverride() const { return mWhiteLevelOverride; }
+    void setWhiteLevelOverride(std::optional<float> value) { mWhiteLevelOverride = value; }
+
     bool clipToLdr() const { return mClipToLdr; }
     void setClipToLdr(bool value) { mClipToLdr = value; }
+
+    auto backgroundColor() { return mBackgroundColor; }
+    void setBackgroundColor(const nanogui::Color& color) { mBackgroundColor = color; }
 
     EInterpolationMode minFilter() const { return mMinFilter; }
     void setMinFilter(EInterpolationMode value) { mMinFilter = value; }
@@ -151,7 +154,9 @@ private:
     float mOffset = 0;
     float mGamma = 2.2f;
 
+    std::optional<float> mWhiteLevelOverride = std::nullopt;
     bool mClipToLdr = false;
+    nanogui::Color mBackgroundColor = nanogui::Color(0, 0, 0, 0);
 
     EInterpolationMode mMinFilter = EInterpolationMode::Trilinear;
     EInterpolationMode mMagFilter = EInterpolationMode::Nearest;

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -121,12 +121,13 @@ public:
     void setMagFilter(EInterpolationMode value) { mImageCanvas->setMagFilter(value); }
 
     ETonemap tonemap() const { return mImageCanvas->tonemap(); }
-
     void setTonemap(ETonemap tonemap);
 
     EMetric metric() const { return mImageCanvas->metric(); }
-
     void setMetric(EMetric metric);
+
+    std::optional<float> overridingWhiteLevel() const;
+    void setOverridingWhiteLevel(std::optional<float> value);
 
     nanogui::Vector2i sizeToFitImage(const std::shared_ptr<Image>& image);
     nanogui::Vector2i sizeToFitAllImages();
@@ -211,26 +212,26 @@ private:
     bool mRequiresFilterUpdate = true;
     bool mRequiresLayoutUpdate = true;
 
-    nanogui::Widget* mVerticalScreenSplit;
+    nanogui::Widget* mVerticalScreenSplit = nullptr;
 
-    nanogui::Widget* mSidebar;
-    nanogui::Button* mHelpButton;
-    nanogui::Widget* mSidebarLayout;
+    nanogui::Widget* mSidebar = nullptr;
+    nanogui::Button* mHelpButton = nullptr;
+    nanogui::Widget* mSidebarLayout = nullptr;
 
-    nanogui::Widget* mFooter;
+    nanogui::Widget* mFooter = nullptr;
     bool mShouldFooterBeVisible = false;
 
-    nanogui::Label* mExposureLabel;
-    nanogui::Slider* mExposureSlider;
+    nanogui::Label* mExposureLabel = nullptr;
+    nanogui::Slider* mExposureSlider = nullptr;
 
-    nanogui::Label* mOffsetLabel;
-    nanogui::Slider* mOffsetSlider;
+    nanogui::Label* mOffsetLabel = nullptr;
+    nanogui::Slider* mOffsetSlider = nullptr;
 
-    nanogui::Label* mGammaLabel;
-    nanogui::Slider* mGammaSlider;
+    nanogui::Label* mGammaLabel = nullptr;
+    nanogui::Slider* mGammaSlider = nullptr;
 
-    nanogui::Widget* mTonemapButtonContainer;
-    nanogui::Widget* mMetricButtonContainer;
+    nanogui::Widget* mTonemapButtonContainer = nullptr;
+    nanogui::Widget* mMetricButtonContainer = nullptr;
 
     std::shared_ptr<BackgroundImagesLoader> mImagesLoader;
     std::shared_ptr<Ipc> mIpc;
@@ -240,36 +241,36 @@ private:
 
     std::vector<std::shared_ptr<Image>> mImages;
 
-    MultiGraph* mHistogram;
+    MultiGraph* mHistogram = nullptr;
     std::set<std::shared_ptr<Image>> mToBump;
 
-    nanogui::TextBox* mFilter;
-    nanogui::Button* mRegexButton;
+    nanogui::TextBox* mFilter = nullptr;
+    nanogui::Button* mRegexButton = nullptr;
 
-    nanogui::Button* mWatchFilesForChangesButton;
+    nanogui::Button* mWatchFilesForChangesButton = nullptr;
     std::chrono::steady_clock::time_point mLastFileChangesCheckTime = {};
 
-    nanogui::Button* mAutoFitToScreenButton;
+    nanogui::Button* mAutoFitToScreenButton = nullptr;
 
     // Buttons which require a current image to be meaningful.
     std::vector<nanogui::Button*> mCurrentImageButtons;
-    nanogui::Button* mImageInfoButton;
+    nanogui::Button* mImageInfoButton = nullptr;
     ImageInfoWindow* mImageInfoWindow = nullptr;
 
     // Buttons which require at least one image to be meaningful
     std::vector<nanogui::Button*> mAnyImageButtons;
 
-    nanogui::Button* mPlayButton;
-    nanogui::IntBox<int>* mFpsTextBox;
+    nanogui::Button* mPlayButton = nullptr;
+    nanogui::IntBox<int>* mFpsTextBox = nullptr;
     std::chrono::steady_clock::time_point mLastPlaybackFrameTime = {};
 
-    nanogui::Widget* mImageButtonContainer;
-    nanogui::Widget* mScrollContent;
-    nanogui::VScrollPanel* mImageScrollContainer;
+    nanogui::Widget* mImageButtonContainer = nullptr;
+    nanogui::Widget* mScrollContent = nullptr;
+    nanogui::VScrollPanel* mImageScrollContainer = nullptr;
 
-    ImageCanvas* mImageCanvas;
+    ImageCanvas* mImageCanvas = nullptr;
 
-    nanogui::Widget* mGroupButtonContainer;
+    nanogui::Widget* mGroupButtonContainer = nullptr;
     std::string mCurrentGroup;
 
     HelpWindow* mHelpWindow = nullptr;
@@ -288,8 +289,11 @@ private:
 
     size_t mClipboardIndex = 0;
 
+    // HDR support
     bool mSupportsHdr = false;
-    nanogui::Button* mClipToLdrButton;
+    nanogui::Button* mClipToLdrButton = nullptr;
+    nanogui::FloatBox<float>* mWhiteLevelBox = nullptr;
+    nanogui::Button* mWhiteLevelOverrideButton = nullptr;
 
     int mDidFitToImage = 0;
 

--- a/include/tev/UberShader.h
+++ b/include/tev/UberShader.h
@@ -48,18 +48,16 @@ public:
         float exposure,
         float offset,
         float gamma,
+        float colorMultiplier,
         bool clipToLdr,
+        const nanogui::Color& backgroundColor,
         ETonemap tonemap,
         EMetric metric,
         const std::optional<Box2i>& crop
     );
 
-    const nanogui::Color& backgroundColor() { return mBackgroundColor; }
-
-    void setBackgroundColor(const nanogui::Color& color) { mBackgroundColor = color; }
-
 private:
-    void bindCheckerboardData(const nanogui::Vector2f& pixelSize, const nanogui::Vector2f& checkerSize);
+    void bindCheckerboardData(const nanogui::Vector2f& pixelSize, const nanogui::Vector2f& checkerSize, const nanogui::Color& backgroundColor);
 
     void bindImageData(
         nanogui::Texture* textureImage, const nanogui::Matrix3f& transformImage, float exposure, float offset, float gamma, ETonemap tonemap
@@ -70,8 +68,6 @@ private:
     nanogui::ref<nanogui::Shader> mShader;
     nanogui::ref<nanogui::Texture> mColorMap;
     nanogui::ref<nanogui::Texture> mDitherMatrix;
-
-    nanogui::Color mBackgroundColor = nanogui::Color(0, 0, 0, 0);
 };
 
 } // namespace tev

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -103,7 +103,9 @@ void ImageCanvas::draw_contents() {
         mExposure,
         mOffset,
         mGamma,
+        mWhiteLevelOverride ? (*mWhiteLevelOverride / glfwGetWindowSdrWhiteLevel(glfwWindow)) : 1.0f,
         mClipToLdr,
+        mBackgroundColor,
         mTonemap,
         mMetric,
         imageSpaceCrop

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -351,6 +351,14 @@ static int mainFunc(span<const string> arguments) {
         {'w', "watch"},
     };
 
+    ValueFlag<float> whiteLevelFlag{
+        parser,
+        "WHITE LEVEL",
+        "Override the automatically detected display white level (for HDR displays) in nits (cd/m²). "
+        "You can set this value if you know the white level of your images and would like to display them at absolute brightness.",
+        {"white-level"},
+    };
+
     PositionalList<string> imageFiles{
         parser,
         "images",
@@ -635,6 +643,10 @@ static int mainFunc(span<const string> arguments) {
 
     if (watchFlag) {
         sImageViewer->setWatchFilesForChanges(true);
+    }
+
+    if (whiteLevelFlag) {
+        sImageViewer->setOverridingWhiteLevel(get(whiteLevelFlag));
     }
 
     sImageViewer->draw_all();


### PR DESCRIPTION
Adds a setting to override the automatically detected display white level.

Useful for displaying images with known white level (e.g. 203 nits for PQ / HLG HDR images) at absolute brightness instead of at the system's configured relative brightness level. 

**IMPORTANT**: this only works correctly when using a well-calibrated HDR display & when the OS/Compositor has HDR enabled.

In the future, **tev** could try detecting images whose encoding has a well-standardized white level to make absolute brightness automatic. Three roadblocks, though:
- There is currently no way for **tev** to know that it is running in a well calibrated HDR environment where adjusting the white level does something meaningful other than confuse the user (because their image no longer matches what e.g. Chrome looks like).
- A few of the PQ/HLG test images that I have lying around assume a relative rather than an absolute white level... so, there seems to be a precedent for ignoring the standard. Ergo: absolute white levels can't be made the default, even if feasible.
- Many HDR image formats (e.g. EXR or JXL when not relying on PQ/HLG transfers) don't have standardized white level metadata at all, so this would be a PQ/HLG exclusive feature as far as I can tell.

Fixes #369 