### PR TITLE
Rendering intents

### DIFF
--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -29,12 +29,30 @@
 
 namespace tev {
 
-nanogui::Matrix3f chromaToRec709Matrix(const std::array<nanogui::Vector2f, 4>& chroma);
-nanogui::Matrix3f xyzToChromaMatrix(const std::array<nanogui::Vector2f, 4>& chroma);
-nanogui::Matrix3f xyzToRec709Matrix();
+enum class ERenderingIntent {
+    Perceptual = 0,
+    RelativeColorimetric = 1,
+    Saturation = 2,
+    AbsoluteColorimetric = 3,
+};
 
-nanogui::Matrix3f adobeToRec709Matrix();
-nanogui::Matrix3f proPhotoToRec709Matrix();
+nanogui::Matrix3f xyzToChromaMatrix(const std::array<nanogui::Vector2f, 4>& chroma);
+nanogui::Matrix3f adaptWhiteBradford(const nanogui::Vector2f& srcWhite, const nanogui::Vector2f& dstWhite);
+
+nanogui::Matrix3f chromaToRec709Matrix(const std::array<nanogui::Vector2f, 4>& chroma);
+
+nanogui::Vector2f whiteD50();
+nanogui::Vector2f whiteD55();
+nanogui::Vector2f whiteD65();
+nanogui::Vector2f whiteD75();
+nanogui::Vector2f whiteD93();
+
+nanogui::Vector2f whiteA();
+nanogui::Vector2f whiteB();
+nanogui::Vector2f whiteC();
+
+nanogui::Vector2f whiteCenter();
+nanogui::Vector2f whiteDci();
 
 std::array<nanogui::Vector2f, 4> rec709Chroma();
 std::array<nanogui::Vector2f, 4> adobeChroma();
@@ -45,8 +63,6 @@ std::array<nanogui::Vector2f, 4> bt2020Chroma();
 std::array<nanogui::Vector2f, 4> bt2100Chroma();
 
 nanogui::Vector2f xy(EExifLightSource lightSource);
-
-nanogui::Matrix3f adaptToXYZD50Bradford(const nanogui::Vector2f& xy);
 
 std::array<nanogui::Vector2f, 4> chromaFromWpPrimaries(int wpPrimaries);
 std::string_view wpPrimariesToString(int wpPrimaties);

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -20,7 +20,6 @@
 
 #include <tev/Common.h>
 #include <tev/Task.h>
-#include <tev/imageio/Exif.h>
 
 #include <nanogui/vector.h>
 
@@ -36,10 +35,14 @@ enum class ERenderingIntent {
     AbsoluteColorimetric = 3,
 };
 
+std::string_view toString(ERenderingIntent intent);
+
 nanogui::Matrix3f xyzToChromaMatrix(const std::array<nanogui::Vector2f, 4>& chroma);
 nanogui::Matrix3f adaptWhiteBradford(const nanogui::Vector2f& srcWhite, const nanogui::Vector2f& dstWhite);
 
-nanogui::Matrix3f chromaToRec709Matrix(const std::array<nanogui::Vector2f, 4>& chroma);
+nanogui::Matrix3f convertColorspaceMatrix(
+    const std::array<nanogui::Vector2f, 4>& srcChroma, const std::array<nanogui::Vector2f, 4>& dstChroma, ERenderingIntent intent
+);
 
 nanogui::Vector2f whiteD50();
 nanogui::Vector2f whiteD55();
@@ -62,6 +65,32 @@ std::array<nanogui::Vector2f, 4> dciP3Chroma();
 std::array<nanogui::Vector2f, 4> bt2020Chroma();
 std::array<nanogui::Vector2f, 4> bt2100Chroma();
 
+enum EExifLightSource : uint16_t {
+    Unknown = 0,
+    Daylight = 1,
+    Fluorescent = 2,
+    TungstenIncandescent = 3,
+    Flash = 4,
+    FineWeather = 9,
+    Cloudy = 10,
+    Shade = 11,
+    DaylightFluorescent = 12,
+    DayWhiteFluorescent = 13,
+    CoolWhiteFluorescent = 14,
+    WhiteFluorescent = 15,
+    WarmWhiteFluorescent = 16,
+    StandardLightA = 17,
+    StandardLightB = 18,
+    StandardLightC = 19,
+    D55 = 20,
+    D65 = 21,
+    D75 = 22,
+    D50 = 23,
+    ISOStudioTungsten = 24,
+    Other = 255,
+};
+
+std::string_view toString(EExifLightSource lightSource);
 nanogui::Vector2f xy(EExifLightSource lightSource);
 
 std::array<nanogui::Vector2f, 4> chromaFromWpPrimaries(int wpPrimaries);
@@ -246,7 +275,8 @@ public:
         uint8_t videoFullRangeFlag;
     };
 
-    std::optional<CICP> getCicp() const;
+    std::optional<CICP> cicp() const;
+    ERenderingIntent renderingIntent() const;
 
     static ColorProfile fromIcc(const uint8_t* iccProfile, size_t iccProfileSize);
     static ColorProfile srgb();
@@ -266,7 +296,7 @@ private:
 // smaller than 0, even if the input was within [0, 1]. This is by design, and, on macOS, the OS translates these out-of-bounds colors
 // correctly to the gamut of the display. Other operating systems, like Windows and Linux don't do this -- it's a TODO for tev to explicitly
 // hook into these OSs' color management systems to ensure that out-of-bounds colors are displayed correctly.
-Task<std::optional<ColorProfile::CICP>> toLinearSrgbPremul(
+Task<void> toLinearSrgbPremul(
     const ColorProfile& profile,
     const nanogui::Vector2i& size,
     int numColorChannels,

--- a/include/tev/imageio/Exif.h
+++ b/include/tev/imageio/Exif.h
@@ -30,33 +30,6 @@ struct _ExifLog;
 
 namespace tev {
 
-enum EExifLightSource : uint16_t {
-    Unknown = 0,
-    Daylight = 1,
-    Fluorescent = 2,
-    TungstenIncandescent = 3,
-    Flash = 4,
-    FineWeather = 9,
-    Cloudy = 10,
-    Shade = 11,
-    DaylightFluorescent = 12,
-    DayWhiteFluorescent = 13,
-    CoolWhiteFluorescent = 14,
-    WhiteFluorescent = 15,
-    WarmWhiteFluorescent = 16,
-    StandardLightA = 17,
-    StandardLightB = 18,
-    StandardLightC = 19,
-    D55 = 20,
-    D65 = 21,
-    D75 = 22,
-    D50 = 23,
-    ISOStudioTungsten = 24,
-    Other = 255,
-};
-
-std::string toString(EExifLightSource lightSource);
-
 class Exif {
 public:
     static constexpr std::array<uint8_t, 6> FOURCC = {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -118,7 +118,9 @@ Task<void> ImageData::deriveWhiteLevelFromMetadata(int priority) {
     // condusive to deriving a white level for display (which should be actual cd/m² luminance). The following code therefore computes
     // actual luminance, but leaves a commented-out option to compute maximum RGB BT.2020 instead.
 
-    const auto toRec2020 = inverse(chromaToRec709Matrix(ituth273::chroma(ituth273::EColorPrimaries::BT2020)));
+    const auto toRec2020 = convertColorspaceMatrix(
+        rec709Chroma(), bt2020Chroma(), ERenderingIntent::AbsoluteColorimetric /* intent doesn't matter because white point is the same */
+    );
 
     for (size_t i = 0; i < layers.size(); ++i) {
         const auto& layer = layers[i];

--- a/src/imageio/Colors.cpp
+++ b/src/imageio/Colors.cpp
@@ -23,8 +23,6 @@
 
 #include <nanogui/vector.h>
 
-#include <ImfChromaticities.h>
-
 #include <lcms2.h>
 #include <lcms2_fast_float.h>
 
@@ -45,59 +43,157 @@ Matrix3f toMatrix3(const float data[3][3]) {
     return result;
 }
 
-Matrix3f transpose(const Imath::M44f& mat) {
-    Matrix3f result;
-    for (int m = 0; m < 3; ++m) {
-        for (int n = 0; n < 3; ++n) {
-            // No flipping of indices needed, because Imath::M44f is row-major while Matrix3f is column-major
-            result.m[m][n] = mat.x[m][n];
-        }
+// This routine was copied from OpenEXR's ImfChromaticities.cpp in accordance
+// with its BSD-3-Clause license. See the header of that file for details.
+// https://github.com/AcademySoftwareFoundation/openexr/blob/main/src/lib/OpenEXR/ImfChromaticities.cpp
+Matrix3f rgbToXyz(const std::array<Vector2f, 4>& chroma, float Y) {
+    //
+    // For an explanation of how the color conversion matrix is derived,
+    // see Roy Hall, "Illumination and Color in Computer Generated Imagery",
+    // Springer-Verlag, 1989, chapter 3, "Perceptual Response"; and
+    // Charles A. Poynton, "A Technical Introduction to Digital Video",
+    // John Wiley & Sons, 1996, chapter 7, "Color science for video".
+    //
+
+    //
+    // X and Z values of RGB value (1, 1, 1), or "white"
+    //
+
+    const Vector2f& red = chroma[0];
+    const Vector2f& green = chroma[1];
+    const Vector2f& blue = chroma[2];
+    const Vector2f& white = chroma[3];
+
+    // prevent a division that rounds to zero
+    if (std::abs(white.y()) <= 1.f && std::abs(white.x() * Y) >= std::abs(white.y()) * std::numeric_limits<float>::max()) {
+        throw std::invalid_argument("Bad chromaticities: white.y cannot be zero");
     }
 
-    return result;
+    float X = white.x() * Y / white.y();
+    float Z = (1 - white.x() - white.y()) * Y / white.y();
+
+    //
+    // Scale factors for matrix rows, compute numerators and common denominator
+    //
+
+    float d = red.x() * (blue.y() - green.y()) + blue.x() * (green.y() - red.y()) + green.x() * (red.y() - blue.y());
+
+    float SrN =
+        (X * (blue.y() - green.y()) - green.x() * (Y * (blue.y() - 1) + blue.y() * (X + Z)) +
+         blue.x() * (Y * (green.y() - 1) + green.y() * (X + Z)));
+
+    float SgN =
+        (X * (red.y() - blue.y()) + red.x() * (Y * (blue.y() - 1) + blue.y() * (X + Z)) - blue.x() * (Y * (red.y() - 1) + red.y() * (X + Z)));
+
+    float SbN =
+        (X * (green.y() - red.y()) - red.x() * (Y * (green.y() - 1) + green.y() * (X + Z)) +
+         green.x() * (Y * (red.y() - 1) + red.y() * (X + Z)));
+
+    if (std::abs(d) < 1.f &&
+        (std::abs(SrN) >= std::abs(d) * std::numeric_limits<float>::max() || std::abs(SgN) >= std::abs(d) * std::numeric_limits<float>::max() ||
+         std::abs(SbN) >= std::abs(d) * std::numeric_limits<float>::max())) {
+        // cannot generate matrix if all RGB primaries have the same y value
+        // or if they all have the an x value of zero
+        // in both cases, the primaries are colinear, which makes them unusable
+        throw std::invalid_argument("Bad chromaticities: RGBtoXYZ matrix is degenerate");
+    }
+
+    float Sr = SrN / d;
+    float Sg = SgN / d;
+    float Sb = SbN / d;
+
+    //
+    // Assemble the matrix
+    //
+
+    Matrix3f M;
+
+    M.m[0][0] = Sr * red.x();
+    M.m[0][1] = Sr * red.y();
+    M.m[0][2] = Sr * (1 - red.x() - red.y());
+
+    M.m[1][0] = Sg * green.x();
+    M.m[1][1] = Sg * green.y();
+    M.m[1][2] = Sg * (1 - green.x() - green.y());
+
+    M.m[2][0] = Sb * blue.x();
+    M.m[2][1] = Sb * blue.y();
+    M.m[2][2] = Sb * (1 - blue.x() - blue.y());
+
+    return M;
 }
 
-Matrix3f xyzToChromaMatrix(const std::array<Vector2f, 4>& chroma) {
-    Imf::Chromaticities imfChroma = {
-        {chroma[0].x(), chroma[0].y()},
-        {chroma[1].x(), chroma[1].y()},
-        {chroma[2].x(), chroma[2].y()},
-        {chroma[3].x(), chroma[3].y()},
-    };
+Matrix3f xyzToRgb(const std::array<Vector2f, 4>& chroma, float Y) { return inverse(rgbToXyz(chroma, Y)); }
 
-    return transpose(Imf::XYZtoRGB(imfChroma, 1));
-}
+Matrix3f xyzToChromaMatrix(const std::array<Vector2f, 4>& chroma) { return xyzToRgb(chroma, 1); }
 
-Matrix3f chromaToRec709Matrix(const std::array<Vector2f, 4>& chroma) {
-    Imf::Chromaticities rec709; // default rec709 (sRGB) primaries
-    Imf::Chromaticities imfChroma = {
-        {chroma[0].x(), chroma[0].y()},
-        {chroma[1].x(), chroma[1].y()},
-        {chroma[2].x(), chroma[2].y()},
-        {chroma[3].x(), chroma[3].y()},
-    };
-
-    // equality comparison for Imf::Chromaticities instances
-    auto chromaEq = [](const Imf::Chromaticities& a, const Imf::Chromaticities& b) {
-        return (a.red - b.red).length2() + (a.green - b.green).length2() + (a.blue - b.blue).length2() + (a.white - b.white).length2() <
-            1e-6f;
-    };
-
-    if (chromaEq(imfChroma, rec709)) {
+// Adapted from LittleCMS's AdaptToXYZD50 function
+Matrix3f adaptWhiteBradford(const Vector2f& srcWhite, const Vector2f& dstWhite) {
+    if (srcWhite == dstWhite) {
         return Matrix3f{1.0f};
     }
 
-    return transpose(Imf::RGBtoXYZ(imfChroma, 1) * Imf::XYZtoRGB(rec709, 1));
+    const float br[3][3] = {
+        {0.8951f,  0.2664f,  -0.1614f},
+        {-0.7502f, 1.7135f,  0.0367f },
+        {0.0389f,  -0.0685f, 1.0296f },
+    };
+    const auto kBradford = toMatrix3(br);
+    const float brInv[3][3] = {
+        {0.9869929f,  -0.1470543f, 0.1599627f},
+        {0.4323053f,  0.5183603f,  0.0492912f},
+        {-0.0085287f, 0.0400428f,  0.9684867f},
+    };
+    const auto kBradfordInv = toMatrix3(brInv);
+
+    const auto xyToXYZ = [](const Vector2f& c) { return Vector3f{c.x() / c.y(), 1.0f, (1.0f - c.x() - c.y()) / c.y()}; };
+
+    const auto lmsSrc = kBradford * xyToXYZ(srcWhite);
+    const auto lmsDst = kBradford * xyToXYZ(dstWhite);
+
+    const float a[3][3] = {
+        {lmsDst[0] / lmsSrc[0], 0,                     0                    },
+        {0,                     lmsDst[1] / lmsSrc[1], 0                    },
+        {0,                     0,                     lmsDst[2] / lmsSrc[2]},
+    };
+    const auto aMat = toMatrix3(a);
+
+    const auto b = aMat * kBradford;
+    return kBradfordInv * b;
 }
 
-Matrix3f xyzToRec709Matrix() {
-    Imf::Chromaticities rec709; // default rec709 (sRGB) primaries
-    return transpose(Imf::XYZtoRGB(rec709, 1));
+Matrix3f convertColorspaceMatrix(const std::array<Vector2f, 4>& srcChroma, const std::array<Vector2f, 4>& dstChroma, ERenderingIntent intent) {
+    if (srcChroma == dstChroma) {
+        return Matrix3f{1.0f};
+    }
+
+    switch (intent) {
+        case ERenderingIntent::Saturation:
+            tlog::warning() << "Saturation rendering intent is not supported; falling back to Perceptual.";
+            [[fallthrough]];
+        case ERenderingIntent::Perceptual:
+        case ERenderingIntent::RelativeColorimetric:
+            return xyzToRgb(dstChroma, 1) * adaptWhiteBradford(srcChroma[3], dstChroma[3]) * rgbToXyz(srcChroma, 1);
+        case ERenderingIntent::AbsoluteColorimetric: return xyzToRgb(dstChroma, 1) * rgbToXyz(srcChroma, 1);
+        default: throw std::invalid_argument("Invalid rendering intent");
+    }
 }
 
+Matrix3f chromaToRec709Matrix(const std::array<Vector2f, 4>& chroma) {
+    return convertColorspaceMatrix(chroma, rec709Chroma(), ERenderingIntent::AbsoluteColorimetric);
+}
+
+Vector2f whiteD50() { return {0.34567f, 0.35850f}; }
+Vector2f whiteD55() { return {0.33242f, 0.34743f}; }
 Vector2f whiteD65() { return {0.31271f, 0.32902f}; }
+Vector2f whiteD75() { return {0.29902f, 0.31485f}; }
+Vector2f whiteD93() { return {0.28315f, 0.29711f}; }
+
+Vector2f whiteA() { return {0.44758f, 0.40745f}; }
+Vector2f whiteB() { return {0.34842f, 0.35161f}; }
+Vector2f whiteC() { return {0.31006f, 0.31616f}; }
+
 Vector2f whiteCenter() { return {0.333333f, 0.333333f}; }
-Vector2f whiteC() { return {0.310f, 0.316f}; }
 Vector2f whiteDci() { return {0.314f, 0.351f}; }
 
 array<Vector2f, 4> rec709Chroma() {
@@ -173,61 +269,29 @@ array<Vector2f, 4> bt2100Chroma() {
 nanogui::Vector2f xy(EExifLightSource lightSource) {
     switch (lightSource) {
         case EExifLightSource::Unknown: return {0.0f, 0.0f};
-        case EExifLightSource::Daylight: return {0.31292, 0.32933};
-        case EExifLightSource::Fluorescent: return {0.37417, 0.37281};
-        case EExifLightSource::TungstenIncandescent: return {0.44758, 0.40745};
+        case EExifLightSource::Daylight: return {0.31292f, 0.32933f};
+        case EExifLightSource::Fluorescent: return {0.37417f, 0.37281f};
+        case EExifLightSource::TungstenIncandescent: return {0.44758f, 0.40745f};
         case EExifLightSource::Flash: return {0.0f, 0.0f};
         case EExifLightSource::FineWeather: return {0.0f, 0.0f};
         case EExifLightSource::Cloudy: return {0.0f, 0.0f};
         case EExifLightSource::Shade: return {0.0f, 0.0f};
-        case EExifLightSource::DaylightFluorescent: return {0.31310, 0.33710};
-        case EExifLightSource::DayWhiteFluorescent: return {0.31379, 0.34531};
-        case EExifLightSource::CoolWhiteFluorescent: return {0.37208, 0.37529};
-        case EExifLightSource::WhiteFluorescent: return {0.40910, 0.39430};
-        case EExifLightSource::WarmWhiteFluorescent: return {0.44018, 0.40329};
-        case EExifLightSource::StandardLightA: return {0.44758f, 0.40745f};
-        case EExifLightSource::StandardLightB: return {0.34842, 0.35161};
+        case EExifLightSource::DaylightFluorescent: return {0.31310f, 0.33710f};
+        case EExifLightSource::DayWhiteFluorescent: return {0.31379f, 0.34531f};
+        case EExifLightSource::CoolWhiteFluorescent: return {0.37208f, 0.37529f};
+        case EExifLightSource::WhiteFluorescent: return {0.40910f, 0.39430f};
+        case EExifLightSource::WarmWhiteFluorescent: return {0.44018f, 0.40329f};
+        case EExifLightSource::StandardLightA: return whiteA();
+        case EExifLightSource::StandardLightB: return whiteB();
         case EExifLightSource::StandardLightC: return whiteC();
-        case EExifLightSource::D55: return {0.33242, 0.34743};
+        case EExifLightSource::D55: return whiteD55();
         case EExifLightSource::D65: return whiteD65();
-        case EExifLightSource::D75: return {0.29902, 0.31485};
-        case EExifLightSource::D50: return {0.34567, 0.35850};
+        case EExifLightSource::D75: return whiteD75();
+        case EExifLightSource::D50: return whiteD50();
         case EExifLightSource::ISOStudioTungsten: return {0.430944089109761f, 0.403585442674295f};
         case EExifLightSource::Other: return {0.0f, 0.0f};
         default: throw invalid_argument{"Invalid EExifLightSource value."};
     }
-}
-
-// Adapted from LittleCMS's AdaptToXYZD50 function
-Matrix3f adaptToXYZD50Bradford(const Vector2f& w) {
-    const float br[3][3] = {
-        {0.8951f,  0.2664f,  -0.1614f},
-        {-0.7502f, 1.7135f,  0.0367f },
-        {0.0389f,  -0.0685f, 1.0296f },
-    };
-    const auto kBradford = toMatrix3(br);
-    const float brInv[3][3] = {
-        {0.9869929f,  -0.1470543f, 0.1599627f},
-        {0.4323053f,  0.5183603f,  0.0492912f},
-        {-0.0085287f, 0.0400428f,  0.9684867f},
-    };
-    const auto kBradfordInv = toMatrix3(brInv);
-
-    const Vector3f white{w.x() / w.y(), 1.0f, (1.0f - w.x() - w.y()) / w.y()};
-    const Vector3f white50{0.96422f, 1.0f, 0.82521f};
-
-    const auto lms = kBradford * white;
-    const auto lms50 = kBradford * white50;
-
-    const float a[3][3] = {
-        {lms50[0] / lms[0], 0,                 0                },
-        {0,                 lms50[1] / lms[1], 0                },
-        {0,                 0,                 lms50[2] / lms[2]},
-    };
-    const auto aMat = toMatrix3(a);
-
-    const auto b = aMat * kBradford;
-    return kBradfordInv * b;
 }
 
 array<Vector2f, 4> chromaFromWpPrimaries(int wpPrimaries) {

--- a/src/imageio/Exif.cpp
+++ b/src/imageio/Exif.cpp
@@ -32,35 +32,6 @@ namespace {
 ExifByteOrder byteOrder(bool reverseEndianness) { return reverseEndianness ? EXIF_BYTE_ORDER_MOTOROLA : EXIF_BYTE_ORDER_INTEL; }
 } // namespace
 
-std::string toString(EExifLightSource lightSource) {
-    switch (lightSource) {
-        case EExifLightSource::Unknown: return "unknown";
-        case EExifLightSource::Daylight: return "daylight";
-        case EExifLightSource::Fluorescent: return "fluorescent";
-        case EExifLightSource::TungstenIncandescent: return "tungsten_incandescent";
-        case EExifLightSource::Flash: return "flash";
-        case EExifLightSource::FineWeather: return "fine_weather";
-        case EExifLightSource::Cloudy: return "cloudy";
-        case EExifLightSource::Shade: return "shade";
-        case EExifLightSource::DaylightFluorescent: return "daylight_fluorescent";
-        case EExifLightSource::DayWhiteFluorescent: return "day_white_fluorescent";
-        case EExifLightSource::CoolWhiteFluorescent: return "cool_white_fluorescent";
-        case EExifLightSource::WhiteFluorescent: return "white_fluorescent";
-        case EExifLightSource::WarmWhiteFluorescent: return "warm_white_fluorescent";
-        case EExifLightSource::StandardLightA: return "standard_a";
-        case EExifLightSource::StandardLightB: return "standard_b";
-        case EExifLightSource::StandardLightC: return "standard_c";
-        case EExifLightSource::D55: return "D55";
-        case EExifLightSource::D65: return "D65";
-        case EExifLightSource::D75: return "D75";
-        case EExifLightSource::D50: return "D50";
-        case EExifLightSource::ISOStudioTungsten: return "iso_studio_tungsten";
-        case EExifLightSource::Other: return "other";
-    }
-
-    throw invalid_argument{"Unknown EXIF light source."};
-}
-
 Exif::Exif() {
     ScopeGuard guard{[this]() { reset(); }};
 

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -112,6 +112,8 @@ Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, 
         priority
     );
 
+    // Treated like EXR: scene-referred by nature. Usually corresponds to linear light, so should not get its white point adjusted.
+    resultData.renderingIntent = ERenderingIntent::AbsoluteColorimetric;
     resultData.hasPremultipliedAlpha = false;
 
     co_return result;

--- a/src/imageio/RawImageLoader.cpp
+++ b/src/imageio/RawImageLoader.cpp
@@ -302,6 +302,10 @@ Task<vector<ImageData>> RawImageLoader::load(istream& iStream, const fs::path& p
         priority
     );
 
+    // As part of its processing, libraw adapts colors to D65 sRGB viewing conditions. Hence we're already display referred at this point
+    // and keep processing relative to the white point.
+    resultData.renderingIntent = ERenderingIntent::RelativeColorimetric;
+
     if (!exif.node.children.empty() && !exif.node.children.front().children.empty()) {
         resultData.attributes.emplace_back(std::move(exif.node));
     }

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -622,7 +622,7 @@ Task<void> postprocessLinearRawDng(
                 const auto whitePoint = xy(illuminant);
                 if (whitePoint.x() > 0.0f && whitePoint.y() > 0.0f) {
                     tlog::debug() << fmt::format("Adapting known illuminant with CIE1931 xy={} to D50", whitePoint);
-                    chromaticAdaptation = adaptToXYZD50Bradford(whitePoint);
+                    chromaticAdaptation = adaptWhiteBradford(whitePoint, whiteD50());
                 } else {
                     tlog::warning() << fmt::format("Unknown illuminant");
                 }
@@ -1466,7 +1466,7 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
         );
     } else if (photometric == PHOTOMETRIC_LOGLUV || photometric == PHOTOMETRIC_LOGL) {
         // If we're a LogLUV image, we've already configured the encoder to give us linear XYZ data, so we can just convert that to Rec.709.
-        resultData.toRec709 = xyzToRec709Matrix();
+        resultData.toRec709 = xyzToChromaMatrix(rec709Chroma());
     } else if (photometric <= PHOTOMETRIC_PALETTE) {
         co_await postprocessRgb(tif, photometric, dataBitsPerSample, numColorChannels, numRgbaChannels, floatRgbaData, resultData, priority);
     } else {


### PR DESCRIPTION
When constrained to the colorimetrically accurate rendering intents (`AbsoluteColorimetric` and `RelativeColorimetric`), it looks very much like the sensible choice is
- scene-referred <-> absolute
  - == convert w/o white point adaptation because data is independent of viewing conditions
- display-referred <-> relative
  - == convert w/ white point adaptation because data is already adapted to a display standard's white point

Of course **tev** will let rendering intents from image metadata / ICC profiles override these defaults, if present.

In practice, rendering intents won't change much and this is largely an academic point... because 99% of images share the D65 white point with display standards (sRGB, BT.2020, etc. all use D65). So it makes no difference whether white point adaptation is performed or not -- it's a no-op anyway.