### PR TITLE
fix(jxl): simplify box loading code & allow loading multiple boxes

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -376,6 +376,20 @@ public:
     const T* data() const { return mBuf.get(); }
 
     size_t size() const { return mSize; }
+    void resize(size_t newSize) {
+        if (newSize <= mSize) {
+            mSize = newSize;
+            return;
+        }
+
+        const auto oldBuf = std::move(mBuf);
+        mBuf = std::make_unique<T[]>(newSize);
+        if (oldBuf) {
+            std::copy_n(oldBuf.get(), mSize, mBuf.get());
+        }
+
+        mSize = newSize;
+    }
 
     operator std::span<const T>() const { return std::span<const T>{mBuf.get(), mSize}; }
     operator std::span<T>() { return std::span<T>{mBuf.get(), mSize}; }


### PR DESCRIPTION
Certain JXL images that carried both exif and xmp metadata incorrectly had their xmp metadata ignored. This PR fixes that (while also simplifying code).