### PR TITLE
Optimize sequential bottleneck in various image operations

### DIFF
--- a/include/tev/Channel.h
+++ b/include/tev/Channel.h
@@ -25,14 +25,16 @@
 
 #include <half.h>
 
+#include <memory>
 #include <span>
 #include <string>
-#include <vector>
 
 namespace tev {
 
 class Channel {
 public:
+    using Data = HeapArray<uint8_t>;
+
     static std::pair<std::string_view, std::string_view> split(std::string_view fullChannel);
 
     static std::string_view tail(std::string_view fullChannel);
@@ -48,7 +50,7 @@ public:
         const nanogui::Vector2i& size,
         EPixelFormat format,
         EPixelFormat desiredFormat,
-        std::shared_ptr<std::vector<uint8_t>> data = nullptr,
+        std::shared_ptr<Data> data = nullptr,
         size_t dataOffset = 0,
         size_t dataStride = 1
     );
@@ -163,8 +165,8 @@ public:
     void setStride(size_t stride) { mDataStride = stride; }
     size_t stride() const { return mDataStride; }
 
-    std::shared_ptr<std::vector<uint8_t>>& dataBuf() { return mData; }
-    const std::shared_ptr<std::vector<uint8_t>>& dataBuf() const { return mData; }
+    std::shared_ptr<Data>& dataBuf() { return mData; }
+    const std::shared_ptr<Data>& dataBuf() const { return mData; }
 
     EPixelFormat desiredPixelFormat() const { return mDesiredPixelFormat; }
 
@@ -181,7 +183,7 @@ private:
     // losslessly. For such images, loaders can set this to F16 to save memory.
     EPixelFormat mDesiredPixelFormat = EPixelFormat::F32;
 
-    std::shared_ptr<std::vector<uint8_t>> mData;
+    std::shared_ptr<Data> mData;
     size_t mDataOffset;
     size_t mDataStride;
 };

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -360,6 +360,25 @@ private:
     bool mArmed = true;
 };
 
+template <typename T>
+class HeapArray {
+public:
+    HeapArray(size_t size) : mBuf{std::make_unique<T[]>(size)}, mSize{size} {}
+    HeapArray(HeapArray&& other) = default;
+    HeapArray& operator=(HeapArray&& other) = default;
+
+    T& operator[](size_t idx) { return mBuf[idx]; }
+
+    T* data() { return mBuf.get(); }
+    const T* data() const { return mBuf.get(); }
+
+    size_t size() const { return mSize; }
+
+private:
+    std::unique_ptr<T[]> mBuf;
+    size_t mSize;
+};
+
 template <typename T> T round(T value, T decimals) {
     auto precision = std::pow(static_cast<T>(10), decimals);
     return std::round(value * precision) / precision;

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -31,6 +31,7 @@
 #include <filesystem>
 #include <functional>
 #include <optional>
+#include <span>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -375,6 +376,9 @@ public:
     const T* data() const { return mBuf.get(); }
 
     size_t size() const { return mSize; }
+
+    operator std::span<const T>() const { return std::span<const T>{mBuf.get(), mSize}; }
+    operator std::span<T>() { return std::span<T>{mBuf.get(), mSize}; }
 
 private:
     std::unique_ptr<T[]> mBuf;

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -371,6 +371,7 @@ public:
 
     operator bool() const { return mBuf != nullptr; }
     T& operator[](size_t idx) { return mBuf[idx]; }
+    const T& operator[](size_t idx) const { return mBuf[idx]; }
 
     T* data() { return mBuf.get(); }
     const T* data() const { return mBuf.get(); }

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -363,10 +363,12 @@ private:
 template <typename T>
 class HeapArray {
 public:
+    HeapArray() : mBuf{nullptr}, mSize{0} {}
     HeapArray(size_t size) : mBuf{std::make_unique<T[]>(size)}, mSize{size} {}
     HeapArray(HeapArray&& other) = default;
     HeapArray& operator=(HeapArray&& other) = default;
 
+    operator bool() const { return mBuf != nullptr; }
     T& operator[](size_t idx) { return mBuf[idx]; }
 
     T* data() { return mBuf.get(); }

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -269,7 +269,7 @@ private:
 
 // Modifies `data` and returns the new size of the data after reorientation.
 Task<nanogui::Vector2i>
-    orientToTopLeft(EPixelFormat format, std::vector<uint8_t>& data, nanogui::Vector2i size, EOrientation orientation, int priority);
+    orientToTopLeft(EPixelFormat format, Channel::Data& data, nanogui::Vector2i size, EOrientation orientation, int priority);
 
 Task<std::vector<std::shared_ptr<Image>>>
     tryLoadImage(int imageId, fs::path path, std::istream& iStream, std::string_view channelSelector, bool applyGainmaps, bool groupChannels);

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -112,8 +112,8 @@ public:
     // The following functions return four values per pixel in RGBA order. The number of pixels is given by `imageDataSize()`. If the canvas
     // does not currently hold an image, or no channels are displayed, then zero pixels are returned.
     nanogui::Vector2i imageDataSize() const { return cropInImageCoords().size(); }
-    std::vector<float> getHdrImageData(bool divideAlpha, int priority) const;
-    std::vector<char> getLdrImageData(bool divideAlpha, int priority) const;
+    HeapArray<float> getHdrImageData(bool divideAlpha, int priority) const;
+    HeapArray<char> getLdrImageData(bool divideAlpha, int priority) const;
 
     void saveImage(const fs::path& filename) const;
 

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -124,13 +124,14 @@ public:
     // Returns a list of all supported mime types, sorted by decoding preference.
     static const std::vector<std::string_view>& supportedMimeTypes();
 
-    static std::vector<Channel> makeRgbaInterleavedChannels(
+    static Task<std::vector<Channel>> makeRgbaInterleavedChannels(
         int numChannels,
         bool hasAlpha,
         const nanogui::Vector2i& size,
         EPixelFormat format,
         EPixelFormat desiredFormat,
-        std::string_view namePrefix = ""
+        std::string_view namePrefix,
+        int priority
     );
 
     static std::vector<Channel> makeNChannels(

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -72,7 +72,7 @@ Channel::Channel(
     const nanogui::Vector2i& size,
     EPixelFormat format,
     EPixelFormat desiredFormat,
-    shared_ptr<vector<uint8_t>> data,
+    shared_ptr<Channel::Data> data,
     size_t dataOffset,
     size_t dataStride
 ) :
@@ -82,7 +82,7 @@ Channel::Channel(
         mDataOffset = dataOffset;
         mDataStride = dataStride;
     } else {
-        mData = make_shared<vector<uint8_t>>(nBytes(format) * (size_t)size.x() * size.y());
+        mData = make_shared<Channel::Data>(nBytes(format) * (size_t)size.x() * size.y());
         mDataOffset = 0;
         mDataStride = nBytes(format);
     }

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -268,7 +268,7 @@ Task<void> ImageData::deriveWhiteLevelFromMetadata(int priority) {
 
 Task<void> ImageData::convertToDesiredPixelFormat(int priority) {
     // All channels sharing the same data buffer must be converted together to avoid multiple conversions of the same data.
-    multimap<shared_ptr<vector<uint8_t>>, Channel*> channelsByData;
+    multimap<shared_ptr<Channel::Data>, Channel*> channelsByData;
     for (auto& c : channels) {
         channelsByData.emplace(c.dataBuf(), &c);
     }
@@ -304,10 +304,10 @@ Task<void> ImageData::convertToDesiredPixelFormat(int priority) {
             continue;
         }
 
-        shared_ptr<vector<uint8_t>> data = it->first;
+        shared_ptr<Channel::Data> data = it->first;
 
         const size_t nSamples = data->size() / nBytes(sourceFormat);
-        vector<uint8_t> convertedData(nSamples * nBytes(targetFormat));
+        Channel::Data convertedData(nSamples * nBytes(targetFormat));
 
         const uint8_t* const src = data->data();
         uint8_t* const dst = convertedData.data();
@@ -400,11 +400,11 @@ Task<void> ImageData::orientToTopLeft(int priority) {
 
     struct DataDesc {
         EPixelFormat pixelFormat;
-        shared_ptr<vector<uint8_t>> data;
+        shared_ptr<Channel::Data> data;
         Vector2i size;
 
         struct Hash {
-            size_t operator()(const DataDesc& interval) const { return hash<shared_ptr<vector<uint8_t>>>()(interval.data); }
+            size_t operator()(const DataDesc& interval) const { return hash<shared_ptr<Channel::Data>>()(interval.data); }
         };
 
         bool operator==(const DataDesc& other) const {
@@ -743,7 +743,7 @@ Texture* Image::texture(span<const string> channelNames, EInterpolationMode minF
         join(channelNames, ",")
     );
 
-    using DataBufPtr = std::shared_ptr<std::vector<uint8_t>>;
+    using DataBufPtr = std::shared_ptr<Channel::Data>;
     DataBufPtr dataPtr = nullptr;
 
     // Check if channel layout is already interleaved. If yes, can directly copy onto GPU!
@@ -758,7 +758,7 @@ Texture* Image::texture(span<const string> channelNames, EInterpolationMode minF
 
         const auto numPixels = this->numPixels();
         const auto size = this->size();
-        dataPtr = make_shared<vector<uint8_t>>(numPixels * numTextureChannels * (bitsPerSample / 8));
+        dataPtr = make_shared<Channel::Data>(numPixels * numTextureChannels * (bitsPerSample / 8));
 
         vector<Task<void>> tasks;
         for (size_t i = 0; i < numTextureChannels; ++i) {
@@ -1002,7 +1002,7 @@ string Image::toString() const {
 
 // Modifies `data` and returns the new size of the data after reorientation.
 Task<nanogui::Vector2i>
-    orientToTopLeft(EPixelFormat format, std::vector<uint8_t>& data, nanogui::Vector2i size, EOrientation orientation, int priority) {
+    orientToTopLeft(EPixelFormat format, Channel::Data& data, nanogui::Vector2i size, EOrientation orientation, int priority) {
     if (orientation == EOrientation::TopLeft) {
         co_return size;
     }
@@ -1023,7 +1023,7 @@ Task<nanogui::Vector2i>
     const size_t numSamplesPerPixel = data.size() / numPixels / numBytesPerSample;
     const size_t numBytesPerPixel = numSamplesPerPixel * numBytesPerSample;
 
-    std::vector<uint8_t> reorientedData(data.size());
+    Channel::Data reorientedData(data.size());
     co_await ThreadPool::global().parallelForAsync<int>(
         0,
         size.y(),

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -926,7 +926,7 @@ void Image::updateChannel(string_view channelName, int x, int y, int width, int 
         const auto numPixels = (size_t)width * height;
         const size_t numTextureChannels = numChannelsInPixelFormat(imageTexture.nanoguiTexture->pixel_format());
         const size_t bitsPerSample = bitsPerSampleInComponentFormat(imageTexture.nanoguiTexture->component_format());
-        vector<uint8_t> textureData(numPixels * numTextureChannels * (bitsPerSample / 8));
+        HeapArray<uint8_t> textureData(numPixels * numTextureChannels * (bitsPerSample / 8));
 
         vector<Task<void>> tasks;
         for (size_t i = 0; i < numTextureChannels; ++i) {

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -57,10 +57,7 @@ static const float CROP_MIN_SIZE = 3;
 ImageViewer::ImageViewer(
     const Vector2i& size, const shared_ptr<BackgroundImagesLoader>& imagesLoader, weak_ptr<Ipc> ipc, bool maximize, bool showUi, bool floatBuffer
 ) :
-    nanogui::Screen{size, "tev", true, maximize, false, true, true, floatBuffer},
-    mImagesLoader{imagesLoader},
-    mIpc{ipc},
-    mMaximizedLaunch{maximize} {
+    Screen{size, "tev", true, maximize, false, true, true, floatBuffer}, mImagesLoader{imagesLoader}, mIpc{ipc}, mMaximizedLaunch{maximize} {
 
     // At this point we no longer need the standalone console (if it exists).
     toggleConsole();
@@ -71,17 +68,17 @@ ImageViewer::ImageViewer(
         int monitorCount;
         auto** monitors = glfwGetMonitors(&monitorCount);
         if (monitors && monitorCount > 0) {
-            nanogui::Vector2i monitorMin{numeric_limits<int>::max(), numeric_limits<int>::max()},
+            Vector2i monitorMin{numeric_limits<int>::max(), numeric_limits<int>::max()},
                 monitorMax{numeric_limits<int>::min(), numeric_limits<int>::min()};
 
             for (int i = 0; i < monitorCount; ++i) {
-                nanogui::Vector2i pos, size;
+                Vector2i pos, size;
                 glfwGetMonitorWorkarea(monitors[i], &pos.x(), &pos.y(), &size.x(), &size.y());
                 monitorMin = min(monitorMin, pos);
                 monitorMax = max(monitorMax, pos + size);
             }
 
-            mMaxWindowSize = min(mMaxWindowSize, max(monitorMax - monitorMin, nanogui::Vector2i{1024, 800}));
+            mMaxWindowSize = min(mMaxWindowSize, max(monitorMax - monitorMin, Vector2i{1024, 800}));
         }
     }
 
@@ -580,7 +577,7 @@ ImageViewer::ImageViewer(
         mFooter->set_visible(false);
     }
 
-    set_resize_callback([this](nanogui::Vector2i) { requestLayoutUpdate(); });
+    set_resize_callback([this](Vector2i) { requestLayoutUpdate(); });
     resize_callback_event(m_size.x(), m_size.y()); // Required on some OSs to get up-to-date pixel ratio
 
     selectImage(nullptr);
@@ -604,14 +601,14 @@ bool ImageViewer::resize_event(const Vector2i& size) {
     return Screen::resize_event(size);
 }
 
-bool ImageViewer::mouse_button_event(const nanogui::Vector2i& p, int button, bool down, int modifiers) {
+bool ImageViewer::mouse_button_event(const Vector2i& p, int button, bool down, int modifiers) {
     // Check if the user performed mousedown on an imagebutton so we can mark it as being dragged. This has to occur before
     // Screen::mouse_button_event as the button would absorb the event.
     if (down) {
         if (mImageScrollContainer->contains(p - mSidebarLayout->parent()->position())) {
             auto& buttons = mImageButtonContainer->children();
 
-            nanogui::Vector2i relMousePos = (absolute_position() + p) - mImageButtonContainer->absolute_position();
+            Vector2i relMousePos = (absolute_position() + p) - mImageButtonContainer->absolute_position();
 
             for (size_t i = 0; i < buttons.size(); ++i) {
                 const auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
@@ -664,7 +661,7 @@ bool ImageViewer::mouse_button_event(const nanogui::Vector2i& p, int button, boo
     return true;
 }
 
-bool ImageViewer::mouse_motion_event_f(const nanogui::Vector2f& p, const nanogui::Vector2f& rel, int button, int modifiers) {
+bool ImageViewer::mouse_motion_event_f(const Vector2f& p, const Vector2f& rel, int button, int modifiers) {
     if (Screen::mouse_motion_event_f(p, rel, button, modifiers)) {
         return true;
     }
@@ -729,7 +726,7 @@ bool ImageViewer::mouse_motion_event_f(const nanogui::Vector2f& p, const nanogui
 
         case EMouseDragType::ImageButtonDrag: {
             auto& buttons = mImageButtonContainer->children();
-            nanogui::Vector2i relMousePos = (absolute_position() + Vector2i{p}) - mImageButtonContainer->absolute_position();
+            Vector2i relMousePos = (absolute_position() + Vector2i{p}) - mImageButtonContainer->absolute_position();
 
             TEV_ASSERT(mDraggedImageButtonId < buttons.size(), "Dragged image button id is out of bounds.");
             auto* draggedImgButton = dynamic_cast<ImageButton*>(buttons[mDraggedImageButtonId]);
@@ -740,7 +737,7 @@ bool ImageViewer::mouse_motion_event_f(const nanogui::Vector2f& p, const nanogui
 
                 auto* imgButton = dynamic_cast<ImageButton*>(buttons[i]);
                 if (imgButton->visible() && imgButton->contains(relMousePos)) {
-                    nanogui::Vector2i pos = imgButton->position();
+                    Vector2i pos = imgButton->position();
                     pos.y() += ((int)draggedImgButton->id() - (int)imgButton->id()) * imgButton->size().y();
                     imgButton->set_position(pos);
                     imgButton->mouse_enter_event(relMousePos, false);
@@ -960,7 +957,7 @@ bool ImageViewer::keyboard_event(int key, int scancode, int action, int modifier
                 scaleAmount = -scaleAmount;
             }
 
-            nanogui::Vector2f origin = nanogui::Vector2f{mImageCanvas->position()} + nanogui::Vector2f{mImageCanvas->size()} * 0.5f;
+            Vector2f origin = Vector2f{mImageCanvas->position()} + Vector2f{mImageCanvas->size()} * 0.5f;
 
             mImageCanvas->scale(scaleAmount, {origin.x(), origin.y()});
             return true;
@@ -1192,7 +1189,7 @@ void ImageViewer::draw_contents() {
     }
 
     if (mRequiresLayoutUpdate) {
-        nanogui::Vector2i oldDraggedImageButtonPos{0, 0};
+        Vector2i oldDraggedImageButtonPos{0, 0};
         auto& buttons = mImageButtonContainer->children();
         if (mDragType == EMouseDragType::ImageButtonDrag) {
             oldDraggedImageButtonPos = dynamic_cast<ImageButton*>(buttons[mDraggedImageButtonId])->position();
@@ -1700,7 +1697,7 @@ void ImageViewer::selectGroup(string group) {
     // Ensure the currently active group button is always fully on-screen
     if (activeGroupButton) {
         mGroupButtonContainer->set_position(
-            nanogui::Vector2i{
+            Vector2i{
                 clamp(
                     mGroupButtonContainer->position().x(),
                     -activeGroupButton->position().x(),
@@ -1872,15 +1869,15 @@ void ImageViewer::setDisplayWhiteLevelSetting(EDisplayWhiteLevelSetting setting)
     }
 }
 
-nanogui::Vector2i ImageViewer::sizeToFitImage(const shared_ptr<Image>& image) {
+Vector2i ImageViewer::sizeToFitImage(const shared_ptr<Image>& image) {
     if (!image) {
         return m_size;
     }
 
-    nanogui::Vector2i requiredSize{image->displaySize().x(), image->displaySize().y()};
+    Vector2i requiredSize{image->displaySize().x(), image->displaySize().y()};
 
     // Convert from image pixel coordinates to nanogui coordinates.
-    requiredSize = nanogui::Vector2i{nanogui::Vector2f{requiredSize} / pixel_ratio()};
+    requiredSize = Vector2i{Vector2f{requiredSize} / pixel_ratio()};
 
     // Take into account the size of the UI.
     if (mSidebar->visible()) {
@@ -1894,8 +1891,8 @@ nanogui::Vector2i ImageViewer::sizeToFitImage(const shared_ptr<Image>& image) {
     return requiredSize;
 }
 
-nanogui::Vector2i ImageViewer::sizeToFitAllImages() {
-    nanogui::Vector2i result = m_size;
+Vector2i ImageViewer::sizeToFitAllImages() {
+    Vector2i result = m_size;
     for (const auto& image : mImages) {
         result = max(result, sizeToFitImage(image));
     }
@@ -1903,7 +1900,7 @@ nanogui::Vector2i ImageViewer::sizeToFitAllImages() {
     return result;
 }
 
-void ImageViewer::resizeToFit(nanogui::Vector2i targetSize) {
+void ImageViewer::resizeToFit(Vector2i targetSize) {
     // On Wayland, some information like the current monitor or fractional DPI scaling is not available until some time has passed.
     // Potentially a few frames have been rendered. Hence postpone resizing until we have a valid monitor.
     if (glfwGetPlatform() == GLFW_PLATFORM_WAYLAND && !glfwGetWindowCurrentMonitor(m_glfw_window)) {
@@ -2465,7 +2462,7 @@ void ImageViewer::updateFilter() {
 void ImageViewer::updateLayout() {
     int sidebarWidth = visibleSidebarWidth();
     int footerHeight = visibleFooterHeight();
-    mImageCanvas->set_fixed_size(m_size - nanogui::Vector2i{sidebarWidth, footerHeight});
+    mImageCanvas->set_fixed_size(m_size - Vector2i{sidebarWidth, footerHeight});
     mSidebar->set_fixed_height(m_size.y() - footerHeight);
 
     mVerticalScreenSplit->set_fixed_size(m_size);
@@ -2480,7 +2477,7 @@ void ImageViewer::updateLayout() {
     perform_layout();
 
     mSidebarLayout->set_fixed_width(mSidebarLayout->parent()->width());
-    mHelpButton->set_position(nanogui::Vector2i{mSidebarLayout->fixed_width() - 38, 5});
+    mHelpButton->set_position(Vector2i{mSidebarLayout->fixed_width() - 38, 5});
     mFilter->set_fixed_width(mSidebarLayout->fixed_width() - 50);
     perform_layout();
 
@@ -2504,15 +2501,16 @@ void ImageViewer::updateTitle() {
 
         caption = fmt::format("{} – {} – {}%", mCurrentImage->shortName(), mCurrentGroup, (int)std::round(mImageCanvas->scale() * 100));
 
-        auto rel = mouse_pos() - mImageCanvas->position();
-        vector<float> values = mImageCanvas->getValuesAtNanoPos({rel.x(), rel.y()}, channels);
-        nanogui::Vector2i imageCoords = mImageCanvas->getImageCoords(mCurrentImage.get(), {rel.x(), rel.y()});
+        const auto rel = mouse_pos() - mImageCanvas->position();
+        const vector<float> values = mImageCanvas->getValuesAtNanoPos({rel.x(), rel.y()}, channels);
+        const Vector2i imageCoords = mImageCanvas->getImageCoords(mCurrentImage.get(), {rel.x(), rel.y()});
         TEV_ASSERT(values.size() >= channelTails.size(), "Should obtain a value for every existing channel.");
 
         string valuesString;
         for (size_t i = 0; i < channelTails.size(); ++i) {
             valuesString += fmt::format("{:.2f},", values[i]);
         }
+
         valuesString.pop_back();
         valuesString += " / 0x";
         for (size_t i = 0; i < channelTails.size(); ++i) {

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -2212,7 +2212,7 @@ void ImageViewer::copyImageCanvasToClipboard() const {
         throw std::runtime_error{"No image selected for copy."};
     }
 
-    auto imageSize = mImageCanvas->imageDataSize();
+    const auto imageSize = mImageCanvas->imageDataSize();
     if (imageSize.x() == 0 || imageSize.y() == 0) {
         throw std::runtime_error{"Image canvas has no image data to copy to clipboard."};
     }
@@ -2233,15 +2233,15 @@ void ImageViewer::copyImageCanvasToClipboard() const {
     imageMetadata.blue_shift = 16;
     imageMetadata.alpha_shift = 24;
 
-    auto imageData = mImageCanvas->getLdrImageData(true, std::numeric_limits<int>::max());
+    const auto imageData = mImageCanvas->getLdrImageData(true, std::numeric_limits<int>::max());
     clip::image image(imageData.data(), imageMetadata);
 
     if (!clip::set_image(image)) {
         throw std::runtime_error{"clip::set_image failed."};
     }
 #else
-    auto imageData = mImageCanvas->getLdrImageData(true, std::numeric_limits<int>::max());
-    auto pngImageSaver = make_unique<StbiLdrImageSaver>();
+    const auto imageData = mImageCanvas->getLdrImageData(true, std::numeric_limits<int>::max());
+    const auto pngImageSaver = make_unique<StbiLdrImageSaver>();
 
     stringstream pngData;
     try {

--- a/src/Ipc.cpp
+++ b/src/Ipc.cpp
@@ -109,7 +109,7 @@ void IpcPacket::setUpdateImage(
         throw runtime_error{"UpdateImage IPC packet must have a non-zero channel count."};
     }
 
-    int32_t nChannels = (int32_t)channelDescs.size();
+    const int32_t nChannels = (int32_t)channelDescs.size();
     vector<string> channelNames(nChannels);
     vector<int64_t> channelOffsets(nChannels);
     vector<int64_t> channelStrides(nChannels);
@@ -130,7 +130,7 @@ void IpcPacket::setUpdateImage(
     payload << channelOffsets;
     payload << channelStrides;
 
-    size_t nPixels = width * height;
+    const size_t nPixels = width * height;
 
     size_t stridedImageDataSize = 0;
     for (int32_t c = 0; c < nChannels; ++c) {
@@ -196,7 +196,7 @@ IpcPacketOpenImage IpcPacket::interpretAsOpenImage() const {
         return result;
     }
 
-    size_t colonPos = imageString.find_last_of(":");
+    const size_t colonPos = imageString.find_last_of(":");
     if (colonPos == string::npos ||
         // windows path of the form X:/* or X:\*
         (colonPos == 1 && imageString.length() >= 3 && (imageString[2] == '\\' || imageString[2] == '/'))) {
@@ -266,7 +266,7 @@ IpcPacketUpdateImage IpcPacket::interpretAsUpdateImage() const {
     result.channelStrides.resize(result.nChannels, 1);
 
     payload >> result.x >> result.y >> result.width >> result.height;
-    size_t nPixels = (size_t)result.width * result.height;
+    const size_t nPixels = (size_t)result.width * result.height;
 
     if (type >= EType::UpdateImageV3) {
         // custom offset/stride support

--- a/src/imageio/ClipboardImageLoader.cpp
+++ b/src/imageio/ClipboardImageLoader.cpp
@@ -64,7 +64,7 @@ Task<vector<ImageData>> ClipboardImageLoader::load(istream& iStream, const fs::p
     // Clipboard images are always 32 bit RGBA. Can be comfortably represented as F16.
     resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16);
 
-    vector<char> data(numBytes);
+    HeapArray<char> data(numBytes);
     iStream.read(reinterpret_cast<char*>(data.data()), numBytes);
     if (iStream.gcount() < (streamsize)numBytes) {
         throw ImageLoadError{fmt::format("Insufficient bytes to read image data ({} vs {}).", iStream.gcount(), numBytes)};

--- a/src/imageio/ClipboardImageLoader.cpp
+++ b/src/imageio/ClipboardImageLoader.cpp
@@ -62,7 +62,7 @@ Task<vector<ImageData>> ClipboardImageLoader::load(istream& iStream, const fs::p
     ImageData& resultData = result.front();
 
     // Clipboard images are always 32 bit RGBA. Can be comfortably represented as F16.
-    resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16);
+    resultData.channels = co_await makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
 
     HeapArray<char> data(numBytes);
     iStream.read(reinterpret_cast<char*>(data.data()), numBytes);

--- a/src/imageio/DdsImageLoader.cpp
+++ b/src/imageio/DdsImageLoader.cpp
@@ -153,14 +153,15 @@ static int getDxgiChannelCount(DXGI_FORMAT fmt) {
 
 Task<vector<ImageData>> DdsImageLoader::load(istream& iStream, const fs::path&, string_view, int priority, bool) const {
     iStream.seekg(0, iStream.end);
-    size_t dataSize = iStream.tellg();
+    const size_t dataSize = iStream.tellg();
     if (dataSize < 4) {
         throw FormatNotSupported{"File is too small."};
     }
 
     iStream.clear();
     iStream.seekg(0);
-    vector<char> data(dataSize);
+
+    HeapArray<char> data{dataSize};
     iStream.read(data.data(), 4);
     if (data[0] != 'D' || data[1] != 'D' || data[2] != 'S' || data[3] != ' ') {
         throw FormatNotSupported{"File is not a DDS file."};

--- a/src/imageio/DdsImageLoader.cpp
+++ b/src/imageio/DdsImageLoader.cpp
@@ -215,8 +215,9 @@ Task<vector<ImageData>> DdsImageLoader::load(istream& iStream, const fs::path&, 
     vector<ImageData> result(1);
     ImageData& resultData = result.front();
 
-    resultData.channels =
-        makeRgbaInterleavedChannels(numChannels, DirectX::HasAlpha(metadata.format), size, EPixelFormat::F32, EPixelFormat::F32);
+    resultData.channels = co_await makeRgbaInterleavedChannels(
+        numChannels, DirectX::HasAlpha(metadata.format), size, EPixelFormat::F32, EPixelFormat::F32, "", priority
+    );
 
     const auto numPixels = (size_t)size.x() * size.y();
     if (numPixels == 0) {

--- a/src/imageio/EmptyImageLoader.cpp
+++ b/src/imageio/EmptyImageLoader.cpp
@@ -49,7 +49,7 @@ Task<vector<ImageData>> EmptyImageLoader::load(istream& iStream, const fs::path&
     for (int i = 0; i < nChannels; ++i) {
         // The following lines decode strings by prefix length. The reason for using sthis encoding is to allow arbitrary characters,
         // including whitespaces, in the channel names.
-        std::vector<char> channelNameData;
+        vector<char> channelNameData;
         int length;
         iStream >> length;
         channelNameData.resize(length + 1, 0);

--- a/src/imageio/Exif.cpp
+++ b/src/imageio/Exif.cpp
@@ -23,7 +23,6 @@
 #include <libexif/exif-data.h>
 
 #include <span>
-#include <vector>
 
 using namespace std;
 
@@ -81,11 +80,11 @@ Exif::Exif(span<const uint8_t> exifData, bool autoPrependFourcc) : Exif() {
     ScopeGuard guard{[this]() { reset(); }};
 
     // If data doesn't already start with fourcc, prepend
-    vector<uint8_t> newExifData;
+    HeapArray<uint8_t> newExifData;
     if (autoPrependFourcc && (exifData.size() < 6 || memcmp(exifData.data(), Exif::FOURCC.data(), 6) != 0)) {
-        newExifData.reserve(exifData.size() + FOURCC.size());
-        newExifData.insert(newExifData.end(), FOURCC.begin(), FOURCC.end());
-        newExifData.insert(newExifData.end(), exifData.begin(), exifData.end());
+        newExifData = HeapArray<uint8_t>{exifData.size() + FOURCC.size()};
+        memcpy(newExifData.data(), FOURCC.data(), FOURCC.size());
+        memcpy(newExifData.data() + FOURCC.size(), exifData.data(), exifData.size());
         exifData = newExifData;
     }
 

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -369,7 +369,7 @@ public:
     RawChannel(size_t partId, string_view name, string_view imfName, Imf::Channel imfChannel, const Vector2i& size) :
         mPartId{partId}, mName{name}, mImfName{imfName}, mImfChannel{imfChannel}, mSize{size} {}
 
-    void resize() { mData.resize((size_t)mSize.x() * mSize.y() * bytesPerPixel()); }
+    void resize() { mData = HeapArray<char>{(size_t)mSize.x() * mSize.y() * bytesPerPixel()}; }
 
     void registerWith(Imf::FrameBuffer& frameBuffer, const Imath::Box2i& dw) {
         int width = dw.max.x - dw.min.x + 1;
@@ -438,7 +438,7 @@ private:
     string mImfName;
     Imf::Channel mImfChannel;
     Vector2i mSize;
-    vector<char> mData;
+    HeapArray<char> mData;
 };
 
 Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const fs::path& path, string_view channelSelector, int priority, bool) const {

--- a/src/imageio/GainMap.cpp
+++ b/src/imageio/GainMap.cpp
@@ -26,7 +26,7 @@ using namespace std;
 namespace tev {
 
 Task<void> applyAppleGainMap(ImageData& image, const ImageData& gainMap, int priority, const AppleMakerNote* amn) {
-    auto size = image.channels[0].size();
+    const auto size = image.channels[0].size();
     TEV_ASSERT(size == gainMap.channels[0].size(), "Image and gain map must have the same size.");
 
     // Apply gain map per https://developer.apple.com/documentation/appkit/applying-apple-hdr-effect-to-your-photos
@@ -55,7 +55,7 @@ Task<void> applyAppleGainMap(ImageData& image, const ImageData& gainMap, int pri
         }
     }
 
-    float headroom = pow(2.0f, std::max(stops, 0.0f));
+    const float headroom = pow(2.0f, std::max(stops, 0.0f));
     tlog::debug() << fmt::format("Derived gain map headroom {} from maker note entries #33={} and #48={}.", headroom, maker33, maker48);
 
     const int numImageChannels = (int)image.channels.size();

--- a/src/imageio/HeifImageLoader.cpp
+++ b/src/imageio/HeifImageLoader.cpp
@@ -186,7 +186,9 @@ Task<vector<ImageData>>
         if (numChannels == 1) {
             resultData.channels.emplace_back(fmt::format("{}L", namePrefix), size, EPixelFormat::F32, EPixelFormat::F16);
         } else {
-            resultData.channels = makeRgbaInterleavedChannels(numChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16);
+            resultData.channels = co_await makeRgbaInterleavedChannels(
+                numChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, namePrefix, priority
+            );
         }
 
         const int numInterleavedChannels = numChannels == 1 ? 1 : 4;
@@ -510,8 +512,8 @@ Task<vector<ImageData>>
         if (numChannels == 1) {
             scaledResultData.channels.emplace_back(fmt::format("{}L", namePrefix), targetSize, EPixelFormat::F32, EPixelFormat::F16);
         } else {
-            scaledResultData.channels = makeRgbaInterleavedChannels(
-                numChannels, resultData.hasChannel(fmt::format("{}A", namePrefix)), targetSize, EPixelFormat::F32, EPixelFormat::F16, namePrefix
+            scaledResultData.channels = co_await makeRgbaInterleavedChannels(
+                numChannels, resultData.hasChannel(fmt::format("{}A", namePrefix)), targetSize, EPixelFormat::F32, EPixelFormat::F16, namePrefix, priority
             );
         }
 

--- a/src/imageio/ImageLoader.cpp
+++ b/src/imageio/ImageLoader.cpp
@@ -127,7 +127,7 @@ vector<Channel> ImageLoader::makeRgbaInterleavedChannels(
 
     const size_t numPixels = (size_t)size.x() * size.y();
     const size_t numBytesPerSample = nBytes(format);
-    shared_ptr<vector<uint8_t>> data = make_shared<vector<uint8_t>>(numBytesPerSample * numPixels * 4);
+    auto data = make_shared<Channel::Data>(numBytesPerSample * numPixels * 4);
 
     // Initialize pattern [0,0,0,1] efficiently using multi-byte writes
     auto init = [numPixels](auto* ptr) {

--- a/src/imageio/JpegTurboImageLoader.cpp
+++ b/src/imageio/JpegTurboImageLoader.cpp
@@ -34,11 +34,11 @@ namespace {
 // Taken from jpegdecoderhelper in libultrahdr per their Apache 2.0 license and shortened.
 // https://github.com/google/libultrahdr/blob/6db3a83ee2b1f79850f3f597172289808dc6a331/lib/src/jpegdecoderhelper.cpp#L125
 void jpeg_extract_marker_payload(
-    const j_decompress_ptr cinfo, const uint32_t markerCode, span<const uint8_t> ns, std::vector<uint8_t>& destination
+    const j_decompress_ptr cinfo, const uint32_t markerCode, span<const uint8_t> ns, HeapArray<uint8_t>& destination
 ) {
     for (jpeg_marker_struct* marker = cinfo->marker_list; marker; marker = marker->next) {
         if (marker->marker == markerCode && marker->data_length > ns.size() && !memcmp(marker->data, ns.data(), ns.size())) {
-            destination.resize(marker->data_length);
+            destination = HeapArray<uint8_t>{marker->data_length};
             memcpy(static_cast<void*>(destination.data()), marker->data, marker->data_length);
             return;
         }
@@ -88,10 +88,10 @@ Task<vector<ImageData>> JpegTurboImageLoader::load(istream& iStream, const fs::p
         throw ImageLoadError{"Failed to read JPEG header."};
     }
 
-    vector<uint8_t> exifData;
+    HeapArray<uint8_t> exifData;
     jpeg_extract_marker_payload(&cinfo, JPEG_APP0 + 1, Exif::FOURCC, exifData);
 
-    vector<uint8_t> xmpData;
+    HeapArray<uint8_t> xmpData;
     static constexpr string_view xmpNs = "http://ns.adobe.com/xap/1.0/";
     jpeg_extract_marker_payload(&cinfo, JPEG_APP0 + 1, {(const uint8_t*)xmpNs.data(), xmpNs.size()}, xmpData);
 
@@ -133,7 +133,7 @@ Task<vector<ImageData>> JpegTurboImageLoader::load(istream& iStream, const fs::p
     Channel::Data imageData(numPixels * numBytesPerPixel);
 
     // Create row pointers for libjpeg and then read image
-    vector<JSAMPROW> rowPointers(size.y());
+    HeapArray<JSAMPROW> rowPointers(size.y());
     for (int y = 0; y < size.y(); ++y) {
         rowPointers[y] = &imageData[y * size.x() * numBytesPerPixel];
     }
@@ -150,7 +150,7 @@ Task<vector<ImageData>> JpegTurboImageLoader::load(istream& iStream, const fs::p
     EOrientation orientation = EOrientation::None;
 
     // Try to extract EXIF data for correct orientation
-    if (!exifData.empty()) {
+    if (exifData) {
         tlog::debug() << fmt::format("Found EXIF data of size {} bytes", exifData.size());
 
         try {
@@ -199,7 +199,7 @@ Task<vector<ImageData>> JpegTurboImageLoader::load(istream& iStream, const fs::p
     // and convert it to linear space via inverse sRGB transfer function.
     if (iccProfile) {
         try {
-            vector<float> floatData(imageData.size());
+            HeapArray<float> floatData(imageData.size());
             co_await toFloat32(imageData.data(), numColorChannels, floatData.data(), numColorChannels, size, false, priority);
 
             const auto profile = ColorProfile::fromIcc(iccProfile, iccProfileSize);

--- a/src/imageio/JpegTurboImageLoader.cpp
+++ b/src/imageio/JpegTurboImageLoader.cpp
@@ -33,9 +33,7 @@ namespace tev {
 namespace {
 // Taken from jpegdecoderhelper in libultrahdr per their Apache 2.0 license and shortened.
 // https://github.com/google/libultrahdr/blob/6db3a83ee2b1f79850f3f597172289808dc6a331/lib/src/jpegdecoderhelper.cpp#L125
-void jpeg_extract_marker_payload(
-    const j_decompress_ptr cinfo, const uint32_t markerCode, span<const uint8_t> ns, HeapArray<uint8_t>& destination
-) {
+void jpeg_extract_marker_payload(const j_decompress_ptr cinfo, const uint32_t markerCode, span<const uint8_t> ns, HeapArray<uint8_t>& destination) {
     for (jpeg_marker_struct* marker = cinfo->marker_list; marker; marker = marker->next) {
         if (marker->marker == markerCode && marker->data_length > ns.size() && !memcmp(marker->data, ns.data(), ns.size())) {
             destination = HeapArray<uint8_t>{marker->data_length};
@@ -190,7 +188,8 @@ Task<vector<ImageData>> JpegTurboImageLoader::load(istream& iStream, const fs::p
 
     // This JPEG loader is at most 8 bits per channel (technically, JPEG can hold more, but we don't support that here). Thus easily fits
     // into F16.
-    resultData.channels = makeRgbaInterleavedChannels(numColorChannels, false, size, EPixelFormat::F32, EPixelFormat::F16);
+    resultData.channels =
+        co_await makeRgbaInterleavedChannels(numColorChannels, false, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
 
     // Since JPEG always has no alpha channel, we default to 1, where premultiplied and straight are equivalent.
     resultData.hasPremultipliedAlpha = true;

--- a/src/imageio/JpegTurboImageLoader.cpp
+++ b/src/imageio/JpegTurboImageLoader.cpp
@@ -130,7 +130,7 @@ Task<vector<ImageData>> JpegTurboImageLoader::load(istream& iStream, const fs::p
     // Allocate memory for image data
     auto numPixels = static_cast<size_t>(size.x()) * size.y();
     auto numBytesPerPixel = numColorChannels;
-    vector<uint8_t> imageData(numPixels * numBytesPerPixel);
+    Channel::Data imageData(numPixels * numBytesPerPixel);
 
     // Create row pointers for libjpeg and then read image
     vector<JSAMPROW> rowPointers(size.y());

--- a/src/imageio/JxlImageLoader.cpp
+++ b/src/imageio/JxlImageLoader.cpp
@@ -414,8 +414,14 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
 
                 Vector2i size{(int)info.xsize, (int)info.ysize};
 
-                data.channels = makeRgbaInterleavedChannels(
-                    numColorChannels, info.alpha_bits, size, EPixelFormat::F32, info.bits_per_sample > 16 ? EPixelFormat::F32 : EPixelFormat::F16
+                data.channels = co_await makeRgbaInterleavedChannels(
+                    numColorChannels,
+                    info.alpha_bits,
+                    size,
+                    EPixelFormat::F32,
+                    info.bits_per_sample > 16 ? EPixelFormat::F32 : EPixelFormat::F16,
+                    "",
+                    priority
                 );
 
                 data.hasPremultipliedAlpha = info.alpha_premultiplied;

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -332,7 +332,7 @@ Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, 
         const bool hasAlpha = numChannels == 2 || numChannels == 4;
         resultData.channels = numInterleavedChannels == 1 ?
             makeNChannels(numChannels, size, EPixelFormat::F32, desiredFormat) :
-            makeRgbaInterleavedChannels(numChannels, hasAlpha, size, EPixelFormat::F32, desiredFormat);
+            co_await makeRgbaInterleavedChannels(numChannels, hasAlpha, size, EPixelFormat::F32, desiredFormat, "", priority);
 
         const auto numSamplesPerRow = (size_t)size.x() * numChannels;
         const auto numSamples = numSamplesPerRow * size.y();

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -329,16 +329,16 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
     const auto numSamples = numPixels * numChannels;
 
     // Allocate enough memory for each frame. By making the data as big as the whole canvas, all frames should fit.
-    vector<png_byte> pngData(numPixels * numBytesPerPixel);
-    vector<float> frameData(numSamples);
-    vector<float> iccTmpFloatData;
+    HeapArray<png_byte> pngData(numPixels * numBytesPerPixel);
+    HeapArray<float> frameData(numSamples);
+    HeapArray<float> iccTmpFloatData;
     if (iccProfileData) {
         // If we have an ICC profile, we need to convert the frame data to float first.
-        iccTmpFloatData.resize(numSamples);
+        iccTmpFloatData = HeapArray<float>(numSamples);
     }
 
     // Png wants to read into a 2D array of pointers to rows, so we need to create that as well
-    vector<png_bytep> rowPointers(height);
+    HeapArray<png_bytep> rowPointers(height);
 
     vector<ImageData> result;
 
@@ -397,9 +397,9 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                 frameData.size() * sizeof(float)
             );
 
-            frameData.resize(numFrameSamples);
+            frameData = HeapArray<float>(numFrameSamples);
             if (iccProfileData) {
-                iccTmpFloatData.resize(numFrameSamples);
+                iccTmpFloatData = HeapArray<float>(numFrameSamples);
             }
         }
 

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -350,7 +350,8 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
 
         // PNG images have a fixed point representation of up to 16 bits per channel in TF space. FP16 is perfectly adequate to represent
         // such values after conversion to linear space.
-        resultData.channels = makeRgbaInterleavedChannels(numChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16);
+        resultData.channels =
+            co_await makeRgbaInterleavedChannels(numChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
         resultData.orientation = orientation;
         resultData.hasPremultipliedAlpha = false;
 

--- a/src/imageio/QoiImageLoader.cpp
+++ b/src/imageio/QoiImageLoader.cpp
@@ -69,7 +69,7 @@ Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, 
     ImageData& resultData = result.front();
 
     // QOI images are 8 bit per pixel which easily fits into F16.
-    resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16);
+    resultData.channels = co_await makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
     resultData.hasPremultipliedAlpha = false;
 
     if (desc.colorspace == QOI_LINEAR) {

--- a/src/imageio/QoiImageLoader.cpp
+++ b/src/imageio/QoiImageLoader.cpp
@@ -39,9 +39,10 @@ Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, 
 
     iStream.clear();
     iStream.seekg(0, iStream.end);
-    size_t dataSize = iStream.tellg();
+    const auto dataSize = iStream.tellg();
     iStream.seekg(0, iStream.beg);
-    vector<char> data(dataSize);
+
+    HeapArray<char> data(dataSize);
     iStream.read(data.data(), dataSize);
 
     qoi_desc desc;

--- a/src/imageio/RawImageLoader.cpp
+++ b/src/imageio/RawImageLoader.cpp
@@ -281,7 +281,7 @@ Task<vector<ImageData>> RawImageLoader::load(istream& iStream, const fs::path& p
     ImageData& resultData = result.front();
 
     const int numChannels = 3;
-    resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, orientedSize, EPixelFormat::F32, EPixelFormat::F16);
+    resultData.channels = co_await makeRgbaInterleavedChannels(numChannels, numChannels == 4, orientedSize, EPixelFormat::F32, EPixelFormat::F16, "", priority);
     resultData.hasPremultipliedAlpha = false;
     // resultData.displayWindow = displayWindow; // This seems to be wrong
 

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -86,8 +86,8 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
         ImageData& resultData = result[frameIdx];
 
         // Unless the image is a .hdr file, it's 8 bits per channel, so we can comfortably fit it into F16.
-        resultData.channels = makeRgbaInterleavedChannels(
-            numChannels, numChannels == 4, size, EPixelFormat::F32, isHdr ? EPixelFormat::F32 : EPixelFormat::F16
+        resultData.channels = co_await makeRgbaInterleavedChannels(
+            numChannels, numChannels == 4, size, EPixelFormat::F32, isHdr ? EPixelFormat::F32 : EPixelFormat::F16, "", priority
         );
         resultData.hasPremultipliedAlpha = false;
         if (numFrames > 1) {

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -1297,7 +1297,7 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
         )};
     }
 
-    vector<uint8_t> tileData(tile.size * tile.count);
+    HeapArray<uint8_t> tileData(tile.size * tile.count);
 
     const size_t numTilesPerPlane = tile.count / numPlanes;
     // We'll unpack the bits into 32-bit or 64-bit unsigned integers first, then convert to float. This simplifies the bit unpacking
@@ -1305,7 +1305,7 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
 
     const size_t unpackedTileRowSamples = tile.width * samplesPerPixel / numPlanes;
     const size_t unpackedTileSize = tile.height * unpackedTileRowSamples * unpackedBitsPerSample / 8;
-    vector<uint8_t> unpackedTile(unpackedTileSize * tile.count);
+    HeapArray<uint8_t> unpackedTile(unpackedTileSize * tile.count);
 
     const bool handleSign = sampleFormat == SAMPLEFORMAT_INT;
 
@@ -1313,7 +1313,7 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
 
     // Read tiled/striped data. Unfortunately, libtiff doesn't support reading all tiles/strips in parallel, so we have to do that
     // sequentially.
-    vector<uint8_t> imageData((size_t)size.x() * size.y() * samplesPerPixel * unpackedBitsPerSample / 8);
+    HeapArray<uint8_t> imageData((size_t)size.x() * size.y() * samplesPerPixel * unpackedBitsPerSample / 8);
     for (size_t i = 0; i < tile.count; ++i) {
         uint8_t* const td = tileData.data() + tile.size * i;
 
@@ -1437,7 +1437,7 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
     }
 
     // The RGBA channels might need color space conversion: store them in a staging buffer first and then try ICC conversion
-    vector<float> floatRgbaData(size.x() * (size_t)size.y() * numRgbaChannels);
+    HeapArray<float> floatRgbaData(size.x() * (size_t)size.y() * numRgbaChannels);
     co_await tiffDataToFloat32<false>(
         kind,
         palette,
@@ -1533,7 +1533,7 @@ Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& 
     const size_t fileSize = iStream.tellg();
     iStream.seekg(0, ios::beg);
 
-    vector<uint8_t> buffer(fileSize + sizeof(Exif::FOURCC));
+    HeapArray<uint8_t> buffer(fileSize + sizeof(Exif::FOURCC));
     copy(Exif::FOURCC.begin(), Exif::FOURCC.end(), buffer.data());
     iStream.read((char*)buffer.data() + sizeof(Exif::FOURCC), fileSize);
 

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -1200,7 +1200,9 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, const int pri
     // Local scope to prevent use-after-move
     {
         const auto desiredPixelFormat = bitsPerSample > 16 ? EPixelFormat::F32 : EPixelFormat::F16;
-        auto rgbaChannels = ImageLoader::makeRgbaInterleavedChannels(numRgbaChannels, hasAlpha, size, EPixelFormat::F32, desiredPixelFormat);
+        auto rgbaChannels = co_await ImageLoader::makeRgbaInterleavedChannels(
+            numRgbaChannels, hasAlpha, size, EPixelFormat::F32, desiredPixelFormat, "", priority
+        );
         auto extraChannels = ImageLoader::makeNChannels(numNonRgbaChannels, size, EPixelFormat::F32, desiredPixelFormat);
 
         resultData.channels.insert(resultData.channels.end(), make_move_iterator(rgbaChannels.begin()), make_move_iterator(rgbaChannels.end()));

--- a/src/imageio/UltraHdrImageLoader.cpp
+++ b/src/imageio/UltraHdrImageLoader.cpp
@@ -71,7 +71,7 @@ Task<vector<ImageData>> UltraHdrImageLoader::load(istream& iStream, const fs::pa
     }
 
     iStream.seekg(0, ios_base::end);
-    int64_t fileSize = iStream.tellg();
+    const int64_t fileSize = iStream.tellg();
     iStream.clear();
     iStream.seekg(0);
 
@@ -79,14 +79,15 @@ Task<vector<ImageData>> UltraHdrImageLoader::load(istream& iStream, const fs::pa
         throw FormatNotSupported{"File is too small."};
     }
 
-    vector<char> buffer(fileSize);
+    HeapArray<char> buffer(fileSize);
     iStream.read(buffer.data(), 3);
 
     if ((uint8_t)buffer[0] != 0xFF || (uint8_t)buffer[1] != 0xD8 || (uint8_t)buffer[2] != 0xFF) {
         throw FormatNotSupported{"File is not a JPEG."};
     }
 
-    iStream.read(buffer.data() + 3, fileSize - 3);
+    const int64_t remainingSize = fileSize - 3;
+    iStream.read(buffer.data() + 3, remainingSize);
 
     auto decoder = uhdr_create_decoder();
     if (!decoder) {

--- a/src/imageio/UltraHdrImageLoader.cpp
+++ b/src/imageio/UltraHdrImageLoader.cpp
@@ -152,7 +152,7 @@ Task<vector<ImageData>> UltraHdrImageLoader::load(istream& iStream, const fs::pa
     const int numChannels = 4;
 
     // Ultra HDR gives us at most F16 data. See https://github.com/google/libultrahdr?tab=readme-ov-file#decoding-api-outline
-    imageData.channels = makeRgbaInterleavedChannels(numChannels, true, size, EPixelFormat::F32, EPixelFormat::F16);
+    imageData.channels = co_await makeRgbaInterleavedChannels(numChannels, true, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
 
     // JPEG always has alpha == 1 in which case there's no distinction between premultiplied and straight alpha
     imageData.hasPremultipliedAlpha = true;
@@ -171,7 +171,7 @@ Task<vector<ImageData>> UltraHdrImageLoader::load(istream& iStream, const fs::pa
     if (iccProfile && iccProfile->data && iccProfile->data_sz > 14) {
         tlog::warning() << "Found ICC color profile. Attempting to apply... " << iccProfile->data_sz;
 
-        auto channels = makeRgbaInterleavedChannels(numChannels, true, size, EPixelFormat::F32, EPixelFormat::F16);
+        auto channels = co_await makeRgbaInterleavedChannels(numChannels, true, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
         try {
             const auto profile = ColorProfile::fromIcc((uint8_t*)iccProfile->data + 14, iccProfile->data_sz - 14);
             co_await toLinearSrgbPremul(

--- a/src/imageio/WebpImageLoader.cpp
+++ b/src/imageio/WebpImageLoader.cpp
@@ -171,7 +171,7 @@ Task<vector<ImageData>> WebpImageLoader::load(istream& iStream, const fs::path&,
             resultData.attributes = attributes;
 
             // WebP is always 8bit per channel, so we can comfortably use F16 for the decoded data.
-            resultData.channels = makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16);
+            resultData.channels = co_await makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
             resultData.hasPremultipliedAlpha = false;
             resultData.partName = fmt::format("frames.{}", frameIdx);
 


### PR DESCRIPTION
Until now, **tev** made liberal use of `std::vector`-based buffers for image data. However, these buffers are unnecessarily zero-initialized (and, to make things worse, sequentially on a single thread). With all other image operations in **tev** being multi-threaded, the simple act of single-threaded zero initialization can be a measurable overhead on systems with lots of threads (e.g. modern threadrippers) when loading large images.

This PR replaces uses of `std::vector` for image data with a lightweight custom heap array type that leaves allocated data uninitialized.