### PR TITLE
Color space control for pixel inspection

### DIFF
--- a/include/tev/Channel.h
+++ b/include/tev/Channel.h
@@ -58,6 +58,9 @@ public:
     std::string_view name() const { return mName; }
     void setName(std::string_view name) { mName = name; }
 
+    bool isAlpha() const { return Channel::isAlpha(mName); }
+    bool isTopmost() const { return Channel::isTopmost(mName); }
+
     size_t numPixels() const { return (size_t)mSize.x() * mSize.y(); }
 
     const nanogui::Vector2i& size() const { return mSize; }

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -451,7 +451,7 @@ inline float toSRGB(float val, float gamma = 2.4f) {
     static constexpr float threshold = 0.0031308f;
 
     const float absVal = std::abs(val);
-    if (val <= threshold) {
+    if (absVal <= threshold) {
         return 12.92f * val;
     } else {
         return std::copysign((1.0f + a) * std::pow(absVal, 1.0f / gamma) - a, val);

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -28,6 +28,7 @@
 
 #include <memory>
 #include <optional>
+#include <unordered_map>
 
 namespace tev {
 
@@ -124,6 +125,18 @@ public:
     float pixelRatio() const { return mPixelRatio; }
     void setPixelRatio(float ratio) { mPixelRatio = ratio; }
 
+    chroma_t inspectionChroma() const { return mInspectionChroma; }
+    void setInspectionChroma(const chroma_t& chroma) { mInspectionChroma = chroma; }
+
+    ituth273::ETransfer inspectionTransfer() const { return mInspectionTransfer; }
+    void setInspectionTransfer(const ituth273::ETransfer transfer) { mInspectionTransfer = transfer; }
+
+    bool inspectionAdaptWhitePoint() const { return mInspectionAdaptWhitePoint; }
+    void setInspectionAdaptWhitePoint(bool adapt) { mInspectionAdaptWhitePoint = adapt; }
+
+    bool inspectionPremultipliedAlpha() const { return mInspectionPremultipliedAlpha; }
+    void setInspectionPremultipliedAlpha(bool premultipied) { mInspectionPremultipliedAlpha = premultipied; }
+
 private:
     static std::vector<Channel> channelsFromImages(
         std::shared_ptr<Image> image, std::shared_ptr<Image> reference, std::string_view requestedChannelGroup, EMetric metric, int priority
@@ -135,6 +148,10 @@ private:
         std::string_view requestedChannelGroup,
         EMetric metric,
         const Box2i& region,
+        const chroma_t& chroma,
+        ituth273::ETransfer transfer,
+        bool adaptWhitePoint,
+        bool premultipliedAlpha,
         int priority
     );
 
@@ -174,8 +191,13 @@ private:
     EMetric mMetric = EMetric::Error;
     std::optional<Box2i> mCrop;
 
-    std::map<std::string, std::shared_ptr<Lazy<std::shared_ptr<CanvasStatistics>>>> mCanvasStatistics;
-    std::map<int, std::vector<std::string>> mImageIdToCanvasStatisticsKey;
+    std::unordered_map<std::string, std::shared_ptr<Lazy<std::shared_ptr<CanvasStatistics>>>> mCanvasStatistics;
+    std::unordered_map<int, std::vector<std::string>> mImageIdToCanvasStatisticsKey;
+
+    chroma_t mInspectionChroma = rec709Chroma();
+    ituth273::ETransfer mInspectionTransfer = ituth273::ETransfer::Linear;
+    bool mInspectionAdaptWhitePoint = false;
+    bool mInspectionPremultipliedAlpha = true;
 };
 
 } // namespace tev

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -137,6 +137,9 @@ public:
     bool inspectionPremultipliedAlpha() const { return mInspectionPremultipliedAlpha; }
     void setInspectionPremultipliedAlpha(bool premultipied) { mInspectionPremultipliedAlpha = premultipied; }
 
+    // Assumes the alpha channel is the last one, if present
+    void applyInspectionParameters(std::vector<float>& values, bool hasAlpha);
+
 private:
     static std::vector<Channel> channelsFromImages(
         std::shared_ptr<Image> image, std::shared_ptr<Image> reference, std::string_view requestedChannelGroup, EMetric metric, int priority

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -195,6 +195,12 @@ public:
 
     void showErrorDialog(std::string_view message);
 
+    void setInspectionChroma(const chroma_t& chroma);
+    chroma_t inspectionChroma() const;
+
+    void setInspectionTransfer(ituth273::ETransfer transfer);
+    ituth273::ETransfer inspectionTransfer() const;
+
 private:
     void updateFilter();
     void updateLayout();
@@ -306,8 +312,8 @@ private:
 
     // HDR UI elements support
     struct ColorSpace {
-        ituth273::ETransferCharacteristics transfer;
-        uint32_t primaries;
+        ituth273::ETransfer transfer;
+        EWpPrimaries primaries;
         float maxLuminance;
 
         bool operator==(const ColorSpace& other) const {
@@ -315,8 +321,14 @@ private:
         }
     };
 
-    std::optional<ColorSpace> mCurrentColorSpace;
+    std::optional<ColorSpace> mSystemColorSpace;
 
+    nanogui::ComboBox* mInspectionPrimariesComboBox = nullptr;
+    std::vector<nanogui::FloatBox<float>*> mInspectionPrimariesBoxes;
+    nanogui::ComboBox* mInspectionTransferComboBox = nullptr;
+    nanogui::Button* mInspectionAdaptWhitePointButton = nullptr;
+
+    nanogui::PopupButton* mColorsPopupButton = nullptr;
     nanogui::PopupButton* mHdrPopupButton = nullptr;
     nanogui::Button* mClipToLdrButton = nullptr;
 

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -30,6 +30,7 @@
 #include <tev/VectorGraphics.h>
 #include <tev/imageio/Colors.h>
 
+#include <nanogui/button.h>
 #include <nanogui/opengl.h>
 #include <nanogui/screen.h>
 #include <nanogui/slider.h>
@@ -195,11 +196,17 @@ public:
 
     void showErrorDialog(std::string_view message);
 
-    void setInspectionChroma(const chroma_t& chroma);
     chroma_t inspectionChroma() const;
+    void setInspectionChroma(const chroma_t& chroma);
 
-    void setInspectionTransfer(ituth273::ETransfer transfer);
     ituth273::ETransfer inspectionTransfer() const;
+    void setInspectionTransfer(ituth273::ETransfer transfer);
+
+    bool inspectionAdaptWhitePoint() const;
+    void setInspectionAdaptWhitePoint(bool adapt);
+
+    bool inspectionPremultipliedAlpha() const;
+    void setInspectionPremultipliedAlpha(bool value);
 
 private:
     void updateFilter();
@@ -327,6 +334,7 @@ private:
     std::vector<nanogui::FloatBox<float>*> mInspectionPrimariesBoxes;
     nanogui::ComboBox* mInspectionTransferComboBox = nullptr;
     nanogui::Button* mInspectionAdaptWhitePointButton = nullptr;
+    nanogui::Button* mInspectionPremultipliedAlphaButton = nullptr;
 
     nanogui::PopupButton* mColorsPopupButton = nullptr;
     nanogui::PopupButton* mHdrPopupButton = nullptr;

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -45,9 +45,7 @@ chroma_t zeroChroma();
 nanogui::Matrix3f xyzToChromaMatrix(const chroma_t& chroma);
 nanogui::Matrix3f adaptWhiteBradford(const nanogui::Vector2f& srcWhite, const nanogui::Vector2f& dstWhite);
 
-nanogui::Matrix3f convertColorspaceMatrix(
-    const chroma_t& srcChroma, const chroma_t& dstChroma, ERenderingIntent intent
-);
+nanogui::Matrix3f convertColorspaceMatrix(const chroma_t& srcChroma, const chroma_t& dstChroma, ERenderingIntent intent);
 
 nanogui::Vector2f whiteD50();
 nanogui::Vector2f whiteD55();
@@ -161,28 +159,47 @@ bool isTransferImplemented(const ETransfer transfer);
 
 ETransfer fromWpTransfer(int wpTransfer);
 
+namespace bt709 {
+static constexpr float beta = 0.018053968510807f;
+static constexpr float alpha = 1.0f + 5.5f * beta;
+static constexpr float thres = 4.5f * beta;
+} // namespace bt709
+
 inline float bt709ToLinear(float val) {
-    constexpr float beta = 0.018053968510807f;
-    constexpr float alpha = 1.0f + 5.5f * beta;
-    constexpr float thres = 4.5f * beta;
-    return val <= thres ? (val / 4.5f) : std::pow((val + alpha - 1.0f) / alpha, 1.0f / 0.45f);
+    return val <= bt709::thres ? (val / 4.5f) : std::pow((val + bt709::alpha - 1.0f) / bt709::alpha, 1.0f / 0.45f);
+}
+
+inline float linearToBt709(float val) {
+    return val <= bt709::beta ? (val * 4.5f) : (bt709::alpha * std::pow(val, 0.45f) - (bt709::alpha - 1.0f));
 }
 
 // From https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.1361-0-199802-W!!PDF-E.pdf, generalized to the more precise constants from the
 // bt709ToLinear function as defined in https://www.itu.int/rec/T-REC-H.273-202407-I/en.
 inline float bt1361ExtendedToLinear(float val) {
-    constexpr float beta = 0.018053968510807f;
-    constexpr float alpha = 1.0f + 5.5f * beta;
-    constexpr float thres = 4.5f * beta;
-    constexpr float negThres = -thres / 4.0f;
+    constexpr float negThres = -bt709::thres / 4.0f;
 
     float result;
     if (val < negThres) {
-        result = -std::pow((-val * 4.0f + alpha - 1.0f) / alpha, 1.0f / 0.45f) / 4.0f;
-    } else if (val <= thres) {
+        result = (-1.0f / 4.0f) * std::pow((-4.0f * val + bt709::alpha - 1.0f) / bt709::alpha, 1.0f / 0.45f);
+    } else if (val <= bt709::thres) {
         result = val / 4.5f;
     } else {
-        result = std::pow((val + alpha - 1.0f) / alpha, 1.0f / 0.45f);
+        result = std::pow((val + bt709::alpha - 1.0f) / bt709::alpha, 1.0f / 0.45f);
+    }
+
+    return result;
+}
+
+inline float linearToBt1361Extended(float val) {
+    constexpr float negThres = -bt709::beta / 4.0f;
+
+    float result;
+    if (val < negThres) {
+        result = (-1.0f / 4.0f) * (bt709::alpha * std::pow(-4.0f * val, 0.45f) - (bt709::alpha - 1.0f));
+    } else if (val <= bt709::beta) {
+        result = val * 4.5f;
+    } else {
+        result = bt709::alpha * std::pow(val, 0.45f) - (bt709::alpha - 1.0f);
     }
 
     return result;
@@ -190,40 +207,74 @@ inline float bt1361ExtendedToLinear(float val) {
 
 // From http://car.france3.mars.free.fr/HD/INA-%2026%20jan%2006/SMPTE%20normes%20et%20confs/s240m.pdf
 inline float smpteSt240ToLinear(float val) { return val <= 0.0913f ? (val / 4.0f) : pow((val + 0.1115f) / 1.1115f, 1.0f / 0.45f); }
+inline float linearToSmpteSt240(float val) { return val <= 0.022825f ? (val * 4.0f) : (1.1115f * pow(val, 0.45f) - 0.1115f); }
+
+namespace pq {
+static constexpr float c1 = 107.0f / 128.0f;
+static constexpr float c2 = 2413.0f / 128.0f;
+static constexpr float c3 = 2392.0f / 128.0f;
+static constexpr float m1 = 1305.0f / 8192.0f;
+static constexpr float m2 = 2523.0f / 32.0f;
+static constexpr float invm1 = 8192.0f / 1305.0f;
+static constexpr float invm2 = 32.0f / 2523.0f;
+} // namespace pq
 
 inline float pqToLinear(float val) {
-    constexpr float c1 = 107.0f / 128.0f;
-    constexpr float c2 = 2413.0f / 128.0f;
-    constexpr float c3 = 2392.0f / 128.0f;
-    constexpr float invm1 = 8192.0f / 1305.0f;
-    constexpr float invm2 = 32.0f / 2523.0f;
+    const float tmp = std::pow(std::max(val, 0.0f), pq::invm2);
+    return 10000.0f / 203.0f * std::pow(std::max(tmp - pq::c1, 0.0f) / std::max(pq::c2 - pq::c3 * tmp, 1e-5f), pq::invm1);
+}
 
-    const float tmp = std::pow(std::max(val, 0.0f), invm2);
-    return 10000.0f / 203.0f * std::pow(std::max(tmp - c1, 0.0f) / std::max(c2 - c3 * tmp, 1e-5f), invm1);
+inline float linearToPq(float val) {
+    val = val * 203.0f / 10000.0f;
+    const float p = std::pow(std::max(val, 0.0f), pq::m1);
+
+    const float num = pq::c1 + pq::c2 * p;
+    return std::pow(num / (1.0f + pq::c3 * p), pq::m2);
 }
 
 inline float smpteSt428ToLinear(float val) { return std::pow(val, 2.6f) * (52.37f / 48.0f); }
+inline float linearToSmpteSt428(float val) { return std::pow(val * (48.0f / 52.37f), 1.0f / 2.6f); }
+
+namespace hlg {
+// TODO: make these params configurable at runtime
+static constexpr float Lw = 1000.0f; // display peak brightness in cd/m² (nits)
+static constexpr float gain = Lw; // can technically be adjusted, but usually set to Lw
+static const float gamma = 1.2f + 0.42f * std::log10(Lw / 1000.0f);
+
+static constexpr float a = 0.17883277f;
+static constexpr float b = 0.28466892f;
+static constexpr float c = 0.55991073f;
+} // namespace hlg
 
 inline nanogui::Vector3f hlgToLinear(const nanogui::Vector3f& val) {
     const auto invOetf = [](const float val) {
-        constexpr float a = 0.17883277f;
-        constexpr float b = 0.28466892f;
-        constexpr float c = 0.55991073f;
-        return val <= 0.5f ? (val * val / 3.0f) : ((std::exp((val - c) / a) + b) / 12.0f);
+        return val <= 0.5f ? (val * val / 3.0f) : ((std::exp((val - hlg::c) / hlg::a) + hlg::b) / 12.0f);
     };
 
     const auto ootf = [](const nanogui::Vector3f& val) {
-        // TODO: make these params configurable
-        constexpr float Lw = 1000.0; // display peak brightness in cd/m² (nits)
-        constexpr float gain = Lw; // can technically be adjusted, but usually set to Lw
-        const float gamma = 1.2f + 0.42f * std::log10(Lw / 1000.0f);
-
         // NOTE: HLG (BT.2100) mandates the use of Rec. 2020 primaries, so the following equation should always be valid.
         const float lum = 0.2627f * val.x() + 0.6780f * val.y() + 0.0593f * val.z();
-        return gain * pow(lum, gamma - 1.0f) * val;
+        return hlg::gain * pow(lum, hlg::gamma - 1.0f) * val;
     };
 
-    return ootf({invOetf(val.x()), invOetf(val.y()), invOetf(val.z())}) / 203.0f; // Convert to linear sRGB units where SDR white is 1.0
+    return ootf({invOetf(val.x()), invOetf(val.y()), invOetf(val.z())}) / 203.0f; // Convert to linear units where SDR white is 1.0
+}
+
+inline nanogui::Vector3f linearToHlg(const nanogui::Vector3f& val) {
+    const auto oetf = [](const float val) {
+        return val <= 1.0f / 12.0f ? std::sqrt(3.0f * val) : (hlg::a * std::log(12.0f * val - hlg::b) + hlg::c);
+    };
+
+    const auto invOotf = [](const nanogui::Vector3f& val) {
+        const auto tmp = val / hlg::gain;
+
+        // NOTE: HLG (BT.2100) mandates the use of Rec. 2020 primaries, so the following equation should always be valid.
+        const float lum = 0.2627f * tmp.x() + 0.6780f * tmp.y() + 0.0593f * tmp.z();
+        return pow(lum, (1.0f - hlg::gamma) / hlg::gamma) * tmp;
+    };
+
+    const auto tmp = invOotf(val * 203.0f); // Convert from linear units where SDR white is 1.0;
+    return {oetf(tmp.x()), oetf(tmp.y()), oetf(tmp.z())};
 }
 
 inline float invTransferComponent(const ETransfer transfer, float val) noexcept {
@@ -245,7 +296,7 @@ inline float invTransferComponent(const ETransfer transfer, float val) noexcept 
         case ETransfer::SRGB: return toLinear(val);
         case ETransfer::PQ: return pqToLinear(val);
         case ETransfer::SMPTE428: return smpteSt428ToLinear(val);
-        case ETransfer::HLG: return val; // Should be handled by invTransfer below
+        case ETransfer::HLG: return val; // Should be handled by `invTransfer()` below
         case ETransfer::Unspecified: return val; // Default to linear if unspecified
     }
 
@@ -265,13 +316,52 @@ inline nanogui::Vector3f invTransfer(const ETransfer transfer, const nanogui::Ve
     }
 }
 
+inline float transferComponent(const ETransfer transfer, float val) noexcept {
+    switch (transfer) {
+        case ETransfer::BT709:
+        case ETransfer::BT601:
+        case ETransfer::BT202010bit:
+        case ETransfer::BT202012bit: return linearToBt709(val);
+        case ETransfer::IEC61966_2_4: // handles negative values by mirroring
+            return std::copysign(linearToBt709(std::abs(val)), val);
+        case ETransfer::BT1361Extended: // extended to negative values (weirdly)
+            return linearToBt1361Extended(val);
+        case ETransfer::Gamma22: return std::pow(std::max(val, 0.0f), 1.0f / 2.2f);
+        case ETransfer::Gamma28: return std::pow(std::max(val, 0.0f), 1.0f / 2.8f);
+        case ETransfer::SMPTE240: return linearToSmpteSt240(val);
+        case ETransfer::Linear: return val;
+        case ETransfer::Log100: return val >= 0.01f ? 1.0f + std::log10(val) / 2.0f : 0.0f;
+        case ETransfer::Log100Sqrt10: return val >= std::sqrt(10.0f) / 1000.0f ? 1.0f + std::log10(val) / 2.5f : 0.0f;
+        case ETransfer::SRGB: return toSRGB(val);
+        case ETransfer::PQ: return linearToPq(val);
+        case ETransfer::SMPTE428: return linearToSmpteSt428(val);
+        case ETransfer::HLG: return val; // Should be handled by `transfer()` below
+        case ETransfer::Unspecified: return val; // Default to linear if unspecified
+    }
+
+    // Other transfer functions are not implemented. Default to linear.
+    return val;
+}
+
+inline nanogui::Vector3f transfer(const ETransfer transfer, const nanogui::Vector3f& val) noexcept {
+    if (transfer == ETransfer::HLG) {
+        return linearToHlg(val);
+    } else {
+        return {
+            transferComponent(transfer, val.x()),
+            transferComponent(transfer, val.y()),
+            transferComponent(transfer, val.z()),
+        };
+    }
+}
+
 inline float bestGuessReferenceWhiteLevel(const ETransfer transfer) {
     switch (transfer) {
         case ETransfer::PQ:
         case ETransfer::HLG: return 203.0f;
 
         case ETransfer::BT709: // 100 nits by convention, see e.g.
-                                              // https://partnerhelp.netflixstudios.com/hc/en-us/articles/360000591787-Color-Critical-Display-Calibration-Guidelines
+                               // https://partnerhelp.netflixstudios.com/hc/en-us/articles/360000591787-Color-Critical-Display-Calibration-Guidelines
         case ETransfer::BT601: // same as BT709 in practice
         case ETransfer::BT1361Extended: // Extends BT709 and inherits conventions.
         case ETransfer::IEC61966_2_4: // xvYCC proposed by sony. Extends BT709 and inherits conventions.

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -107,6 +107,8 @@ enum class EWpPrimaries : int {
     DCIP3 = 8, // SMPTE431
     DisplayP3 = 9, // SMPTE432
     AdobeRGB = 10, // ISO 12640-4
+    //
+    ProPhotoRGB = 127, // Not actually in the spec, but useful for tev to have
 };
 
 chroma_t chroma(EWpPrimaries wpPrimaries);

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -296,7 +296,7 @@ inline float invTransferComponent(const ETransfer transfer, float val) noexcept 
         case ETransfer::SRGB: return toLinear(val);
         case ETransfer::PQ: return pqToLinear(val);
         case ETransfer::SMPTE428: return smpteSt428ToLinear(val);
-        case ETransfer::HLG: return val; // Should be handled by `invTransfer()` below
+        case ETransfer::HLG: return hlgToLinear({val, val, val}).x(); // Treat single component as R=G=B
         case ETransfer::Unspecified: return val; // Default to linear if unspecified
     }
 
@@ -335,7 +335,7 @@ inline float transferComponent(const ETransfer transfer, float val) noexcept {
         case ETransfer::SRGB: return toSRGB(val);
         case ETransfer::PQ: return linearToPq(val);
         case ETransfer::SMPTE428: return linearToSmpteSt428(val);
-        case ETransfer::HLG: return val; // Should be handled by `transfer()` below
+        case ETransfer::HLG: return linearToHlg({val, val, val}).x(); // Treat single component as R=G=B
         case ETransfer::Unspecified: return val; // Default to linear if unspecified
     }
 

--- a/src/HelpWindow.cpp
+++ b/src/HelpWindow.cpp
@@ -119,7 +119,7 @@ HelpWindow::HelpWindow(Widget* parent, weak_ptr<Ipc> weakIpc, function<void()> c
     addRow(imageSelection, "O/Shift+O", "Increase/decrease offset by 0.1");
 
     addRow(imageSelection, "B (hold)", "Draw a border around the image");
-    addRow(imageSelection, "Shift+Ctrl (hold)", "Display raw bytes on pixels when zoomed-in");
+    addRow(imageSelection, "Shift+Ctrl (hold)", "Display sRGB bytes when zoomed-in");
 #ifdef __APPLE__
     addRow(imageSelection, "Enter", "Rename the image");
 #else

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -524,7 +524,7 @@ Image::Image(const fs::path& path, fs::file_time_type fileLastModified, ImageDat
 
     if (groupChannels) {
         for (const auto& l : mData.layers) {
-            auto groups = getGroupedChannels(l);
+            const auto groups = getGroupedChannels(l);
             mChannelGroups.insert(end(mChannelGroups), begin(groups), end(groups));
         }
     } else {
@@ -536,6 +536,13 @@ Image::Image(const fs::path& path, fs::file_time_type fileLastModified, ImageDat
                     vector<string>{string{c.name()}, string{c.name()}, string{c.name()}}
             }
             );
+        }
+    }
+
+    // Ensure that alpha channels are last in their group
+    for (const auto& group : mChannelGroups) {
+        for (const auto& channel : group.channels) {
+            TEV_ASSERT(Channel::tail(channel) != "A" || &channel == &group.channels.back(), "Alpha channel must be last in channel group.");
         }
     }
 }

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -198,7 +198,7 @@ void ImageCanvas::drawPixelValuesAsText(NVGcontext* ctx) {
                     Vector2f pos;
 
                     if (shiftAndControlHeld) {
-                        const unsigned char discretizedValue = (char)(values[i] * 255 + 0.5f);
+                        const unsigned char discretizedValue = (char)(clamp(values[i], 0.0f, 1.0f) * 255 + 0.5f);
                         str = fmt::format("{:02X}", discretizedValue);
                         pos = Vector2f{
                             m_pos.x() + nano.x() + (i - 0.5f * (colors.size() - 1)) * fontSize * 0.88f,

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -55,16 +55,17 @@ static const int SIDEBAR_MIN_WIDTH = 230;
 static const float CROP_MIN_SIZE = 3;
 
 static const vector<pair<EWpPrimaries, string_view>> PRIMARIES = {
-    {EWpPrimaries::SRGB,       "sRGB"        },
-    {EWpPrimaries::BT2020,     "BT.2020"     },
-    {EWpPrimaries::DCIP3,      "DCI P3"      },
-    {EWpPrimaries::DisplayP3,  "Display P3"  },
-    {EWpPrimaries::AdobeRGB,   "Adobe RGB"   },
-    {EWpPrimaries::NTSC,       "NTSC"        },
-    {EWpPrimaries::PAL,        "PAL"         },
-    {EWpPrimaries::PALM,       "PAL-M"       },
-    {EWpPrimaries::Film,       "Generic Film"},
-    {EWpPrimaries::CIE1931XYZ, "CIE 1931 XYZ"},
+    {EWpPrimaries::SRGB,        "sRGB"        },
+    {EWpPrimaries::BT2020,      "BT.2020"     },
+    {EWpPrimaries::DCIP3,       "DCI P3"      },
+    {EWpPrimaries::DisplayP3,   "Display P3"  },
+    {EWpPrimaries::AdobeRGB,    "Adobe RGB"   },
+    {EWpPrimaries::ProPhotoRGB, "ProPhoto RGB"},
+    {EWpPrimaries::NTSC,        "NTSC"        },
+    {EWpPrimaries::PAL,         "PAL"         },
+    {EWpPrimaries::PALM,        "PAL-M"       },
+    {EWpPrimaries::Film,        "Generic Film"},
+    {EWpPrimaries::CIE1931XYZ,  "CIE 1931 XYZ"},
 };
 
 static const vector<pair<ituth273::ETransfer, string_view>> TRANSFERS = {

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -2730,8 +2730,8 @@ void ImageViewer::updateTitle() {
         valuesString.pop_back();
         valuesString += " / 0x";
         for (size_t i = 0; i < channelTails.size(); ++i) {
-            float tonemappedValue = channelTails[i] == "A" ? values[i] : toSRGB(values[i]);
-            unsigned char discretizedValue = (char)(tonemappedValue * 255 + 0.5f);
+            const float srgbValue = channelTails[i] == "A" ? values[i] : toSRGB(values[i]);
+            unsigned char discretizedValue = (char)(clamp(srgbValue, 0.0f, 1.0f) * 255 + 0.5f);
             valuesString += fmt::format("{:02X}", discretizedValue);
         }
 

--- a/src/imageio/Colors.cpp
+++ b/src/imageio/Colors.cpp
@@ -42,8 +42,8 @@ string_view toString(ERenderingIntent intent) {
     }
 }
 
-array<Vector2f, 4> zeroChroma() {
-    array<Vector2f, 4> chroma;
+chroma_t zeroChroma() {
+    chroma_t chroma;
     fill(chroma.begin(), chroma.end(), Vector2f{0.0f});
     return chroma;
 }
@@ -63,7 +63,7 @@ Matrix3f toMatrix3(const float data[3][3]) {
 // This routine was copied from OpenEXR's ImfChromaticities.cpp in accordance
 // with its BSD-3-Clause license. See the header of that file for details.
 // https://github.com/AcademySoftwareFoundation/openexr/blob/main/src/lib/OpenEXR/ImfChromaticities.cpp
-Matrix3f rgbToXyz(const std::array<Vector2f, 4>& chroma, float Y) {
+Matrix3f rgbToXyz(const chroma_t& chroma, float Y) {
     //
     // For an explanation of how the color conversion matrix is derived,
     // see Roy Hall, "Illumination and Color in Computer Generated Imagery",
@@ -140,9 +140,9 @@ Matrix3f rgbToXyz(const std::array<Vector2f, 4>& chroma, float Y) {
     return M;
 }
 
-Matrix3f xyzToRgb(const std::array<Vector2f, 4>& chroma, float Y) { return inverse(rgbToXyz(chroma, Y)); }
+Matrix3f xyzToRgb(const chroma_t& chroma, float Y) { return inverse(rgbToXyz(chroma, Y)); }
 
-Matrix3f xyzToChromaMatrix(const std::array<Vector2f, 4>& chroma) { return xyzToRgb(chroma, 1); }
+Matrix3f xyzToChromaMatrix(const chroma_t& chroma) { return xyzToRgb(chroma, 1); }
 
 // Adapted from LittleCMS's AdaptToXYZD50 function
 Matrix3f adaptWhiteBradford(const Vector2f& srcWhite, const Vector2f& dstWhite) {
@@ -179,7 +179,7 @@ Matrix3f adaptWhiteBradford(const Vector2f& srcWhite, const Vector2f& dstWhite) 
     return kBradfordInv * b;
 }
 
-Matrix3f convertColorspaceMatrix(const std::array<Vector2f, 4>& srcChroma, const std::array<Vector2f, 4>& dstChroma, ERenderingIntent intent) {
+Matrix3f convertColorspaceMatrix(const chroma_t& srcChroma, const chroma_t& dstChroma, ERenderingIntent intent) {
     if (srcChroma == dstChroma) {
         return Matrix3f{1.0f};
     }
@@ -196,7 +196,7 @@ Matrix3f convertColorspaceMatrix(const std::array<Vector2f, 4>& srcChroma, const
     }
 }
 
-Matrix3f chromaToRec709Matrix(const std::array<Vector2f, 4>& chroma, ERenderingIntent intent) {
+Matrix3f chromaToRec709Matrix(const chroma_t& chroma, ERenderingIntent intent) {
     return convertColorspaceMatrix(chroma, rec709Chroma(), intent);
 }
 
@@ -213,7 +213,7 @@ Vector2f whiteC() { return {0.31006f, 0.31616f}; }
 Vector2f whiteCenter() { return {0.333333f, 0.333333f}; }
 Vector2f whiteDci() { return {0.314f, 0.351f}; }
 
-array<Vector2f, 4> rec709Chroma() {
+chroma_t rec709Chroma() {
     return {
         {
          {0.6400f, 0.3300f},
@@ -224,7 +224,7 @@ array<Vector2f, 4> rec709Chroma() {
     };
 }
 
-array<Vector2f, 4> adobeChroma() {
+chroma_t adobeChroma() {
     return {
         {
          {0.6400f, 0.3300f},
@@ -235,7 +235,7 @@ array<Vector2f, 4> adobeChroma() {
     };
 }
 
-array<Vector2f, 4> proPhotoChroma() {
+chroma_t proPhotoChroma() {
     return {
         {
          {0.734699f, 0.265301f},
@@ -246,7 +246,7 @@ array<Vector2f, 4> proPhotoChroma() {
     };
 }
 
-array<Vector2f, 4> displayP3Chroma() {
+chroma_t displayP3Chroma() {
     return {
         {
          {0.6800f, 0.3200f},
@@ -257,7 +257,7 @@ array<Vector2f, 4> displayP3Chroma() {
     };
 }
 
-array<Vector2f, 4> dciP3Chroma() {
+chroma_t dciP3Chroma() {
     return {
         {
          {0.6800f, 0.3200f},
@@ -268,7 +268,7 @@ array<Vector2f, 4> dciP3Chroma() {
     };
 }
 
-array<Vector2f, 4> bt2020Chroma() {
+chroma_t bt2020Chroma() {
     return {
         {
          {0.7080f, 0.2920f},
@@ -279,7 +279,7 @@ array<Vector2f, 4> bt2020Chroma() {
     };
 }
 
-array<Vector2f, 4> bt2100Chroma() {
+chroma_t bt2100Chroma() {
     return bt2020Chroma(); // BT.2100 uses the same primaries as BT.2020
 }
 
@@ -340,8 +340,8 @@ nanogui::Vector2f xy(EExifLightSource lightSource) {
     }
 }
 
-array<Vector2f, 4> chromaFromWpPrimaries(int wpPrimaries) {
-    if (wpPrimaries == 10) {
+chroma_t chroma(EWpPrimaries wpPrimaries) {
+    if (wpPrimaries == EWpPrimaries::AdobeRGB) {
         // Special case for Adobe RGB (1998) primaries, which is not in the H.273 spec
         return adobeChroma();
     }
@@ -349,10 +349,10 @@ array<Vector2f, 4> chromaFromWpPrimaries(int wpPrimaries) {
     return ituth273::chroma(ituth273::fromWpPrimaries(wpPrimaries));
 }
 
-string_view wpPrimariesToString(int wpPrimaries) {
-    if (wpPrimaries == 10) {
+string_view toString(EWpPrimaries wpPrimaries) {
+    if (wpPrimaries == EWpPrimaries::AdobeRGB) {
         // Special case for Adobe RGB (1998) primaries, which is not in the H.273 spec
-        return "adobe_rgb";
+        return "adobergb";
     }
 
     return ituth273::toString(ituth273::fromWpPrimaries(wpPrimaries));
@@ -380,7 +380,7 @@ string_view toString(const EColorPrimaries primaries) {
     return "invalid";
 }
 
-array<Vector2f, 4> chroma(const EColorPrimaries primaries) {
+chroma_t chroma(const EColorPrimaries primaries) {
     switch (primaries) {
         default: tlog::warning() << fmt::format("Unknown color primaries {}. Using Rec.709 chroma.", (int)primaries); return rec709Chroma();
         case EColorPrimaries::BT709: return rec709Chroma();
@@ -448,85 +448,85 @@ array<Vector2f, 4> chroma(const EColorPrimaries primaries) {
     return rec709Chroma(); // Fallback to Rec.709 if unknown
 }
 
-string_view toString(const ETransferCharacteristics transfer) {
+string_view toString(const ETransfer transfer) {
     switch (transfer) {
-        case ETransferCharacteristics::BT709: return "bt709";
-        case ETransferCharacteristics::Unspecified: return "unspecified";
-        case ETransferCharacteristics::Gamma22: return "gamma22";
-        case ETransferCharacteristics::Gamma28: return "gamma28";
-        case ETransferCharacteristics::BT601: return "bt601";
-        case ETransferCharacteristics::SMPTE240: return "smpte240";
-        case ETransferCharacteristics::Linear: return "linear";
-        case ETransferCharacteristics::Log100: return "log100";
-        case ETransferCharacteristics::Log100Sqrt10: return "log100_sqrt10";
-        case ETransferCharacteristics::IEC61966_2_4: return "iec61966";
-        case ETransferCharacteristics::BT1361Extended: return "bt1361_extended";
-        case ETransferCharacteristics::SRGB: return "srgb";
-        case ETransferCharacteristics::BT202010bit: return "bt2020_10bit";
-        case ETransferCharacteristics::BT202012bit: return "bt2020_12bit";
-        case ETransferCharacteristics::PQ: return "pq";
-        case ETransferCharacteristics::SMPTE428: return "smpte428";
-        case ETransferCharacteristics::HLG: return "hlg";
+        case ETransfer::BT709: return "bt709";
+        case ETransfer::Unspecified: return "unspecified";
+        case ETransfer::Gamma22: return "gamma22";
+        case ETransfer::Gamma28: return "gamma28";
+        case ETransfer::BT601: return "bt601";
+        case ETransfer::SMPTE240: return "smpte240";
+        case ETransfer::Linear: return "linear";
+        case ETransfer::Log100: return "log100";
+        case ETransfer::Log100Sqrt10: return "log100_sqrt10";
+        case ETransfer::IEC61966_2_4: return "iec61966";
+        case ETransfer::BT1361Extended: return "bt1361_extended";
+        case ETransfer::SRGB: return "srgb";
+        case ETransfer::BT202010bit: return "bt2020_10bit";
+        case ETransfer::BT202012bit: return "bt2020_12bit";
+        case ETransfer::PQ: return "pq";
+        case ETransfer::SMPTE428: return "smpte428";
+        case ETransfer::HLG: return "hlg";
     }
 
     return "invalid";
 }
 
-EColorPrimaries fromWpPrimaries(int wpPrimaries) {
+EColorPrimaries fromWpPrimaries(EWpPrimaries wpPrimaries) {
     switch (wpPrimaries) {
-        case 1: return ituth273::EColorPrimaries::BT709;
-        case 2: return ituth273::EColorPrimaries::BT470M;
-        case 3: return ituth273::EColorPrimaries::BT470BG;
-        case 4: return ituth273::EColorPrimaries::SMPTE170M;
-        case 5: return ituth273::EColorPrimaries::Film;
-        case 6: return ituth273::EColorPrimaries::BT2020;
-        case 7: return ituth273::EColorPrimaries::SMPTE428;
-        case 8: return ituth273::EColorPrimaries::SMPTE431;
-        case 9: return ituth273::EColorPrimaries::SMPTE432;
+        case EWpPrimaries::SRGB: return ituth273::EColorPrimaries::BT709;
+        case EWpPrimaries::PALM: return ituth273::EColorPrimaries::BT470M;
+        case EWpPrimaries::PAL: return ituth273::EColorPrimaries::BT470BG;
+        case EWpPrimaries::NTSC: return ituth273::EColorPrimaries::SMPTE170M;
+        case EWpPrimaries::Film: return ituth273::EColorPrimaries::Film;
+        case EWpPrimaries::BT2020: return ituth273::EColorPrimaries::BT2020;
+        case EWpPrimaries::CIE1931XYZ: return ituth273::EColorPrimaries::SMPTE428;
+        case EWpPrimaries::DCIP3: return ituth273::EColorPrimaries::SMPTE431;
+        case EWpPrimaries::DisplayP3: return ituth273::EColorPrimaries::SMPTE432;
+        default:
+            throw std::invalid_argument{fmt::format("Unknown wp color primaries: {}", toString(wpPrimaries))};
     }
-
-    throw std::invalid_argument{"Unknown wp color primaries: " + std::to_string(wpPrimaries)};
 }
 
-bool isTransferImplemented(const ETransferCharacteristics transfer) {
+bool isTransferImplemented(const ETransfer transfer) {
     switch (transfer) {
-        case ETransferCharacteristics::BT709:
-        case ETransferCharacteristics::BT601:
-        case ETransferCharacteristics::BT202010bit:
-        case ETransferCharacteristics::BT202012bit:
-        case ETransferCharacteristics::IEC61966_2_4: // handles negative values by mirroring
-        case ETransferCharacteristics::BT1361Extended: // extended to negative values (weirdly)
-        case ETransferCharacteristics::Gamma22:
-        case ETransferCharacteristics::Gamma28:
-        case ETransferCharacteristics::SMPTE240:
-        case ETransferCharacteristics::Linear:
-        case ETransferCharacteristics::Log100:
-        case ETransferCharacteristics::Log100Sqrt10:
-        case ETransferCharacteristics::SRGB:
-        case ETransferCharacteristics::PQ:
-        case ETransferCharacteristics::SMPTE428:
-        case ETransferCharacteristics::HLG:
-        case ETransferCharacteristics::Unspecified: return true;
+        case ETransfer::BT709:
+        case ETransfer::BT601:
+        case ETransfer::BT202010bit:
+        case ETransfer::BT202012bit:
+        case ETransfer::IEC61966_2_4: // handles negative values by mirroring
+        case ETransfer::BT1361Extended: // extended to negative values (weirdly)
+        case ETransfer::Gamma22:
+        case ETransfer::Gamma28:
+        case ETransfer::SMPTE240:
+        case ETransfer::Linear:
+        case ETransfer::Log100:
+        case ETransfer::Log100Sqrt10:
+        case ETransfer::SRGB:
+        case ETransfer::PQ:
+        case ETransfer::SMPTE428:
+        case ETransfer::HLG:
+        case ETransfer::Unspecified: return true;
     }
 
     return false;
 }
 
-ETransferCharacteristics fromWpTransfer(int wpTransfer) {
+ETransfer fromWpTransfer(int wpTransfer) {
     switch (wpTransfer) {
-        case 1: return ETransferCharacteristics::BT709;
-        case 2: return ETransferCharacteristics::Gamma22;
-        case 3: return ETransferCharacteristics::Gamma28;
-        case 4: return ETransferCharacteristics::SMPTE240;
-        case 5: return ETransferCharacteristics::Linear;
-        case 6: return ETransferCharacteristics::Log100;
-        case 7: return ETransferCharacteristics::Log100Sqrt10;
-        case 8: return ETransferCharacteristics::IEC61966_2_4;
-        case 9: return ETransferCharacteristics::SRGB;
-        case 10: return ETransferCharacteristics::SRGB; // TODO: handle the fact that this is the extended SRGB variant
-        case 11: return ETransferCharacteristics::PQ;
-        case 12: return ETransferCharacteristics::SMPTE428;
-        case 13: return ETransferCharacteristics::HLG;
+        case 1: return ETransfer::BT709;
+        case 2: return ETransfer::Gamma22;
+        case 3: return ETransfer::Gamma28;
+        case 4: return ETransfer::SMPTE240;
+        case 5: return ETransfer::Linear;
+        case 6: return ETransfer::Log100;
+        case 7: return ETransfer::Log100Sqrt10;
+        case 8: return ETransfer::IEC61966_2_4;
+        case 9: return ETransfer::SRGB;
+        case 10: return ETransfer::SRGB; // TODO: handle the fact that this is the extended SRGB variant
+        case 11: return ETransfer::PQ;
+        case 12: return ETransfer::SMPTE428;
+        case 13: return ETransfer::HLG;
     }
 
     throw std::invalid_argument{"Unknown transfer characteristics from color manager: " + std::to_string(wpTransfer)};
@@ -624,7 +624,7 @@ optional<ColorProfile::CICP> ColorProfile::cicp() const {
 
     return ColorProfile::CICP{
         .primaries = (ituth273::EColorPrimaries)cicp->ColourPrimaries,
-        .transfer = (ituth273::ETransferCharacteristics)cicp->TransferCharacteristics,
+        .transfer = (ituth273::ETransfer)cicp->TransferCharacteristics,
         .matrixCoeffs = cicp->MatrixCoefficients,
         .videoFullRangeFlag = cicp->VideoFullRangeFlag,
     };

--- a/src/imageio/HeifImageLoader.cpp
+++ b/src/imageio/HeifImageLoader.cpp
@@ -370,7 +370,7 @@ Task<vector<ImageData>>
             range = limitedRangeForBitsPerSample(bitsPerSample);
         }
 
-        auto cicpTransfer = static_cast<ituth273::ETransferCharacteristics>(nclx->transfer_characteristics);
+        auto cicpTransfer = static_cast<ituth273::ETransfer>(nclx->transfer_characteristics);
         tlog::debug() << fmt::format(
             "NCLX: primaries={}, transfer={}, full_range={}",
             ituth273::toString((ituth273::EColorPrimaries)nclx->color_primaries),
@@ -380,7 +380,7 @@ Task<vector<ImageData>>
 
         if (!ituth273::isTransferImplemented(cicpTransfer)) {
             tlog::warning() << fmt::format("Unsupported transfer '{}' in NCLX. Using sRGB instead.", ituth273::toString(cicpTransfer));
-            cicpTransfer = ituth273::ETransferCharacteristics::SRGB;
+            cicpTransfer = ituth273::ETransfer::SRGB;
         }
 
         auto* const pixelData = resultData.channels.front().floatData();

--- a/src/imageio/JxlImageLoader.cpp
+++ b/src/imageio/JxlImageLoader.cpp
@@ -521,14 +521,14 @@ Task<vector<ImageData>> JxlImageLoader::load(istream& iStream, const fs::path& p
                             tlog::debug() << fmt::format("gamma={}", ce->gamma);
                         }
 
-                        auto cicpTransfer = hasGamma ? ituth273::ETransferCharacteristics::Unspecified :
-                                                       static_cast<ituth273::ETransferCharacteristics>(ce->transfer_function);
+                        auto cicpTransfer = hasGamma ? ituth273::ETransfer::Unspecified :
+                                                       static_cast<ituth273::ETransfer>(ce->transfer_function);
 
                         if (!hasGamma) {
                             if (!ituth273::isTransferImplemented(cicpTransfer)) {
                                 tlog::warning()
                                     << fmt::format("Unsupported transfer '{}'. Using sRGB instead.", ituth273::toString(cicpTransfer));
-                                cicpTransfer = ituth273::ETransferCharacteristics::SRGB;
+                                cicpTransfer = ituth273::ETransfer::SRGB;
                             }
 
                             data.hdrMetadata.bestGuessWhiteLevel = ituth273::bestGuessReferenceWhiteLevel(cicpTransfer);

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -476,12 +476,12 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                 ) == PNG_INFO_cICP) {
 
                 const auto primaries = (ituth273::EColorPrimaries)cicp.colourPrimaries;
-                auto transfer = (ituth273::ETransferCharacteristics)cicp.transferFunction;
+                auto transfer = (ituth273::ETransfer)cicp.transferFunction;
 
                 if (!ituth273::isTransferImplemented(transfer)) {
                     tlog::warning()
                         << fmt::format("Unsupported transfer '{}' in cICP chunk. Using sRGB instead.", ituth273::toString(transfer));
-                    transfer = ituth273::ETransferCharacteristics::SRGB;
+                    transfer = ituth273::ETransfer::SRGB;
                 }
 
                 tlog::debug() << fmt::format(
@@ -619,7 +619,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
             resultData.hasPremultipliedAlpha = true;
 
             if (hasChunkChrm) {
-                const array<Vector2f, 4> chroma = {
+                const chroma_t chroma = {
                     {
                      {(float)ch[2], (float)ch[3]}, // red
                         {(float)ch[4], (float)ch[5]}, // green

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -922,10 +922,6 @@ Task<void> postprocessRgb(
         tlog::debug() << fmt::format("Found preview color space: {}", (uint32_t)pcsInt);
 
         const EPreviewColorSpace pcs = static_cast<EPreviewColorSpace>(pcsInt);
-        // if (pcs == EPreviewColorSpace::AdobeRGB || pcs == EPreviewColorSpace::ProPhotoRGB) {
-        //     tlog::warning(
-        //     ) << "Linearization from Adobe RGB and ProPhoto RGB is not implemented yet. Using inverse sRGB transfer function instead.";
-        // }
 
         size_t numPixels = (size_t)size.x() * size.y();
         co_await ThreadPool::global().parallelForAsync<size_t>(

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -867,7 +867,7 @@ Task<void> postprocessRgb(
 ) {
     const Vector2i size = resultData.size();
 
-    array<Vector2f, 4> chroma = rec709Chroma();
+    chroma_t chroma = rec709Chroma();
     if (float* primaries; TIFFGetField(tif, TIFFTAG_PRIMARYCHROMATICITIES, &primaries)) {
         tlog::debug() << "Found custom primaries; applying...";
         chroma[0] = {primaries[0], primaries[1]};

--- a/src/imageio/UltraHdrImageLoader.cpp
+++ b/src/imageio/UltraHdrImageLoader.cpp
@@ -54,14 +54,14 @@ static string toString(uhdr_color_gamut_t cg) {
     }
 }
 
-ituth273::ETransferCharacteristics toCicpTransfer(uhdr_color_transfer_t ct) {
+ituth273::ETransfer toCicpTransfer(uhdr_color_transfer_t ct) {
     switch (ct) {
-        case UHDR_CT_UNSPECIFIED: return ituth273::ETransferCharacteristics::Unspecified;
-        case UHDR_CT_LINEAR: return ituth273::ETransferCharacteristics::Linear;
-        case UHDR_CT_HLG: return ituth273::ETransferCharacteristics::HLG;
-        case UHDR_CT_PQ: return ituth273::ETransferCharacteristics::PQ;
-        case UHDR_CT_SRGB: return ituth273::ETransferCharacteristics::SRGB;
-        default: return ituth273::ETransferCharacteristics::Unspecified;
+        case UHDR_CT_UNSPECIFIED: return ituth273::ETransfer::Unspecified;
+        case UHDR_CT_LINEAR: return ituth273::ETransfer::Linear;
+        case UHDR_CT_HLG: return ituth273::ETransfer::HLG;
+        case UHDR_CT_PQ: return ituth273::ETransfer::PQ;
+        case UHDR_CT_SRGB: return ituth273::ETransfer::SRGB;
+        default: return ituth273::ETransfer::Unspecified;
     }
 }
 


### PR DESCRIPTION
Adds a GUI popup window for controlling the color space in which pixel values are displayed on hover, when zooming in, and in the histogram.

This is a generalization of https://github.com/Tom94/tev/pull/391