### PR TITLE
Faster thread pool with large thread counts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -101,6 +101,12 @@
 [submodule "dependencies/xmp"]
 	path = dependencies/xmp
 	url = https://github.com/tom94/xmp
+	shallow = true
 [submodule "dependencies/libexpat"]
 	path = dependencies/libexpat
 	url = https://github.com/libexpat/libexpat
+	shallow = true
+[submodule "dependencies/concurrentqueue"]
+	path = dependencies/concurrentqueue
+	url = https://github.com/cameron314/concurrentqueue
+	shallow = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ endif()
 target_include_directories(tev PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     # Header-only dependencies whose include path cannot be inherited from link targets
+    ${CMAKE_CURRENT_SOURCE_DIR}/dependencies
     ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/args
     ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/fmt/include
     ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/qoi

--- a/include/tev/HelpWindow.h
+++ b/include/tev/HelpWindow.h
@@ -43,6 +43,7 @@ private:
     std::function<void()> mCloseCallback;
     nanogui::TabWidget* mTabWidget = nullptr;
     nanogui::VScrollPanel* mScrollPanel = nullptr;
+    nanogui::VScrollPanel* mAboutScrollPanel = nullptr;
 };
 
 } // namespace tev

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -34,6 +34,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <queue>
 #include <span>
 #include <string>
 #include <vector>

--- a/include/tev/ThreadPool.h
+++ b/include/tev/ThreadPool.h
@@ -69,9 +69,9 @@ public:
         return res;
     }
 
-    // auto enqueueStopToken() {
-    //     return enqueueTask([]() {}, std::numeric_limits<int>::max(), true);
-    // }
+    auto enqueueStopToken() {
+        return enqueueTask([]() {}, std::numeric_limits<int>::max(), true);
+    }
 
     inline auto enqueueCoroutine(int priority) noexcept {
         class Awaiter {
@@ -156,6 +156,8 @@ public:
     }
 
     size_t numThreads() const { return mNumThreads; }
+
+    std::recursive_mutex& taskQueueMutex() { return mTaskQueueMutex; }
 
 private:
     bool mShuttingDown = false;

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -66,10 +66,13 @@ Task<void> toFloat32(
         numSamplesPerRowOut = numSamplesPerPixelOut * size.x();
     }
 
-    size_t numSamplesPerPixel = std::min(numSamplesPerPixelIn, numSamplesPerPixelOut);
+    const size_t numSamplesPerPixel = std::min(numSamplesPerPixelIn, numSamplesPerPixelOut);
+    const size_t numPixels = (size_t)size.x() * size.y();
+
     co_await ThreadPool::global().parallelForAsync<int>(
         0,
         size.y(),
+        numPixels * numSamplesPerPixel,
         [&](int y) {
             size_t rowIdxIn = y * numSamplesPerRowIn;
             size_t rowIdxOut = y * numSamplesPerRowOut;

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -92,6 +92,7 @@ Task<void> Channel::divideByAsync(const Channel& other, int priority) {
     co_await ThreadPool::global().parallelForAsync<size_t>(
         0,
         other.numPixels(),
+        other.numPixels(),
         [&](size_t i) {
             if (other.at(i) != 0) {
                 setAt(i, at(i) / other.at(i));
@@ -104,7 +105,9 @@ Task<void> Channel::divideByAsync(const Channel& other, int priority) {
 }
 
 Task<void> Channel::multiplyWithAsync(const Channel& other, int priority) {
-    co_await ThreadPool::global().parallelForAsync<size_t>(0, other.numPixels(), [&](size_t i) { setAt(i, at(i) * other.at(i)); }, priority);
+    co_await ThreadPool::global().parallelForAsync<size_t>(
+        0, other.numPixels(), other.numPixels(), [&](size_t i) { setAt(i, at(i) * other.at(i)); }, priority
+    );
 }
 
 void Channel::updateTile(int x, int y, int width, int height, span<const float> newData) {

--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -55,11 +55,13 @@ HelpWindow::HelpWindow(Widget* parent, weak_ptr<Ipc> weakIpc, function<void()> c
     closeButton->set_callback(mCloseCallback);
 
     static const int WINDOW_WIDTH = 640;
+    static const int WINDOW_HEIGHT = 640;
 
     set_layout(new GroupLayout{});
     set_fixed_width(WINDOW_WIDTH);
 
     mTabWidget = new TabWidget{this};
+    mTabWidget->set_fixed_height(WINDOW_HEIGHT);
 
     // Keybindings tab
     Widget* tmp = new Widget(mTabWidget);
@@ -194,10 +196,13 @@ HelpWindow::HelpWindow(Widget* parent, weak_ptr<Ipc> weakIpc, function<void()> c
     }
 
     // About tab
-    Widget* about = new Widget(mTabWidget);
+    tmp = new Widget(mTabWidget);
+    mAboutScrollPanel = new VScrollPanel{tmp};
+    mTabWidget->append_tab("About", tmp);
+
+    Widget* about = new Widget(mAboutScrollPanel);
     about->set_layout(new GroupLayout{});
-    mTabWidget->append_tab("About", about);
-    about->set_layout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 0, 0});
+    // about->set_layout(new BoxLayout{Orientation::Vertical, Alignment::Fill, 0, 0});
 
     auto addLibrary = [](Widget* current, string name, string desc) {
         auto row = new Widget{current};
@@ -227,12 +232,19 @@ HelpWindow::HelpWindow(Widget* parent, weak_ptr<Ipc> weakIpc, function<void()> c
     addLibrary(about, "aom", "AV1 video codec library");
 #endif
     addLibrary(about, "clip", "Cross-platform clipboard library");
+    addLibrary(about, "concurrentqueue", "Cross-platform lightweight semaphore");
+#ifdef _WIN32
+    addLibrary(about, "DirectXTex", "DirectX texture processing library");
+#endif
     addLibrary(about, "{fmt}", "Fast & safe formatting library");
     addLibrary(about, "Glad", "Multi-language GL loader-generator");
     addLibrary(about, "GLFW", "OpenGL desktop development library");
 #ifdef TEV_SUPPORT_HEIC
     addLibrary(about, "libde265", "Open h.265 video codec library");
 #endif
+    addLibrary(about, "libdeflate", "DEFLATE/zlib/gzip compression library");
+    addLibrary(about, "libexif", "EXIF metadata parsing library");
+    addLibrary(about, "libexpat", "XML parsing library");
 #ifdef TEV_SUPPORT_JXL
     addLibrary(about, "libjpeg-turbo", "Fast JPEG image format library");
     addLibrary(about, "libjxl", "JPEG XL image format library");
@@ -249,14 +261,18 @@ HelpWindow::HelpWindow(Widget* parent, weak_ptr<Ipc> weakIpc, function<void()> c
     addLibrary(about, "NanoGUI", "Small GUI library");
     addLibrary(about, "NanoVG", "Small vector graphics library");
     addLibrary(about, "OpenEXR", "EXR image file format");
-    addLibrary(about, "qoi", "File format for fast, lossless image compression");
+    addLibrary(about, "qoi", "QOI image format library");
     addLibrary(about, "stb_image(_write)", "Single-header library for loading and writing images");
     addLibrary(about, "tinylogger", "Minimal pretty-logging library");
     addLibrary(about, "UTF8-CPP", "Lightweight UTF-8 string manipulation library");
+    addLibrary(about, "XMP-Toolkit-SDK", "XMP metadata parsing library");
+    addLibrary(about, "zlib", "zlib compression library");
 
     // Make the keybindings page as big as is needed to fit the about tab
     perform_layout(screen()->nvg_context());
-    mScrollPanel->set_fixed_height(about->height() + 12);
+    mAboutScrollPanel->set_fixed_height(WINDOW_HEIGHT - 30);
+    mAboutScrollPanel->set_fixed_width(WINDOW_WIDTH - 40);
+    mScrollPanel->set_fixed_height(WINDOW_HEIGHT - 30);
     mScrollPanel->set_fixed_width(WINDOW_WIDTH - 40);
 
     mTabWidget->set_selected_id(0);

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -672,6 +672,7 @@ HeapArray<float> ImageCanvas::getHdrImageData(bool divideAlpha, int priority) co
     ThreadPool::global().parallelFor(
         imageRegion.min.y(),
         imageRegion.max.y(),
+        numPixels * 4,
         [nChannelsToSave, &channels, &result, &imageRegion](int y) {
             int yresult = y - imageRegion.min.y();
             for (int x = imageRegion.min.x(); x < imageRegion.max.x(); ++x) {
@@ -690,6 +691,7 @@ HeapArray<float> ImageCanvas::getHdrImageData(bool divideAlpha, int priority) co
         ThreadPool::global().parallelFor(
             (size_t)0,
             numPixels,
+            numPixels * 4,
             [&result](size_t j) {
                 float alpha = result[j * 4 + 3];
                 float factor = alpha == 0 ? 0 : 1 / alpha;
@@ -712,6 +714,7 @@ HeapArray<char> ImageCanvas::getLdrImageData(bool divideAlpha, int priority) con
     ThreadPool::global().parallelFor<size_t>(
         0,
         floatData.size() / 4,
+        floatData.size(),
         [&](const size_t i) {
             const size_t start = 4 * i;
             const Vector3f rgb = applyTonemap({
@@ -857,6 +860,7 @@ vector<Channel> ImageCanvas::channelsFromImages(
         ThreadPool::global().parallelFor<size_t>(
             0,
             image->numPixels(),
+            image->numPixels() * channels.size(),
             [&](size_t j) {
                 for (size_t c = 0; c < channels.size(); ++c) {
                     result[c].setAt(j, channels[c]->at(j));
@@ -878,6 +882,7 @@ vector<Channel> ImageCanvas::channelsFromImages(
         ThreadPool::global().parallelFor<int>(
             0,
             size.y(),
+            image->numPixels() * channels.size(),
             [&](int y) {
                 for (size_t c = 0; c < channels.size(); ++c) {
                     const auto* channel = channels[c];
@@ -1008,6 +1013,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
         ThreadPool::global().parallelForAsync<size_t>(
             0,
             numPixels,
+            numPixels * nChannels,
             [&](const size_t j) {
                 int x = (int)(j % regionSize.x()) + region.min.x();
                 int y = (int)(j / regionSize.x()) + region.min.y();
@@ -1024,6 +1030,7 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
     co_await ThreadPool::global().parallelForAsync<size_t>(
         0,
         nChannels,
+        numPixels * nChannels,
         [&](size_t c) {
             for (size_t j = 0; j < numPixels; ++j) {
                 int x = (int)(j % regionSize.x()) + region.min.x();

--- a/src/Ipc.cpp
+++ b/src/Ipc.cpp
@@ -296,6 +296,7 @@ IpcPacketUpdateImage IpcPacket::interpretAsUpdateImage() const {
     ThreadPool::global().parallelFor<size_t>(
         0,
         nPixels,
+        nPixels * result.nChannels,
         [&](size_t px) {
             for (int32_t c = 0; c < result.nChannels; ++c) {
                 result.imageData[c][px] = stridedImageData[result.channelOffsets[c] + px * result.channelStrides[c]];

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -31,8 +31,8 @@ ThreadPool::ThreadPool(size_t maxNumThreads, bool force) {
         maxNumThreads = min((size_t)thread::hardware_concurrency(), maxNumThreads);
     }
 
-    startThreads(maxNumThreads);
     mNumTasksInSystem.store(0);
+    startThreads(maxNumThreads);
 }
 
 ThreadPool::~ThreadPool() {
@@ -45,7 +45,7 @@ ThreadPool::~ThreadPool() {
 }
 
 void ThreadPool::startThreads(size_t num) {
-    const lock_guard lock{mTaskQueueMutex};
+    const scoped_lock lock{mThreadsMutex};
     if (mShuttingDown) {
         return;
     }
@@ -56,40 +56,29 @@ void ThreadPool::startThreads(size_t num) {
             const auto id = this_thread::get_id();
             // tlog::debug() << "Spawning thread pool thread " << id;
 
-            unique_lock lock{mTaskQueueMutex};
             while (true) {
-                if (!lock) {
-                    lock.lock();
-                }
-
-                // look for a work item
-                while (mThreads.size() <= mNumThreads && mTaskQueue.empty()) {
-                    // if there are none wait for notification
-                    mWorkerCondition.wait(lock);
-                }
-
-                if (mThreads.size() > mNumThreads) {
-                    break;
-                }
-
-                const function<void()> task{std::move(mTaskQueue.top().fun)};
-                mTaskQueue.pop();
-
-                // Unlock the lock, so we can process the task without blocking other threads
-                lock.unlock();
-
-                task();
+                QueuedTask task = {};
+                while (!mTaskQueueSemaphore.wait()) {}
 
                 {
-                    const unique_lock localLock{mTaskQueueMutex};
+                    const scoped_lock taskQueueLock{mTaskQueueMutex};
+                    TEV_ASSERT(!mTaskQueue.empty(), "Task queue was empty after semaphore wait.");
 
-                    mNumTasksInSystem--;
+                    task = std::move(mTaskQueue.top());
+                    mTaskQueue.pop();
+                }
 
-                    if (mNumTasksInSystem == 0) {
-                        mSystemBusyCondition.notify_all();
-                    }
+                if (task.fun) {
+                    task.fun();
+                }
+
+                mNumTasksInSystem--;
+                if (task.stopToken) {
+                    break;
                 }
             }
+
+            const scoped_lock threadsLock{mThreadsMutex};
 
             // Remove oneself from the thread pool. NOTE: at this point, the lock is still held, so modifying mThreads is safe.
             // tlog::debug() << "Shutting down thread pool thread " << id;
@@ -107,59 +96,27 @@ void ThreadPool::startThreads(size_t num) {
 }
 
 void ThreadPool::shutdownThreads(size_t num) {
-    {
-        const lock_guard lock{mTaskQueueMutex};
-
-        const auto numToClose = min(num, mNumThreads);
-        mNumThreads -= numToClose;
+    mNumThreads -= num;
+    for (size_t i = 0; i < num; ++i) {
+        enqueueTask([]() {}, std::numeric_limits<int>::max(), true);
     }
-
-    // Wake up all the threads to have them quit
-    mWorkerCondition.notify_all();
 }
 
 void ThreadPool::shutdown() {
-    {
-        const lock_guard lock{mTaskQueueMutex};
-
-        mNumThreads = 0;
-        mShuttingDown = true;
-    }
-
-    // Wake up all the threads to have them quit
-    mWorkerCondition.notify_all();
+    shutdownThreads(mNumThreads);
+    mShuttingDown = true;
 }
 
 void ThreadPool::waitUntilFinished() {
-    unique_lock lock{mTaskQueueMutex};
-
-    if (mNumTasksInSystem == 0) {
-        return;
+    while (mThreads.size() > 0 && mNumTasksInSystem > 0) {
+        this_thread::sleep_for(1ms);
     }
-
-    mSystemBusyCondition.wait(lock);
 }
 
-void ThreadPool::waitUntilFinishedFor(const chrono::microseconds Duration) {
-    unique_lock lock{mTaskQueueMutex};
-
-    if (mNumTasksInSystem == 0) {
-        return;
-    }
-
-    mSystemBusyCondition.wait_for(lock, Duration);
-}
-
-void ThreadPool::flushQueue() {
-    const lock_guard lock{mTaskQueueMutex};
-
-    mNumTasksInSystem -= mTaskQueue.size();
-    while (!mTaskQueue.empty()) {
-        mTaskQueue.pop();
-    }
-
-    if (mNumTasksInSystem == 0) {
-        mSystemBusyCondition.notify_all();
+void ThreadPool::waitUntilFinishedFor(const chrono::microseconds duration) {
+    const auto now = chrono::steady_clock::now();
+    while (mThreads.size() > 0 && mNumTasksInSystem > 0 && chrono::steady_clock::now() - now < duration) {
+        this_thread::sleep_for(1ms);
     }
 }
 

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -68,11 +68,9 @@ void ThreadPool::startThreads(size_t num) {
                     mTaskQueue.pop();
                 }
 
-                if (task.fun) {
-                    task.fun();
-                }
-
+                task.fun();
                 mNumTasksInSystem--;
+
                 if (task.stopToken) {
                     break;
                 }
@@ -98,7 +96,7 @@ void ThreadPool::startThreads(size_t num) {
 void ThreadPool::shutdownThreads(size_t num) {
     mNumThreads -= num;
     for (size_t i = 0; i < num; ++i) {
-        enqueueTask([]() {}, std::numeric_limits<int>::max(), true);
+        enqueueStopToken();
     }
 }
 

--- a/src/imageio/Colors.cpp
+++ b/src/imageio/Colors.cpp
@@ -828,9 +828,12 @@ Task<void> toLinearSrgbPremul(
 
     const size_t nSrcSamplesPerRow = size.x() * numChannels;
     const size_t nDstSamplesPerRow = size.x() * numChannelsOut;
+
+    const size_t numSamples = (size_t)size.x() * size.y() * numChannels;
     co_await ThreadPool::global().parallelForAsync<size_t>(
         0,
         size.y(),
+        numSamples * 4, // arbitrary factor to reflect increased cost of color conversion
         [&](size_t y) {
             size_t srcOffset = y * nSrcSamplesPerRow * bytesPerSample;
             size_t dstOffset = y * nDstSamplesPerRow;

--- a/src/imageio/GainMap.cpp
+++ b/src/imageio/GainMap.cpp
@@ -79,6 +79,7 @@ Task<void> applyAppleGainMap(ImageData& image, const ImageData& gainMap, int pri
     co_await ThreadPool::global().parallelForAsync<size_t>(
         0,
         numPixels,
+        numPixels * numImageChannels,
         [&](size_t i) {
             for (int c = 0; c < numImageChannels; ++c) {
                 if (c == alphaChannelIndex) {

--- a/src/imageio/HeifImageLoader.cpp
+++ b/src/imageio/HeifImageLoader.cpp
@@ -388,6 +388,7 @@ Task<vector<ImageData>>
         co_await ThreadPool::global().parallelForAsync<size_t>(
             0,
             numPixels,
+            numPixels * numInterleavedChannels,
             [&](size_t i) {
                 // HEIF/AVIF unfortunately tends to have the alpha channel premultiplied in non-linear space (after application of the
                 // transfer), so we must unpremultiply prior to the color space conversion and transfer function inversion.

--- a/src/imageio/ImageLoader.cpp
+++ b/src/imageio/ImageLoader.cpp
@@ -134,7 +134,7 @@ Task<vector<Channel>> ImageLoader::makeRgbaInterleavedChannels(
         using ptr_float_t = std::remove_pointer_t<decltype(ptr)>;
         const ptr_float_t pattern[4] = {(ptr_float_t)0.0, (ptr_float_t)0.0, (ptr_float_t)0.0, (ptr_float_t)1.0};
         co_await ThreadPool::global().parallelForAsync<size_t>(
-            0, numPixels, [pattern, ptr](size_t i) { memcpy(ptr + i * 4, pattern, sizeof(ptr_float_t) * 4); }, priority
+            0, numPixels, numPixels, [pattern, ptr](size_t i) { memcpy(ptr + i * 4, pattern, sizeof(ptr_float_t) * 4); }, priority
         );
     };
 
@@ -191,9 +191,11 @@ Task<void> ImageLoader::resizeChannelsAsync(const vector<Channel>& srcChannels, 
         TEV_ASSERT(dstChannels[i].size() == targetSize, "Destination channels' size must match.");
     }
 
+    const size_t numSamples = (size_t)targetSize.x() * targetSize.y() * numChannels;
     co_await ThreadPool::global().parallelForAsync<int>(
         0,
         targetSize.y(),
+        numSamples,
         [&](int dstY) {
             const float scaleX = (float)size.x() / targetSize.x();
             const float scaleY = (float)size.y() / targetSize.y();

--- a/src/imageio/JxlImageLoader.cpp
+++ b/src/imageio/JxlImageLoader.cpp
@@ -524,6 +524,7 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
                         co_await ThreadPool::global().parallelForAsync<size_t>(
                             0,
                             numPixels,
+                            numPixels * 4,
                             [&](size_t i) {
                                 // Jxl unfortunately premultiplies the alpha channel in non-linear space (after application of the
                                 // transfer), so we must unpremultiply prior to the color space conversion and transfer function inversion.
@@ -565,9 +566,12 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
                             extraChannel.name, size, EPixelFormat::F32, extraChannel.bitsPerSample > 16 ? EPixelFormat::F32 : EPixelFormat::F16
                         }
                     );
+
+                    const size_t numPixels = (size_t)size.x() * size.y();
                     co_await ThreadPool::global().parallelForAsync<size_t>(
                         0,
                         size.y(),
+                        numPixels,
                         [&](size_t y) {
                             size_t srcOffset = y * (size.x() >> extraChannel.dimShift);
                             for (int x = 0; x < size.x(); ++x) {

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -487,6 +487,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                 co_await ThreadPool::global().parallelForAsync<size_t>(
                     0,
                     numPixels,
+                    numSamples,
                     [&](size_t i) {
                         const float alpha = dstData[i * 4 + 3];
                         Vector3f color;
@@ -584,6 +585,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
             co_await ThreadPool::global().parallelForAsync<size_t>(
                 0,
                 numPixels,
+                numSamples,
                 [&](size_t i) {
                     const float alpha = dstData[i * 4 + 3];
                     for (int c = 0; c < 3; ++c) {
@@ -621,6 +623,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
             co_await ThreadPool::global().parallelForAsync<int>(
                 0,
                 size.y(),
+                numSamples,
                 [&](int y) {
                     Vector2i framePos;
                     framePos.y() = y - frameOffset.y();

--- a/src/imageio/RawImageLoader.cpp
+++ b/src/imageio/RawImageLoader.cpp
@@ -286,9 +286,11 @@ Task<vector<ImageData>> RawImageLoader::load(istream& iStream, const fs::path& p
     // resultData.displayWindow = displayWindow; // This seems to be wrong
 
     const auto* imgData = iProcessor.imgdata.image;
+    const size_t numPixels = (size_t)size.x() * size.y();
     co_await ThreadPool::global().parallelForAsync<int>(
         0,
         size.y(),
+        numPixels * numChannels,
         [&](int y) {
             for (int x = 0; x < size.x(); x++) {
                 const size_t i = (size_t)y * size.x() + x;

--- a/src/imageio/WebpImageLoader.cpp
+++ b/src/imageio/WebpImageLoader.cpp
@@ -230,6 +230,7 @@ Task<vector<ImageData>> WebpImageLoader::load(istream& iStream, const fs::path&,
             co_await ThreadPool::global().parallelForAsync<int>(
                 0,
                 size.y(),
+                numSamples,
                 [&](int y) {
                     for (int x = 0; x < size.x(); ++x) {
                         const size_t canvasPixelIdx = (size_t)y * size.x() + (size_t)x;


### PR DESCRIPTION
Very large thread counts (e.g. recent threadripper CPUs) cause too much contention in the thread pool's task queue. This PR is meant to alleviate this issue in two ways:
1. Gating the queue's lock behind a light-weight semaphore (== only threads that are guaranteed to pop a task get to try to unlock in the first place)
2. Adding a minimum task size to ensure task cost is larger than queuing cost.