### PR TITLE
feat(ipc): ensure primary instance received all data sent

### DIFF
--- a/include/tev/Ipc.h
+++ b/include/tev/Ipc.h
@@ -270,6 +270,8 @@ public:
     Ipc(std::string_view hostname = "");
     virtual ~Ipc();
 
+    void sendRemainingDataAndDisconnectFromPrimaryInstance();
+
     bool isPrimaryInstance() const { return mIsPrimaryInstance; }
     bool isConnectedToPrimaryInstance() const;
 


### PR DESCRIPTION
Generally: makes shutdown of IPC connections more graceful. This is only relevant for corner cases and if the primary instance ever starts sending data to secondary instances. As **tev** behaves currently (one-way communication), shutdown should have already implicitly happened gracefully beforehand. This PR just makes it explicit.