### PR TITLE
fix(ipc): always little endian

### DIFF
--- a/src/Ipc.cpp
+++ b/src/Ipc.cpp
@@ -829,7 +829,10 @@ size_t Ipc::SocketConnection::service(function<void(const IpcPacket&)> callback)
         while (processedOffset + 4 <= mRecvOffset) {
             // There's at least enough to figure out the next message's length.
             const char* const messagePtr = mBuffer.data() + processedOffset;
-            const uint32_t messageLength = *((uint32_t*)messagePtr);
+            uint32_t messageLength = *((uint32_t*)messagePtr);
+            if constexpr (endian::native == endian::big) {
+                messageLength = swapBytes(messageLength);
+            }
 
             if (messageLength > mBuffer.size()) {
                 mBuffer.resize(messageLength);


### PR DESCRIPTION
Treats the IPC protocol as always being little endian (like the Python `tevclient` already does). I.e., tevclient will now be able to connect to tev instances running on big endian machines, and tev itself will be able to communicate across machines with different endianness.

In practice, little endian is already used on x86(_64) CPUs and on Apple silicon, so most users aren't effected by this.