### PR TITLE
Guess image reference white & add option to match display reference white

### DIFF
--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -39,6 +39,8 @@
 
 namespace tev {
 
+static constexpr float DEFAULT_IMAGE_WHITE_LEVEL = 80.0f;
+
 struct AttributeNode {
     std::string name;
     std::string value;
@@ -49,7 +51,7 @@ struct AttributeNode {
 struct HdrMetadata {
     float maxCLL = 0.0f;
     float maxFALL = 0.0f;
-    float whiteLevel = 80.0f;
+    float whiteLevel = DEFAULT_IMAGE_WHITE_LEVEL;
 };
 
 struct ImageData {
@@ -174,8 +176,9 @@ public:
     }
 
     const Box2i& dataWindow() const { return mData.dataWindow; }
-
     const Box2i& displayWindow() const { return mData.displayWindow; }
+
+    float whiteLevel() const { return mData.hdrMetadata.whiteLevel; }
 
     nanogui::Vector2f centerDisplayOffset(const Box2i& displayWindow) const {
         return Box2f{dataWindow()}.middle() - Box2f{displayWindow}.middle();

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -84,6 +84,7 @@ struct ImageData {
     std::vector<std::string> channelsInLayer(std::string_view layerName) const;
 
     Task<void> convertToRec709(int priority);
+    Task<void> deriveWhiteLevelFromMetadata(int priority);
     Task<void> convertToDesiredPixelFormat(int priority);
 
     void alphaOperation(const std::function<void(Channel&, const Channel&)>& func);

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -46,6 +46,12 @@ struct AttributeNode {
     std::vector<AttributeNode> children;
 };
 
+struct HdrMetadata {
+    float maxCLL = 0.0f;
+    float maxFALL = 0.0f;
+    float whiteLevel = 80.0f;
+};
+
 struct ImageData {
     ImageData() = default;
     ImageData(const ImageData&) = delete;
@@ -59,6 +65,8 @@ struct ImageData {
     bool hasPremultipliedAlpha = false;
     EOrientation orientation = EOrientation::TopLeft;
     std::vector<AttributeNode> attributes;
+
+    HdrMetadata hdrMetadata;
 
     Box2i dataWindow;
     Box2i displayWindow;

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -126,8 +126,19 @@ public:
     EMetric metric() const { return mImageCanvas->metric(); }
     void setMetric(EMetric metric);
 
-    std::optional<float> overridingWhiteLevel() const;
-    void setOverridingWhiteLevel(std::optional<float> value);
+    float displayWhiteLevel() const;
+    void setDisplayWhiteLevel(float value);
+    void setDisplayWhiteLevelToImageMetadata();
+    void setImageWhiteLevel(float value);
+
+    enum class EDisplayWhiteLevelSetting {
+        System = 0,
+        Custom = 1,
+        ImageMetadata = 2,
+    };
+
+    EDisplayWhiteLevelSetting displayWhiteLevelSetting() const;
+    void setDisplayWhiteLevelSetting(EDisplayWhiteLevelSetting value);
 
     nanogui::Vector2i sizeToFitImage(const std::shared_ptr<Image>& image);
     nanogui::Vector2i sizeToFitAllImages();
@@ -295,8 +306,11 @@ private:
     bool mSupportsAbsoluteBrightness = false;
 
     nanogui::Button* mClipToLdrButton = nullptr;
-    nanogui::FloatBox<float>* mWhiteLevelBox = nullptr;
-    nanogui::Button* mWhiteLevelOverrideButton = nullptr;
+
+    nanogui::FloatBox<float>* mDisplayWhiteLevelBox = nullptr;
+    nanogui::ComboBox* mDisplayWhiteLevelSettingComboBox = nullptr;
+
+    nanogui::FloatBox<float>* mImageWhiteLevelBox = nullptr;
 
     int mDidFitToImage = 0;
 

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -83,7 +83,7 @@ enum class ETransferCharacteristics : uint8_t {
     Linear = 8,
     Log100 = 9,
     Log100Sqrt10 = 10,
-    IEC61966 = 11,
+    IEC61966_2_4 = 11,
     BT1361Extended = 12,
     SRGB = 13,
     BT202010bit = 14,
@@ -102,8 +102,7 @@ inline float bt709ToLinear(float val) {
     constexpr float beta = 0.018053968510807f;
     constexpr float alpha = 1.0f + 5.5f * beta;
     constexpr float thres = 4.5f * beta;
-    const float result = val <= thres ? (val / 4.5f) : std::pow((val + alpha - 1.0f) / alpha, 1.0f / 0.45f);
-    return (100.0f / 80.0f) * result; // Convert to linear sRGB units where SDR white is 1.0
+    return val <= thres ? (val / 4.5f) : std::pow((val + alpha - 1.0f) / alpha, 1.0f / 0.45f);
 }
 
 // From https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.1361-0-199802-W!!PDF-E.pdf, generalized to the more precise constants from the
@@ -123,7 +122,7 @@ inline float bt1361ExtendedToLinear(float val) {
         result = std::pow((val + alpha - 1.0f) / alpha, 1.0f / 0.45f);
     }
 
-    return (100.0f / 80.0f) * result; // Convert to linear sRGB units where SDR white is 1.0
+    return result;
 }
 
 // From http://car.france3.mars.free.fr/HD/INA-%2026%20jan%2006/SMPTE%20normes%20et%20confs/s240m.pdf
@@ -157,7 +156,7 @@ inline float invTransfer(const ETransferCharacteristics transfer, float val) {
         case ETransferCharacteristics::BT601:
         case ETransferCharacteristics::BT202010bit:
         case ETransferCharacteristics::BT202012bit: return bt709ToLinear(val);
-        case ETransferCharacteristics::IEC61966: // handles negative values by mirroring
+        case ETransferCharacteristics::IEC61966_2_4: // handles negative values by mirroring
             return std::copysign(bt709ToLinear(std::abs(val)), val);
         case ETransferCharacteristics::BT1361Extended: // extended to negative values (weirdly)
             return bt1361ExtendedToLinear(val);
@@ -176,6 +175,23 @@ inline float invTransfer(const ETransferCharacteristics transfer, float val) {
 
     // Other transfer functions are not implemented. Default to linear.
     return val;
+}
+
+inline float bestGuessReferenceWhiteLevel(const ETransferCharacteristics transfer) {
+    switch (transfer) {
+        case ETransferCharacteristics::PQ:
+        case ETransferCharacteristics::HLG: return 203.0f;
+
+        case ETransferCharacteristics::BT709: // 100 nits by convention, see e.g.
+                                              // https://partnerhelp.netflixstudios.com/hc/en-us/articles/360000591787-Color-Critical-Display-Calibration-Guidelines
+        case ETransferCharacteristics::BT601: // same as BT709 in practice
+        case ETransferCharacteristics::BT1361Extended: // Extends BT709 and inherits conventions.
+        case ETransferCharacteristics::IEC61966_2_4: // xvYCC proposed by sony. Extends BT709 and inherits conventions.
+        case ETransferCharacteristics::BT202010bit: // SMPTE ST 2080-1 specifies 100 nits for SDR white
+        case ETransferCharacteristics::BT202012bit: return 100.0f;
+
+        default: return 80.0f;
+    }
 }
 } // namespace ituth273
 
@@ -234,7 +250,7 @@ private:
 // smaller than 0, even if the input was within [0, 1]. This is by design, and, on macOS, the OS translates these out-of-bounds colors
 // correctly to the gamut of the display. Other operating systems, like Windows and Linux don't do this -- it's a TODO for tev to explicitly
 // hook into these OSs' color management systems to ensure that out-of-bounds colors are displayed correctly.
-Task<void> toLinearSrgbPremul(
+Task<std::optional<ColorProfile::CICP>> toLinearSrgbPremul(
     const ColorProfile& profile,
     const nanogui::Vector2i& size,
     int numColorChannels,

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -273,7 +273,7 @@ ImageViewer::ImageViewer(
 
             if (mSupportsAbsoluteBrightness) {
                 mDisplayWhiteLevelBox->set_tooltip(
-                    "The display white level in nits (cd/m²). "
+                    "The display reference white level (aka. paper white) in nits (cd/m²). "
                     "This value determines how bright a pixel value of 1.0 appears on the display. "
                     "It follows your system settings by default.\n\n"
                     "You can customize this value to change the brightness at which images are displayed. "
@@ -320,7 +320,7 @@ ImageViewer::ImageViewer(
             mImageWhiteLevelBox->set_default_value(to_string(DEFAULT_IMAGE_WHITE_LEVEL));
             mImageWhiteLevelBox->set_units("nits");
             mImageWhiteLevelBox->set_tooltip(
-                "tev's best guess of the image's reference white level in nits (cd/m²). "
+                "tev's best guess of the image's reference white level (aka. paper white) in nits (cd/m²). "
                 "This value represents the brightness a pixel value of 1.0 is meant to represent.\n\n"
 
                 "tev usually has to guess this value for multiple reasons. "
@@ -328,7 +328,7 @@ ImageViewer::ImageViewer(
                 "Other formats are scene-referred and thus do have an absolute white level, but this information is often not stored in the file. "
                 "Sometimes, it is not even clear whether a given image format is display- or scene-referred.\n\n"
 
-                "However, when an image has unambiguous metadata, e.g. uses the PQ transfer function or contains HDR10 metadata, "
+                "However, when an image has unambiguous metadata, e.g. uses the PQ transfer function, "
                 "tev can determine the white level reliably."
             );
 

--- a/src/imageio/Colors.cpp
+++ b/src/imageio/Colors.cpp
@@ -230,350 +230,6 @@ Matrix3f adaptToXYZD50Bradford(const Vector2f& w) {
     return kBradfordInv * b;
 }
 
-class GlobalCmsContext {
-public:
-    GlobalCmsContext() {
-        cmsSetLogErrorHandler([](cmsContext, cmsUInt32Number errorCode, const char* message) {
-            tlog::error() << fmt::format("lcms error #{}: {}", errorCode, message);
-        });
-    }
-};
-
-class CmsContext {
-public:
-    CmsContext(const CmsContext&) = delete;
-    CmsContext& operator=(const CmsContext&) = delete;
-    CmsContext(CmsContext&&) = delete;
-    CmsContext& operator=(CmsContext&&) = delete;
-
-    static const CmsContext& threadLocal() {
-        static thread_local CmsContext threadCtx;
-        return threadCtx;
-    }
-
-    cmsContext get() const { return mCtx; }
-
-    cmsHPROFILE rec709Profile() const { return mRec709Profile; }
-    cmsHPROFILE grayProfile() const { return mGrayProfile; }
-
-private:
-    CmsContext() {
-        static GlobalCmsContext globalCtx;
-
-        mCtx = cmsCreateContext(cmsFastFloatExtensions(), nullptr);
-        if (!mCtx) {
-            throw runtime_error{"Failed to create LCMS context."};
-        }
-
-        cmsCIExyY D65 = {0.3127, 0.3290, 1.0};
-        cmsCIExyYTRIPLE Rec709Primaries = {
-            {0.6400, 0.3300, 1.0},
-            {0.3000, 0.6000, 1.0},
-            {0.1500, 0.0600, 1.0}
-        };
-
-        cmsToneCurve* linearCurve[3];
-        linearCurve[0] = linearCurve[1] = linearCurve[2] = cmsBuildGamma(mCtx, 1.0f);
-
-        mRec709Profile = cmsCreateRGBProfileTHR(mCtx, &D65, &Rec709Primaries, linearCurve);
-        if (!mRec709Profile) {
-            throw runtime_error{"Failed to create Rec.709 color profile."};
-        }
-
-        cmsToneCurve* grayCurve = cmsBuildGamma(mCtx, 1.0f);
-        mGrayProfile = cmsCreateGrayProfileTHR(mCtx, &D65, grayCurve);
-        if (!mGrayProfile) {
-            throw runtime_error{"Failed to create gray color profile."};
-        }
-    }
-
-    ~CmsContext() {
-        if (mGrayProfile) {
-            cmsCloseProfile(mGrayProfile);
-        }
-
-        if (mRec709Profile) {
-            cmsCloseProfile(mRec709Profile);
-        }
-
-        if (mCtx) {
-            cmsDeleteContext(mCtx);
-        }
-    }
-
-    cmsContext mCtx = nullptr;
-    cmsHPROFILE mRec709Profile = nullptr;
-    cmsHPROFILE mGrayProfile = nullptr;
-};
-
-ColorProfile::~ColorProfile() {
-    if (mProfile) {
-        cmsCloseProfile(mProfile);
-    }
-}
-
-ColorProfile ColorProfile::fromIcc(const uint8_t* iccProfile, size_t iccProfileSize) {
-    cmsHPROFILE srcProfile = cmsOpenProfileFromMemTHR(CmsContext::threadLocal().get(), iccProfile, (cmsUInt32Number)iccProfileSize);
-    if (!srcProfile) {
-        throw runtime_error{"Failed to create ICC profile from raw data."};
-    }
-
-    string desc = "<unnamed>";
-    const size_t len = cmsGetProfileInfoUTF8(srcProfile, cmsInfoDescription, "en", "US", nullptr, 0);
-    if (len > 0) {
-        desc.resize(len);
-        cmsGetProfileInfoUTF8(srcProfile, cmsInfoDescription, "en", "US", desc.data(), (cmsUInt32Number)desc.size());
-    }
-
-    tlog::debug() << fmt::format("Loaded ICC profile '{}'.", desc);
-
-    return srcProfile;
-}
-
-Task<void> toLinearSrgbPremul(
-    const ColorProfile& profile,
-    const Vector2i& size,
-    int numColorChannels,
-    EAlphaKind alphaKind,
-    EPixelFormat pixelFormat,
-    uint8_t* __restrict src,
-    float* __restrict rgbaDst,
-    int numChannelsOut,
-    int priority
-) {
-    const int numChannels = numColorChannels + (alphaKind != EAlphaKind::None ? 1 : 0);
-
-    if (!profile.isValid()) {
-        throw runtime_error{"Color profile must be valid."};
-    }
-
-    if (numColorChannels < 1 || numColorChannels > 4) {
-        throw runtime_error{"Must have 1, 2, 3, or 4 color channels."};
-    }
-
-    if (alphaKind == EAlphaKind::PremultipliedNonlinear && pixelFormat != EPixelFormat::F32) {
-        throw runtime_error{"Premultiplied nonlinear alpha is only supported for F32 pixel format."};
-    }
-
-    bool validCicp = false;
-
-    ituth273::EColorPrimaries primaries = ituth273::EColorPrimaries::Unspecified;
-    ituth273::ETransferCharacteristics transfer = ituth273::ETransferCharacteristics::Unspecified;
-    int matrixCoefficients = 0; // 0 = RGB, 1 = BT.709 YCbCr, 6 = BT.601 YCbCr
-    int videoFullRangeFlag = 0; // 0 = limited range, 1 = full range
-
-    if (cmsVideoSignalType* cicp = (cmsVideoSignalType*)cmsReadTag(profile.get(), cmsSigcicpTag); cicp != nullptr) {
-        tlog::debug() << fmt::format(
-            "ICC profile has CICP tag. Attempting manual conversion.",
-            (int)cicp->ColourPrimaries,
-            (int)cicp->TransferCharacteristics,
-            (int)cicp->MatrixCoefficients,
-            (int)cicp->VideoFullRangeFlag
-        );
-
-        validCicp = true;
-
-        primaries = (ituth273::EColorPrimaries)cicp->ColourPrimaries;
-        transfer = (ituth273::ETransferCharacteristics)cicp->TransferCharacteristics;
-        matrixCoefficients = cicp->MatrixCoefficients;
-        videoFullRangeFlag = cicp->VideoFullRangeFlag;
-
-        if (!ituth273::isTransferImplemented(transfer)) {
-            tlog::warning() << fmt::format("Unsupported transfer '{}' in CICP tag. Falling back to LCMS2.", ituth273::toString(transfer));
-            validCicp = false;
-        }
-
-        if (cicp->MatrixCoefficients != 0) {
-            tlog::warning()
-                << fmt::format("Unsupported matrix coefficients in cICP chunk: {}. Falling back to LCMS2.", cicp->MatrixCoefficients);
-            validCicp = false;
-        }
-
-        if (pixelFormat != EPixelFormat::F32) {
-            tlog::warning() << "Unsupported CICP color conversion from non-F32 pixel format. Falling back to LCMS2.";
-            validCicp = false;
-        }
-    }
-
-    LimitedRange range = LimitedRange::full();
-    Matrix3f toRec709 = Matrix3f{1.0f};
-
-    if (validCicp) {
-        tlog::debug() << fmt::format(
-            "CICP: primaries={} transfer={} coeffs={} fullRange={}",
-            ituth273::toString(primaries),
-            ituth273::toString(transfer),
-            matrixCoefficients,
-            videoFullRangeFlag == 1 ? "yes" : "no"
-        );
-
-        range = videoFullRangeFlag != 0 ? LimitedRange::full() : limitedRangeForBitsPerSample(nBits(pixelFormat));
-        toRec709 = chromaToRec709Matrix(ituth273::chroma(primaries));
-    }
-
-    // Create transform from source profile to Rec.709
-    cmsUInt32Number type = CHANNELS_SH(numColorChannels);
-
-    size_t bytesPerSample = 0;
-    switch (pixelFormat) {
-        case EPixelFormat::U8:
-            type |= BYTES_SH(1);
-            bytesPerSample = 1;
-            break;
-        case EPixelFormat::U16:
-            type |= BYTES_SH(2);
-            bytesPerSample = 2;
-            break;
-        case EPixelFormat::F16:
-            type |= BYTES_SH(2) | FLOAT_SH(1);
-            bytesPerSample = 2;
-            break;
-        case EPixelFormat::F32:
-            type |= BYTES_SH(4) | FLOAT_SH(1);
-            bytesPerSample = 4;
-            break;
-        default: throw runtime_error{"Unsupported pixel format."};
-    }
-
-    if (pixelFormat != EPixelFormat::F32) {
-        tlog::warning() << "Color conversion from non-F32 pixel format detected. This can be significantly slower than F32->F32.";
-    }
-
-    if (alphaKind != EAlphaKind::None) {
-        type |= EXTRA_SH(1);
-    }
-
-    // We expressly *don't* tell lcms2 that the alpha channel is premultiplied, because it would divide the alpha channel prior to color
-    // space conversion and inverse transfer function application. This would be bad for multiple reasons: first, EAlphaKind::Premultiplied
-    // indicated premultiplication in linear space, and second, lcms2 does not handle the case of alpha close to 0 very accurately. This is
-    // also the reason, why we manually unpremultiply in the case of EAlphaKind::PremultipliedNonlinear below rather than relying on lcms2.
-    // if (alphaKind == EAlphaKind::Premultiplied) {
-    //     type |= PREMUL_SH(1);
-    // }
-
-    // TODO: differentiate between single channel RGB and gray
-    if (numColorChannels == 1) {
-        type |= COLORSPACE_SH(PT_GRAY);
-    } else if (numColorChannels == 4) {
-        type |= COLORSPACE_SH(PT_CMYK);
-    } else {
-        type |= COLORSPACE_SH(PT_RGB);
-    }
-
-    cmsUInt32Number typeOut = 0;
-    switch (numChannelsOut) {
-        case 1: typeOut = TYPE_GRAY_FLT; break;
-        case 2: typeOut = TYPE_GRAYA_FLT; break;
-        case 3: typeOut = TYPE_RGB_FLT; break;
-        case 4: typeOut = TYPE_RGBA_FLT; break;
-        default: throw runtime_error{"Invalid number of output channels."};
-    }
-
-    const int numColorChannelsOut = numChannelsOut == 1 || numChannelsOut == 2 ? 1 : 3;
-
-    tlog::debug() << fmt::format(
-        "Creating color transform: numColorChannels={} alphaKind={} pixelFormat={} numChannels={} type={:#010x} -> numChannelsOut={} typeOut={:#010x}",
-        numColorChannels,
-        (int)alphaKind,
-        (int)pixelFormat,
-        numChannels,
-        type,
-        numChannelsOut,
-        typeOut
-    );
-
-    cmsHTRANSFORM transform = cmsCreateTransformTHR(
-        CmsContext::threadLocal().get(),
-        profile.get(),
-        type,
-        numColorChannels == 1 && numColorChannelsOut == 1 ? CmsContext::threadLocal().grayProfile() :
-                                                            CmsContext::threadLocal().rec709Profile(),
-        // Always output in straight alpha. We would prefer to have the transform output in premultiplied alpha, but lcms2 throws an error
-        // if we set this as the output type.
-        typeOut,
-        // Since tev's intent is to inspect images, we want to be as color-accurate as possible rather than perceptually pleasing. Hence the
-        // following rendering intent.
-        INTENT_RELATIVE_COLORIMETRIC,
-        alphaKind != EAlphaKind::None ? cmsFLAGS_COPY_ALPHA : 0
-    );
-
-    if (!transform) {
-        throw runtime_error{"Failed to create color transform to Rec.709."};
-    }
-
-    const size_t nSrcSamplesPerRow = size.x() * numChannels;
-    const size_t nDstSamplesPerRow = size.x() * numChannelsOut;
-    co_await ThreadPool::global().parallelForAsync<size_t>(
-        0,
-        size.y(),
-        [&](size_t y) {
-            size_t srcOffset = y * nSrcSamplesPerRow * bytesPerSample;
-            size_t dstOffset = y * nDstSamplesPerRow;
-
-            uint8_t* __restrict srcPtr = &src[srcOffset];
-            float* __restrict dstPtr = &rgbaDst[dstOffset];
-
-            // If premultiplied alpha is in nonlinear space, we need to manually unpremultiply it before the color transform.
-            if (alphaKind == EAlphaKind::PremultipliedNonlinear) {
-                for (int x = 0; x < size.x(); ++x) {
-                    const size_t baseIdx = x * numChannels;
-                    const float alpha = *(float*)&srcPtr[(baseIdx + numColorChannels) * bytesPerSample];
-                    const float factor = alpha == 0.0f ? 1.0f : 1.0f / alpha;
-                    for (int c = 0; c < numChannels - 1; ++c) {
-                        *(float*)&srcPtr[(baseIdx + c) * bytesPerSample] *= factor;
-                    }
-                }
-            }
-
-            if (validCicp) {
-                for (int x = 0; x < size.x(); ++x) {
-                    const size_t baseIdxSrc = x * numChannels;
-                    const size_t baseIdxDst = x * numChannelsOut;
-
-                    Vector3f color;
-                    for (int c = 0; c < numColorChannels; ++c) {
-                        const float val = (*(float*)&srcPtr[(baseIdxSrc + c) * bytesPerSample] - range.offset) * range.scale;
-                        color[c] = ituth273::invTransfer(transfer, val);
-                    }
-
-                    color = toRec709 * color;
-
-                    for (int c = 0; c < numColorChannelsOut; ++c) {
-                        dstPtr[baseIdxDst + c] = color[c];
-                    }
-
-                    if (alphaKind != EAlphaKind::None) {
-                        dstPtr[baseIdxDst + numColorChannelsOut] = *(float*)&srcPtr[(baseIdxSrc + numColorChannels) * bytesPerSample];
-                    }
-                }
-            } else {
-                // Armchair parallelization of lcms: cmsDoTransform is reentrant per the spec, i.e. it can be called from multiple threads. So:
-                // call cmsDoTransform for each row in parallel.
-                cmsDoTransform(transform, srcPtr, dstPtr, size.x());
-            }
-
-            // If we passed straight alpha data through lcms2, we need to multiply it by alpha again, hence we need to premultiply. If the
-            // input image had non-linear premultiplied alpha, alpha==0 pixels were preserved as-is when converting to straight alpha, so we
-            // also should not re-multiply those.
-            if (alphaKind != EAlphaKind::None && alphaKind != EAlphaKind::Premultiplied) {
-                for (int x = 0; x < size.x(); ++x) {
-                    const size_t baseIdx = x * numChannelsOut;
-
-                    float factor = dstPtr[baseIdx + numChannelsOut - 1];
-                    if (factor == 0.0f && alphaKind == EAlphaKind::PremultipliedNonlinear) {
-                        factor = 1.0f;
-                    }
-
-                    for (int c = 0; c < numChannelsOut - 1; ++c) {
-                        dstPtr[baseIdx + c] *= factor;
-                    }
-                }
-            }
-        },
-        priority
-    );
-}
-
 array<Vector2f, 4> chromaFromWpPrimaries(int wpPrimaries) {
     if (wpPrimaries == 10) {
         // Special case for Adobe RGB (1998) primaries, which is not in the H.273 spec
@@ -767,6 +423,344 @@ ETransferCharacteristics fromWpTransfer(int wpTransfer) {
 }
 
 } // namespace ituth273
+
+class GlobalCmsContext {
+public:
+    GlobalCmsContext() {
+        cmsSetLogErrorHandler([](cmsContext, cmsUInt32Number errorCode, const char* message) {
+            tlog::error() << fmt::format("lcms error #{}: {}", errorCode, message);
+        });
+    }
+};
+
+class CmsContext {
+public:
+    CmsContext(const CmsContext&) = delete;
+    CmsContext& operator=(const CmsContext&) = delete;
+    CmsContext(CmsContext&&) = delete;
+    CmsContext& operator=(CmsContext&&) = delete;
+
+    static const CmsContext& threadLocal() {
+        static thread_local CmsContext threadCtx;
+        return threadCtx;
+    }
+
+    cmsContext get() const { return mCtx; }
+
+    cmsHPROFILE rec709Profile() const { return mRec709Profile; }
+    cmsHPROFILE grayProfile() const { return mGrayProfile; }
+
+private:
+    CmsContext() {
+        static GlobalCmsContext globalCtx;
+
+        mCtx = cmsCreateContext(cmsFastFloatExtensions(), nullptr);
+        if (!mCtx) {
+            throw runtime_error{"Failed to create LCMS context."};
+        }
+
+        cmsCIExyY D65 = {0.3127, 0.3290, 1.0};
+        cmsCIExyYTRIPLE Rec709Primaries = {
+            {0.6400, 0.3300, 1.0},
+            {0.3000, 0.6000, 1.0},
+            {0.1500, 0.0600, 1.0}
+        };
+
+        cmsToneCurve* linearCurve[3];
+        linearCurve[0] = linearCurve[1] = linearCurve[2] = cmsBuildGamma(mCtx, 1.0f);
+
+        mRec709Profile = cmsCreateRGBProfileTHR(mCtx, &D65, &Rec709Primaries, linearCurve);
+        if (!mRec709Profile) {
+            throw runtime_error{"Failed to create Rec.709 color profile."};
+        }
+
+        cmsToneCurve* grayCurve = cmsBuildGamma(mCtx, 1.0f);
+        mGrayProfile = cmsCreateGrayProfileTHR(mCtx, &D65, grayCurve);
+        if (!mGrayProfile) {
+            throw runtime_error{"Failed to create gray color profile."};
+        }
+    }
+
+    ~CmsContext() {
+        if (mGrayProfile) {
+            cmsCloseProfile(mGrayProfile);
+        }
+
+        if (mRec709Profile) {
+            cmsCloseProfile(mRec709Profile);
+        }
+
+        if (mCtx) {
+            cmsDeleteContext(mCtx);
+        }
+    }
+
+    cmsContext mCtx = nullptr;
+    cmsHPROFILE mRec709Profile = nullptr;
+    cmsHPROFILE mGrayProfile = nullptr;
+};
+
+ColorProfile::~ColorProfile() {
+    if (mProfile) {
+        cmsCloseProfile(mProfile);
+    }
+}
+
+optional<ColorProfile::CICP> ColorProfile::getCicp() const {
+    const auto* cicp = (const cmsVideoSignalType*)cmsReadTag(get(), cmsSigcicpTag);
+    if (!cicp) {
+        return nullopt;
+    }
+
+    return ColorProfile::CICP{
+        .primaries = (ituth273::EColorPrimaries)cicp->ColourPrimaries,
+        .transfer = (ituth273::ETransferCharacteristics)cicp->TransferCharacteristics,
+        .matrixCoeffs = cicp->MatrixCoefficients,
+        .videoFullRangeFlag = cicp->VideoFullRangeFlag,
+    };
+}
+
+ColorProfile ColorProfile::fromIcc(const uint8_t* iccProfile, size_t iccProfileSize) {
+    cmsHPROFILE srcProfile = cmsOpenProfileFromMemTHR(CmsContext::threadLocal().get(), iccProfile, (cmsUInt32Number)iccProfileSize);
+    if (!srcProfile) {
+        throw runtime_error{"Failed to create ICC profile from raw data."};
+    }
+
+    string desc = "<unnamed>";
+    const size_t len = cmsGetProfileInfoUTF8(srcProfile, cmsInfoDescription, "en", "US", nullptr, 0);
+    if (len > 0) {
+        desc.resize(len);
+        cmsGetProfileInfoUTF8(srcProfile, cmsInfoDescription, "en", "US", desc.data(), (cmsUInt32Number)desc.size());
+    }
+
+    tlog::debug() << fmt::format("Loaded ICC profile '{}'.", desc);
+
+    return srcProfile;
+}
+
+Task<void> toLinearSrgbPremul(
+    const ColorProfile& profile,
+    const Vector2i& size,
+    int numColorChannels,
+    EAlphaKind alphaKind,
+    EPixelFormat pixelFormat,
+    uint8_t* __restrict src,
+    float* __restrict rgbaDst,
+    int numChannelsOut,
+    int priority
+) {
+    const int numChannels = numColorChannels + (alphaKind != EAlphaKind::None ? 1 : 0);
+
+    if (!profile.isValid()) {
+        throw runtime_error{"Color profile must be valid."};
+    }
+
+    if (numColorChannels < 1 || numColorChannels > 4) {
+        throw runtime_error{"Must have 1, 2, 3, or 4 color channels."};
+    }
+
+    if (alphaKind == EAlphaKind::PremultipliedNonlinear && pixelFormat != EPixelFormat::F32) {
+        throw runtime_error{"Premultiplied nonlinear alpha is only supported for F32 pixel format."};
+    }
+
+    auto cicp = profile.getCicp();
+    if (cicp) {
+        tlog::debug() << fmt::format("ICC profile has CICP tag. Attempting manual conversion.");
+    }
+
+    if (cicp && !ituth273::isTransferImplemented(cicp->transfer)) {
+        tlog::warning() << fmt::format("Unsupported transfer '{}' in CICP tag. Falling back to LCMS2.", ituth273::toString(cicp->transfer));
+        cicp = nullopt;
+    }
+
+    if (cicp && cicp->matrixCoeffs != 0) {
+        tlog::warning() << fmt::format("Unsupported matrix coefficients in cICP chunk: {}. Falling back to LCMS2.", cicp->matrixCoeffs);
+        cicp = nullopt;
+    }
+
+    if (cicp && pixelFormat != EPixelFormat::F32) {
+        tlog::warning() << "Unsupported CICP color conversion from non-F32 pixel format. Falling back to LCMS2.";
+        cicp = nullopt;
+    }
+
+    LimitedRange range = LimitedRange::full();
+    Matrix3f toRec709 = Matrix3f{1.0f};
+
+    if (cicp) {
+        tlog::debug() << fmt::format(
+            "CICP: primaries={} transfer={} coeffs={} fullRange={}",
+            ituth273::toString(cicp->primaries),
+            ituth273::toString(cicp->transfer),
+            cicp->matrixCoeffs,
+            cicp->videoFullRangeFlag == 1 ? "yes" : "no"
+        );
+
+        range = cicp->videoFullRangeFlag != 0 ? LimitedRange::full() : limitedRangeForBitsPerSample(nBits(pixelFormat));
+        toRec709 = chromaToRec709Matrix(ituth273::chroma(cicp->primaries));
+    }
+
+    // Create transform from source profile to Rec.709
+    cmsUInt32Number type = CHANNELS_SH(numColorChannels);
+
+    size_t bytesPerSample = 0;
+    switch (pixelFormat) {
+        case EPixelFormat::U8:
+            type |= BYTES_SH(1);
+            bytesPerSample = 1;
+            break;
+        case EPixelFormat::U16:
+            type |= BYTES_SH(2);
+            bytesPerSample = 2;
+            break;
+        case EPixelFormat::F16:
+            type |= BYTES_SH(2) | FLOAT_SH(1);
+            bytesPerSample = 2;
+            break;
+        case EPixelFormat::F32:
+            type |= BYTES_SH(4) | FLOAT_SH(1);
+            bytesPerSample = 4;
+            break;
+        default: throw runtime_error{"Unsupported pixel format."};
+    }
+
+    if (pixelFormat != EPixelFormat::F32) {
+        tlog::warning() << "Color conversion from non-F32 pixel format detected. This can be significantly slower than F32->F32.";
+    }
+
+    if (alphaKind != EAlphaKind::None) {
+        type |= EXTRA_SH(1);
+    }
+
+    // We expressly *don't* tell lcms2 that the alpha channel is premultiplied, because it would divide the alpha channel prior to color
+    // space conversion and inverse transfer function application. This would be bad for multiple reasons: first, EAlphaKind::Premultiplied
+    // indicated premultiplication in linear space, and second, lcms2 does not handle the case of alpha close to 0 very accurately. This is
+    // also the reason, why we manually unpremultiply in the case of EAlphaKind::PremultipliedNonlinear below rather than relying on lcms2.
+    // if (alphaKind == EAlphaKind::Premultiplied) {
+    //     type |= PREMUL_SH(1);
+    // }
+
+    // TODO: differentiate between single channel RGB and gray
+    if (numColorChannels == 1) {
+        type |= COLORSPACE_SH(PT_GRAY);
+    } else if (numColorChannels == 4) {
+        type |= COLORSPACE_SH(PT_CMYK);
+    } else {
+        type |= COLORSPACE_SH(PT_RGB);
+    }
+
+    cmsUInt32Number typeOut = 0;
+    switch (numChannelsOut) {
+        case 1: typeOut = TYPE_GRAY_FLT; break;
+        case 2: typeOut = TYPE_GRAYA_FLT; break;
+        case 3: typeOut = TYPE_RGB_FLT; break;
+        case 4: typeOut = TYPE_RGBA_FLT; break;
+        default: throw runtime_error{"Invalid number of output channels."};
+    }
+
+    const int numColorChannelsOut = numChannelsOut == 1 || numChannelsOut == 2 ? 1 : 3;
+
+    tlog::debug() << fmt::format(
+        "Creating color transform: numColorChannels={} alphaKind={} pixelFormat={} numChannels={} type={:#010x} -> numChannelsOut={} typeOut={:#010x}",
+        numColorChannels,
+        (int)alphaKind,
+        (int)pixelFormat,
+        numChannels,
+        type,
+        numChannelsOut,
+        typeOut
+    );
+
+    cmsHTRANSFORM transform = cmsCreateTransformTHR(
+        CmsContext::threadLocal().get(),
+        profile.get(),
+        type,
+        numColorChannels == 1 && numColorChannelsOut == 1 ? CmsContext::threadLocal().grayProfile() :
+                                                            CmsContext::threadLocal().rec709Profile(),
+        // Always output in straight alpha. We would prefer to have the transform output in premultiplied alpha, but lcms2 throws an error
+        // if we set this as the output type.
+        typeOut,
+        // Since tev's intent is to inspect images, we want to be as color-accurate as possible rather than perceptually pleasing. Hence the
+        // following rendering intent.
+        INTENT_RELATIVE_COLORIMETRIC,
+        alphaKind != EAlphaKind::None ? cmsFLAGS_COPY_ALPHA : 0
+    );
+
+    if (!transform) {
+        throw runtime_error{"Failed to create color transform to Rec.709."};
+    }
+
+    const size_t nSrcSamplesPerRow = size.x() * numChannels;
+    const size_t nDstSamplesPerRow = size.x() * numChannelsOut;
+    co_await ThreadPool::global().parallelForAsync<size_t>(
+        0,
+        size.y(),
+        [&](size_t y) {
+            size_t srcOffset = y * nSrcSamplesPerRow * bytesPerSample;
+            size_t dstOffset = y * nDstSamplesPerRow;
+
+            uint8_t* __restrict srcPtr = &src[srcOffset];
+            float* __restrict dstPtr = &rgbaDst[dstOffset];
+
+            // If premultiplied alpha is in nonlinear space, we need to manually unpremultiply it before the color transform.
+            if (alphaKind == EAlphaKind::PremultipliedNonlinear) {
+                for (int x = 0; x < size.x(); ++x) {
+                    const size_t baseIdx = x * numChannels;
+                    const float alpha = *(float*)&srcPtr[(baseIdx + numColorChannels) * bytesPerSample];
+                    const float factor = alpha == 0.0f ? 1.0f : 1.0f / alpha;
+                    for (int c = 0; c < numChannels - 1; ++c) {
+                        *(float*)&srcPtr[(baseIdx + c) * bytesPerSample] *= factor;
+                    }
+                }
+            }
+
+            if (cicp) {
+                for (int x = 0; x < size.x(); ++x) {
+                    const size_t baseIdxSrc = x * numChannels;
+                    const size_t baseIdxDst = x * numChannelsOut;
+
+                    Vector3f color;
+                    for (int c = 0; c < numColorChannels; ++c) {
+                        const float val = (*(float*)&srcPtr[(baseIdxSrc + c) * bytesPerSample] - range.offset) * range.scale;
+                        color[c] = ituth273::invTransfer(cicp->transfer, val);
+                    }
+
+                    color = toRec709 * color;
+
+                    for (int c = 0; c < numColorChannelsOut; ++c) {
+                        dstPtr[baseIdxDst + c] = color[c];
+                    }
+
+                    if (alphaKind != EAlphaKind::None) {
+                        dstPtr[baseIdxDst + numColorChannelsOut] = *(float*)&srcPtr[(baseIdxSrc + numColorChannels) * bytesPerSample];
+                    }
+                }
+            } else {
+                // Armchair parallelization of lcms: cmsDoTransform is reentrant per the spec, i.e. it can be called from multiple threads.
+                // So: call cmsDoTransform for each row in parallel.
+                cmsDoTransform(transform, srcPtr, dstPtr, size.x());
+            }
+
+            // If we passed straight alpha data through lcms2, we need to multiply it by alpha again, hence we need to premultiply. If the
+            // input image had non-linear premultiplied alpha, alpha==0 pixels were preserved as-is when converting to straight alpha, so we
+            // also should not re-multiply those.
+            if (alphaKind != EAlphaKind::None && alphaKind != EAlphaKind::Premultiplied) {
+                for (int x = 0; x < size.x(); ++x) {
+                    const size_t baseIdx = x * numChannelsOut;
+
+                    float factor = dstPtr[baseIdx + numChannelsOut - 1];
+                    if (factor == 0.0f && alphaKind == EAlphaKind::PremultipliedNonlinear) {
+                        factor = 1.0f;
+                    }
+
+                    for (int c = 0; c < numChannelsOut - 1; ++c) {
+                        dstPtr[baseIdx + c] *= factor;
+                    }
+                }
+            }
+        },
+        priority
+    );
+}
 
 LimitedRange limitedRangeForBitsPerSample(int bitsPerSample) {
     switch (bitsPerSample) {

--- a/src/imageio/Colors.cpp
+++ b/src/imageio/Colors.cpp
@@ -349,7 +349,7 @@ string_view toString(const ETransferCharacteristics transfer) {
         case ETransferCharacteristics::Linear: return "linear";
         case ETransferCharacteristics::Log100: return "log100";
         case ETransferCharacteristics::Log100Sqrt10: return "log100_sqrt10";
-        case ETransferCharacteristics::IEC61966: return "iec61966";
+        case ETransferCharacteristics::IEC61966_2_4: return "iec61966";
         case ETransferCharacteristics::BT1361Extended: return "bt1361_extended";
         case ETransferCharacteristics::SRGB: return "srgb";
         case ETransferCharacteristics::BT202010bit: return "bt2020_10bit";
@@ -384,7 +384,7 @@ bool isTransferImplemented(const ETransferCharacteristics transfer) {
         case ETransferCharacteristics::BT601:
         case ETransferCharacteristics::BT202010bit:
         case ETransferCharacteristics::BT202012bit:
-        case ETransferCharacteristics::IEC61966: // handles negative values by mirroring
+        case ETransferCharacteristics::IEC61966_2_4: // handles negative values by mirroring
         case ETransferCharacteristics::BT1361Extended: // extended to negative values (weirdly)
         case ETransferCharacteristics::BT470M:
         case ETransferCharacteristics::BT470BG:
@@ -411,7 +411,7 @@ ETransferCharacteristics fromWpTransfer(int wpTransfer) {
         case 5: return ETransferCharacteristics::Linear;
         case 6: return ETransferCharacteristics::Log100;
         case 7: return ETransferCharacteristics::Log100Sqrt10;
-        case 8: return ETransferCharacteristics::IEC61966;
+        case 8: return ETransferCharacteristics::IEC61966_2_4;
         case 9: return ETransferCharacteristics::SRGB;
         case 10: return ETransferCharacteristics::SRGB; // TODO: handle the fact that this is the extended SRGB variant
         case 11: return ETransferCharacteristics::PQ;
@@ -538,7 +538,7 @@ ColorProfile ColorProfile::fromIcc(const uint8_t* iccProfile, size_t iccProfileS
     return srcProfile;
 }
 
-Task<void> toLinearSrgbPremul(
+Task<optional<ColorProfile::CICP>> toLinearSrgbPremul(
     const ColorProfile& profile,
     const Vector2i& size,
     int numColorChannels,
@@ -760,6 +760,8 @@ Task<void> toLinearSrgbPremul(
         },
         priority
     );
+
+    co_return cicp;
 }
 
 LimitedRange limitedRangeForBitsPerSample(int bitsPerSample) {

--- a/src/imageio/HeifImageLoader.cpp
+++ b/src/imageio/HeifImageLoader.cpp
@@ -240,6 +240,15 @@ Task<vector<ImageData>>
             resultData.hasPremultipliedAlpha = true;
         };
 
+        if (heif_content_light_level cll; heif_image_handle_get_content_light_level(imgHandle, &cll) != 0) {
+            resultData.hdrMetadata.maxCLL = cll.max_content_light_level;
+            resultData.hdrMetadata.maxFALL = cll.max_pic_average_light_level;
+
+            tlog::debug() << fmt::format(
+                "Found content light level information: maxCLL={} maxFALL={}", resultData.hdrMetadata.maxCLL, resultData.hdrMetadata.maxFALL
+            );
+        }
+
         // If we've got an ICC color profile, apply that because it's the most detailed / standardized.
         size_t profileSize = heif_image_handle_get_raw_color_profile_size(imgHandle);
         if (profileSize != 0) {
@@ -491,8 +500,8 @@ Task<vector<ImageData>>
 
             // If we found an apple-style gainmap, apply it to the main image.
             if (loadGainmap) {
-                tlog::debug(
-                ) << fmt::format("Found Apple HDR gain map: {}. Checking EXIF maker notes for application parameters.", auxLayerName);
+                tlog::debug()
+                    << fmt::format("Found Apple HDR gain map: {}. Checking EXIF maker notes for application parameters.", auxLayerName);
                 auto amn = findAppleMakerNote();
                 if (amn) {
                     tlog::debug() << "Successfully decoded Apple maker note; applying gain map.";

--- a/src/imageio/JxlImageLoader.cpp
+++ b/src/imageio/JxlImageLoader.cpp
@@ -177,7 +177,8 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
             TEV_ASSERT(taskStart != taskEnd, "Should not produce tasks with empty range.");
 
             tasks.emplace_back(
-                [](JxlParallelRunFunction func, void* jpegxlOpaque, uint32_t taskId, uint32_t tStart, uint32_t tEnd, int tPriority, ThreadPool* pool
+                [](
+                    JxlParallelRunFunction func, void* jpegxlOpaque, uint32_t taskId, uint32_t tStart, uint32_t tEnd, int tPriority, ThreadPool* pool
                 ) -> Task<void> {
                     co_await pool->enqueueCoroutine(tPriority);
                     for (uint32_t j = tStart; j < tEnd; ++j) {
@@ -257,14 +258,16 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
                 }
 
                 tlog::debug() << fmt::format(
-                    "Image size={}x{} channels={} bits_per_sample={} alpha_bits={} alpha_premultiplied={} have_animation={}",
+                    "Image size={}x{} channels={} bits_per_sample={}:{} alpha_bits={} alpha_premultiplied={} have_animation={} intensity_target={}",
                     info.xsize,
                     info.ysize,
                     info.num_color_channels,
                     info.bits_per_sample,
+                    info.exponent_bits_per_sample,
                     info.alpha_bits,
                     info.alpha_premultiplied,
-                    info.have_animation
+                    info.have_animation,
+                    info.intensity_target
                 );
 
                 if (info.alpha_bits && info.num_extra_channels == 0) {
@@ -322,8 +325,9 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
                     }
                 }
 
-                tlog::debug(
-                ) << fmt::format("Frame {}: duration={}, is_last={} name={}", frameId, frameHeader.duration, frameHeader.is_last, frameName);
+                tlog::debug() << fmt::format(
+                    "Frame {}: duration={}, is_last={} name={}", frameId, frameHeader.duration, frameHeader.is_last, frameName
+                );
             } break;
             case JXL_DEC_NEED_IMAGE_OUT_BUFFER: {
                 // libjxl expects the alpha channels to be decoded as part of the image (despite counting as an extra channel) and all
@@ -422,6 +426,12 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
                     data.partName = frameName;
                 }
 
+                if (info.intensity_target != 0 && info.intensity_target != 255) {
+                    // Some JXL files use the intensity_target field to indicate maxCLL (e.g. https://people.csail.mit.edu/ericchan/hdr/).
+                    // Values of 0 and 255 are reserved/meaningless, so ignore those.
+                    data.hdrMetadata.maxCLL = info.intensity_target;
+                }
+
                 bool colorChannelsLoaded = false;
                 if (!iccProfile.empty()) {
                     tlog::debug() << "Found ICC color profile. Attempting to apply...";
@@ -456,7 +466,7 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
                     // decoder has already prepared the data in linear sRGB for us.
                     if (ce) {
                         tlog::debug() << fmt::format(
-                            "JxlColorEncoding: colorspace={}, primaries={}, whitepoint={}, transfer={}",
+                            "JxlColorEncoding: colorspace={} primaries={} whitepoint={} transfer={}",
                             jxlToString(ce->color_space),
                             jxlToString(ce->primaries),
                             jxlToString(ce->white_point),
@@ -524,7 +534,9 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
 
                     // Resize the channel to the image size
                     auto& channel = data.channels.emplace_back(
-                        Channel{extraChannel.name, size, EPixelFormat::F32, extraChannel.bitsPerSample > 16 ? EPixelFormat::F32 : EPixelFormat::F16}
+                        Channel{
+                            extraChannel.name, size, EPixelFormat::F32, extraChannel.bitsPerSample > 16 ? EPixelFormat::F32 : EPixelFormat::F16
+                        }
                     );
                     co_await ThreadPool::global().parallelForAsync<size_t>(
                         0,

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -138,7 +138,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
         throw ImageLoadError{fmt::format("Unsupported PNG bit depth: {}", bitDepth)};
     }
 
-    tlog::debug() << fmt::format("PNG image info: size={}, numChannels={}, bitDepth={}, colorType={}", size, numChannels, bitDepth, colorType);
+    tlog::debug() << fmt::format("PNG image info: size={} numChannels={} bitDepth={} colorType={}", size, numChannels, bitDepth, colorType);
 
     // 16 bit channels are big endian by default, but we want little endian on little endian systems
     if (bitDepth == 16 && std::endian::little == std::endian::native) {
@@ -269,6 +269,13 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
         png_read_image(pngPtr, rowPointers.data());
 
         auto applyColorspace = [&]() -> Task<void> {
+            if (double maxCLL, maxFALL; png_get_cLLI(pngPtr, infoPtr, &maxCLL, &maxFALL) == PNG_INFO_cLLI) {
+                tlog::info() << fmt::format("cLLI: maxCLL={} maxFALL={}", maxCLL, maxFALL);
+
+                resultData.hdrMetadata.maxCLL = static_cast<float>(maxCLL);
+                resultData.hdrMetadata.maxFALL = static_cast<float>(maxFALL);
+            }
+
             // According to https://www.w3.org/TR/png-3/#color-chunk-precendence, if a cICP chunk exists, use it to convert to sRGB. Else,
             // if an iCCP chunk exists, use its embedded ICC color profile to convert to linear sRGB. Otherwise, check the sRGB chunk for
             // whether the image is in sRGB/Rec709. If not, then check the gAMA and cHRM chunks for gamma and chromaticity values and use
@@ -294,7 +301,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                 }
 
                 tlog::debug() << fmt::format(
-                    "cICP: primaries={}, transfer={}, full_range={}",
+                    "cICP: primaries={} transfer={} full_range={}",
                     ituth273::toString(primaries),
                     ituth273::toString(transfer),
                     cicp.videoFullRangeFlag == 1 ? "yes" : "no"
@@ -329,6 +336,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                 resultData.toRec709 = chromaToRec709Matrix(ituth273::chroma(primaries));
 
                 resultData.hasPremultipliedAlpha = true;
+
                 co_return;
             } else if (iccProfileData) {
                 try {

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -1432,7 +1432,7 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
     // Try color space conversion using ICC profile if available. This is going to be the most accurate method.
     if (iccProfileData && iccProfileSize > 0) {
         try {
-            co_await toLinearSrgbPremul(
+            const auto cicp = co_await toLinearSrgbPremul(
                 ColorProfile::fromIcc((uint8_t*)iccProfileData, iccProfileSize),
                 size,
                 numColorChannels,
@@ -1443,6 +1443,10 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
                 4,
                 priority
             );
+
+            if (cicp) {
+                resultData.hdrMetadata.whiteLevel = ituth273::bestGuessReferenceWhiteLevel(cicp->transfer);
+            }
 
             resultData.hasPremultipliedAlpha = true;
             co_return resultData;

--- a/src/imageio/WebpImageLoader.cpp
+++ b/src/imageio/WebpImageLoader.cpp
@@ -180,7 +180,7 @@ Task<vector<ImageData>> WebpImageLoader::load(istream& iStream, const fs::path&,
                 try {
                     // Color space conversion from float to float is faster than u8 to float, hence we convert first.
                     co_await toFloat32(data, numChannels, iccTmpFloatData.data(), numChannels, frameSize, true, priority);
-                    co_await toLinearSrgbPremul(
+                    const auto cicp = co_await toLinearSrgbPremul(
                         ColorProfile::fromIcc(iccProfileData.data(), iccProfileData.size()),
                         frameSize,
                         numColorChannels,
@@ -191,6 +191,10 @@ Task<vector<ImageData>> WebpImageLoader::load(istream& iStream, const fs::path&,
                         4,
                         priority
                     );
+
+                    if (cicp) {
+                        resultData.hdrMetadata.whiteLevel = ituth273::bestGuessReferenceWhiteLevel(cicp->transfer);
+                    }
                 } catch (const std::runtime_error& e) { tlog::warning() << fmt::format("Failed to apply ICC profile: {}", e.what()); }
             } else {
                 co_await toFloat32<uint8_t, true, true>(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,7 +354,9 @@ static int mainFunc(span<const string> arguments) {
     ValueFlag<string> whiteLevelFlag{
         parser,
         "WHITE LEVEL",
-        "Override the system's display white level in nits (cd/m²). Only possible on HDR systems with absolute brightness capability. "
+        "Override the system's display white level in nits (cd/m²). "
+        "Also known as \"reference white\" or \"paper white\". "
+        "Only possible on HDR systems with absolute brightness capability. "
         "You can also set the white level to 'image' to use the image's metadata white level if available.",
         {"wl", "white-level"},
     };


### PR DESCRIPTION
Guessing happens mostly based on the transfer function.

The PR also comes with calculations based on maxCLL/maxFALL metadata, if present, but those proved fairly unreliable in my testing so are disabled for now.