### PR TITLE
Implement IPC via unix sockets (and use in network-restricted flatpak sandbox)

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -382,6 +382,7 @@ int lastSocketError();
 std::string errorString(int errorId);
 
 fs::path homeDirectory();
+fs::path runtimeDirectory();
 
 void toggleConsole();
 

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -34,6 +34,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -389,6 +390,28 @@ void toggleConsole();
 
 bool shuttingDown();
 void setShuttingDown();
+
+struct FlatpakInfo {
+    std::string flatpakId = "";
+    std::unordered_map<std::string_view, std::unordered_map<std::string_view, std::string>> metadata;
+
+    bool hasNetworkAccess() const {
+        const auto it = metadata.find("Context");
+        if (it == metadata.end()) {
+            return false;
+        }
+
+        const auto accessIt = it->second.find("shared");
+        if (accessIt == it->second.end()) {
+            return false;
+        }
+
+        const auto parts = split(accessIt->second, ";");
+        return std::find(parts.begin(), parts.end(), "network") != parts.end();
+    }
+};
+
+const std::optional<FlatpakInfo>& flatpakInfo();
 
 enum EInterpolationMode : int {
     Nearest = 0,

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <filesystem>
 #include <functional>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>

--- a/include/tev/HelpWindow.h
+++ b/include/tev/HelpWindow.h
@@ -19,20 +19,20 @@
 #pragma once
 
 #include <tev/Common.h>
+#include <tev/Ipc.h>
 
 #include <nanogui/tabwidget.h>
 #include <nanogui/vscrollpanel.h>
 #include <nanogui/window.h>
 
+#include <memory>
 #include <string>
 
 namespace tev {
 
-class Ipc;
-
 class HelpWindow : public nanogui::Window {
 public:
-    HelpWindow(nanogui::Widget* parent, bool supportsHdr, const Ipc& ipc, std::function<void()> closeCallback);
+    HelpWindow(nanogui::Widget* parent, bool supportsHdr, std::weak_ptr<Ipc> ipc, std::function<void()> closeCallback);
 
     bool keyboard_event(int key, int scancode, int action, int modifiers) override;
 

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -46,7 +46,7 @@ public:
     ImageViewer(
         const nanogui::Vector2i& size,
         const std::shared_ptr<BackgroundImagesLoader>& imagesLoader,
-        const std::shared_ptr<Ipc>& ipc,
+        std::weak_ptr<Ipc> ipc,
         bool maximize,
         bool showUi,
         bool floatBuffer
@@ -172,7 +172,7 @@ public:
     }
 
     BackgroundImagesLoader& imagesLoader() const { return *mImagesLoader; }
-    Ipc& ipc() const { return *mIpc; }
+    std::weak_ptr<Ipc> ipc() const { return mIpc; }
 
     void copyImageCanvasToClipboard() const;
     void copyImageNameToClipboard() const;
@@ -234,7 +234,7 @@ private:
     nanogui::Widget* mMetricButtonContainer = nullptr;
 
     std::shared_ptr<BackgroundImagesLoader> mImagesLoader;
-    std::shared_ptr<Ipc> mIpc;
+    std::weak_ptr<Ipc> mIpc;
 
     std::shared_ptr<Image> mCurrentImage;
     std::shared_ptr<Image> mCurrentReference;

--- a/include/tev/Ipc.h
+++ b/include/tev/Ipc.h
@@ -267,7 +267,7 @@ public:
     using socket_t = int;
 #endif
 
-    Ipc(std::string_view hostname = "127.0.0.1:14158");
+    Ipc(std::string_view hostname = "");
     virtual ~Ipc();
 
     bool isPrimaryInstance() const { return mIsPrimaryInstance; }

--- a/include/tev/Ipc.h
+++ b/include/tev/Ipc.h
@@ -23,6 +23,7 @@
 
 #include <list>
 #include <span>
+#include <variant>
 #include <vector>
 
 namespace tev {
@@ -277,8 +278,6 @@ public:
     void sendToPrimaryInstance(const IpcPacket& message);
     void receiveFromSecondaryInstance(std::function<void(const IpcPacket&)> callback);
 
-    std::string ip() const { return mIp; }
-    std::string port() const { return mPort; }
     std::string hostname() const;
 
     size_t nActiveConnections() const { return mSocketConnections.size(); }
@@ -320,8 +319,16 @@ private:
 
     std::list<SocketConnection> mSocketConnections;
 
-    std::string mIp;
-    std::string mPort;
+    struct IpHost {
+        std::string ip;
+        std::string port;
+    };
+
+    struct UnixHost {
+        fs::path socketPath;
+    };
+
+    std::variant<IpHost, UnixHost> mHostInfo;
     std::string mLockName;
 
     size_t mNTotalBytesSent = 0;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -27,6 +27,7 @@
 #include <cctype>
 #include <map>
 #include <regex>
+#include <string>
 
 #ifdef _WIN32
 #    include <Shlobj.h>
@@ -314,12 +315,12 @@ fs::path runtimeDirectory() {
         return fs::path{"/tmp"};
     }
 
-    const char* flatpakId = getenv("FLATPAK_ID");
-    if (!flatpakId || !*flatpakId) {
+    const auto fpi = flatpakInfo();
+    if (!fpi) {
         return xdgRuntimeDir;
     }
 
-    return fs::path{xdgRuntimeDir} / "app" / flatpakId;
+    return fs::path{xdgRuntimeDir} / "app" / fpi->flatpakId;
 #endif
 }
 
@@ -342,6 +343,48 @@ static std::atomic<bool> sShuttingDown{false};
 bool shuttingDown() { return sShuttingDown; }
 
 void setShuttingDown() { sShuttingDown = true; }
+
+const optional<FlatpakInfo>& flatpakInfo() {
+    const auto getFlatpakInfo = []() -> optional<FlatpakInfo> {
+        const char* flatpakId = getenv("FLATPAK_ID");
+        if (!flatpakId || !*flatpakId) {
+            return nullopt;
+        }
+
+        FlatpakInfo info;
+        info.flatpakId = flatpakId;
+
+        ifstream idFile{"/.flatpak-info"};
+        if (!idFile) {
+            return info;
+        }
+
+        string line;
+        string currentSection = "";
+        while (getline(idFile, line)) {
+            if (line.empty()) {
+                continue;
+            }
+
+            if (line.front() == '[' && line.back() == ']') {
+                currentSection = line.substr(1, line.size() - 2);
+                continue;
+            }
+
+            const auto parts = split(line, "=");
+            if (parts.size() < 2) {
+                continue;
+            }
+
+            info.metadata[currentSection][parts[0]] = line.substr(parts[0].size() + 1);
+        }
+
+        return info;
+    };
+
+    static optional<FlatpakInfo> sFlatpakInfo = getFlatpakInfo();
+    return sFlatpakInfo;
+}
 
 EInterpolationMode toInterpolationMode(string_view name) {
     // Perform matching on uppercase strings

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -38,7 +38,7 @@
 #    include <unistd.h>
 #endif
 #if !defined(__APPLE__) and !defined(_WIN32)
-#include <sys/xattr.h>
+#    include <sys/xattr.h>
 #endif
 
 using namespace nanogui;
@@ -302,6 +302,24 @@ fs::path homeDirectory() {
 #else
     struct passwd* pw = getpwuid(getuid());
     return pw->pw_dir;
+#endif
+}
+
+fs::path runtimeDirectory() {
+#ifdef _WIN32
+    return homeDirectory() / "AppData" / "Local" / "tev";
+#else
+    const char* xdgRuntimeDir = getenv("XDG_RUNTIME_DIR");
+    if (!xdgRuntimeDir || !*xdgRuntimeDir) {
+        return fs::path{"/tmp"};
+    }
+
+    const char* flatpakId = getenv("FLATPAK_ID");
+    if (!flatpakId || !*flatpakId) {
+        return xdgRuntimeDir;
+    }
+
+    return fs::path{xdgRuntimeDir} / "app" / flatpakId;
 #endif
 }
 

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -50,7 +50,7 @@ static const int SIDEBAR_MIN_WIDTH = 230;
 static const float CROP_MIN_SIZE = 3;
 
 ImageViewer::ImageViewer(
-    const Vector2i& size, const shared_ptr<BackgroundImagesLoader>& imagesLoader, const shared_ptr<Ipc>& ipc, bool maximize, bool showUi, bool floatBuffer
+    const Vector2i& size, const shared_ptr<BackgroundImagesLoader>& imagesLoader, weak_ptr<Ipc> ipc, bool maximize, bool showUi, bool floatBuffer
 ) :
     nanogui::Screen{size, "tev", true, maximize, false, true, true, floatBuffer},
     mImagesLoader{imagesLoader},

--- a/src/Ipc.cpp
+++ b/src/Ipc.cpp
@@ -372,7 +372,7 @@ static int closeSocket(Ipc::socket_t socket) {
 }
 
 Ipc::Ipc(string_view hostname) : mSocketFd{INVALID_SOCKET} {
-    mLockName = fmt::format(".tev-lock.{}", hostname);
+    mLockName = fmt::format(".tev.{}.lock", hostname);
 
     const auto parts = split(hostname, ":");
     mIp = parts.front();

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -54,7 +54,7 @@ void ThreadPool::startThreads(size_t num) {
     for (size_t i = mThreads.size(); i < mNumThreads; ++i) {
         mThreads.emplace_back([this] {
             const auto id = this_thread::get_id();
-            tlog::debug() << "Spawning thread pool thread " << id;
+            // tlog::debug() << "Spawning thread pool thread " << id;
 
             unique_lock lock{mTaskQueueMutex};
             while (true) {
@@ -92,7 +92,7 @@ void ThreadPool::startThreads(size_t num) {
             }
 
             // Remove oneself from the thread pool. NOTE: at this point, the lock is still held, so modifying mThreads is safe.
-            tlog::debug() << "Shutting down thread pool thread " << id;
+            // tlog::debug() << "Shutting down thread pool thread " << id;
 
             const auto it = find_if(mThreads.begin(), mThreads.end(), [&id](const std::thread& t) { return t.get_id() == id; });
             TEV_ASSERT(it != mThreads.end(), "Thread not found in thread pool.");

--- a/src/imageio/Exif.cpp
+++ b/src/imageio/Exif.cpp
@@ -78,7 +78,7 @@ Exif::Exif() {
 
     exif_log_set_func(
         mExifLog,
-        [](ExifLog* log, ExifLogCode kind, const char* domain, const char* format, va_list args, void* userData) {
+        [](ExifLog*, ExifLogCode kind, const char* domain, const char* format, va_list args, void* userData) {
             bool* error = static_cast<bool*>(userData);
 
             char buf[1024];
@@ -117,7 +117,11 @@ Exif::Exif(span<const uint8_t> exifData, bool autoPrependFourcc) : Exif() {
         exifData = newExifData;
     }
 
-    exif_data_load_data(mExif, exifData.data(), exifData.size());
+    if (exifData.size() > numeric_limits<unsigned int>::max()) {
+        throw invalid_argument{"EXIF data size exceeds maximum supported size."};
+    }
+
+    exif_data_load_data(mExif, exifData.data(), (unsigned int)exifData.size());
 
     if (*mExifLogError) {
         throw invalid_argument{"Failed to decode EXIF data."};

--- a/src/imageio/GainMap.cpp
+++ b/src/imageio/GainMap.cpp
@@ -58,8 +58,8 @@ Task<void> applyAppleGainMap(ImageData& image, const ImageData& gainMap, int pri
     float headroom = pow(2.0f, std::max(stops, 0.0f));
     tlog::debug() << fmt::format("Derived gain map headroom {} from maker note entries #33={} and #48={}.", headroom, maker33, maker48);
 
-    const int numImageChannels = image.channels.size();
-    const int numGainMapChannels = gainMap.channels.size();
+    const int numImageChannels = (int)image.channels.size();
+    const int numGainMapChannels = (int)gainMap.channels.size();
 
     int alphaChannelIndex = -1;
     for (int c = 0; c < numImageChannels; ++c) {

--- a/src/imageio/ImageLoader.cpp
+++ b/src/imageio/ImageLoader.cpp
@@ -126,10 +126,10 @@ vector<Channel> ImageLoader::makeRgbaInterleavedChannels(
 
     // Initialize pattern [0,0,0,1] efficiently using multi-byte writes
     auto init = [numPixels](auto* ptr) {
-        using float_t = std::remove_pointer_t<decltype(ptr)>;
-        const float_t pattern[4] = {(float_t)0.0, (float_t)0.0, (float_t)0.0, (float_t)1.0};
+        using ptr_float_t = std::remove_pointer_t<decltype(ptr)>;
+        const ptr_float_t pattern[4] = {(ptr_float_t)0.0, (ptr_float_t)0.0, (ptr_float_t)0.0, (ptr_float_t)1.0};
         for (size_t i = 0; i < numPixels; ++i) {
-            memcpy(ptr + i * 4, pattern, sizeof(float_t) * 4);
+            memcpy(ptr + i * 4, pattern, sizeof(ptr_float_t) * 4);
         }
     };
 

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -46,8 +46,8 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
     png_set_error_fn(
         pngPtr,
         nullptr,
-        [](png_structp png_ptr, png_const_charp error_msg) { throw ImageLoadError{fmt::format("PNG error: {}", error_msg)}; },
-        [](png_structp png_ptr, png_const_charp warning_msg) { tlog::warning() << fmt::format("PNG warning: {}", warning_msg); }
+        [](png_structp, png_const_charp error_msg) { throw ImageLoadError{fmt::format("PNG error: {}", error_msg)}; },
+        [](png_structp, png_const_charp warning_msg) { tlog::warning() << fmt::format("PNG warning: {}", warning_msg); }
     );
 
     infoPtr = png_create_info_struct(pngPtr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -457,7 +457,7 @@ static int mainFunc(span<const string> arguments) {
 
     // Spawn a background thread that opens images passed via stdin. To allow whitespace characters in filenames, we use the convention that
     // paths in stdin must be separated by newlines.
-    thread stdinThread{[&]() {
+    thread stdinThread{[weakImagesLoader = weak_ptr<BackgroundImagesLoader>{imagesLoader}]() {
         string channelSelector;
         while (!shuttingDown()) {
             for (string line; getline(cin, line) && !shuttingDown();) {
@@ -472,7 +472,9 @@ static int mainFunc(span<const string> arguments) {
                     continue;
                 }
 
-                imagesLoader->enqueue(tev::toPath(imageFile), channelSelector, false);
+                if (auto imagesLoader = weakImagesLoader.lock(); imagesLoader) {
+                    imagesLoader->enqueue(tev::toPath(imageFile), channelSelector, false);
+                }
             }
 
             this_thread::sleep_for(10ms);


### PR DESCRIPTION
This PR lets IPC optionally communicate via unix sockets rather than TCP/IP. Curiously, Windows also supports unix sockets these days.

The feature is primarily useful when running in network-restricted sandboxes (like flatpak), where **tev** would still like to be reachable by other instances to avoid duplicate windows, etc.

Unix sockets also afford much faster data transmission, potentially useful if a client wants to send a lot of image data to **tev** quickly. Though none of the IPC SDKs currently support unix sockets.