### PR TITLE
CLI conversion

### DIFF
--- a/include/tev/Channel.h
+++ b/include/tev/Channel.h
@@ -36,6 +36,8 @@ public:
     using Data = HeapArray<uint8_t>;
 
     static std::pair<std::string_view, std::string_view> split(std::string_view fullChannel);
+    static std::string join(std::string_view layer, std::string_view channel);
+    static std::string joinIfNonempty(std::string_view layer, std::string_view channel);
 
     static std::string_view tail(std::string_view fullChannel);
     static std::string_view head(std::string_view fullChannel);

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -523,6 +523,21 @@ struct FlatpakInfo {
 
 const std::optional<FlatpakInfo>& flatpakInfo();
 
+enum class EAlphaKind {
+    // This refers to premultiplied alpha in nonlinear space, i.e. after a transfer function like gamma correction. This kind of
+    // premultiplied alpha has generally little use, since one should not blend in non-linear space. But, regrettably, some image formats
+    // represent premultiplied alpha this way. Our color management system (lcms2) for handling ICC color profiles unfortunately also
+    // expects this kind of premultiplied alpha, so we have to support it.
+    PremultipliedNonlinear,
+    // This refers to premultiplied alpha in linear space, i.e. before a transfer function like gamma correction. This is the most useful
+    // kind of premultiplied alpha.
+    Premultiplied,
+    Straight,
+    None,
+};
+
+std::string_view toString(EAlphaKind mode);
+
 enum EInterpolationMode : int {
     Nearest = 0,
     Bilinear,

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -455,6 +455,8 @@ std::string_view trimLeft(std::string_view s);
 std::string_view trimRight(std::string_view s);
 std::string_view trim(std::string_view s);
 
+std::string substituteCurly(std::string_view str, const std::function<std::string(std::string_view)>& replacer);
+
 bool matchesFuzzy(std::string_view text, std::string_view filter, size_t* matchedPartId = nullptr);
 bool matchesRegex(std::string_view text, std::string_view filter);
 inline bool matchesFuzzyOrRegex(std::string_view text, std::string_view filter, bool isRegex) {

--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -457,6 +457,8 @@ std::string_view trim(std::string_view s);
 
 std::string substituteCurly(std::string_view str, const std::function<std::string(std::string_view)>& replacer);
 
+nanogui::Color parseColor(std::string_view str);
+
 bool matchesFuzzy(std::string_view text, std::string_view filter, size_t* matchedPartId = nullptr);
 bool matchesRegex(std::string_view text, std::string_view filter);
 inline bool matchesFuzzyOrRegex(std::string_view text, std::string_view filter, bool isRegex) {

--- a/include/tev/FalseColor.h
+++ b/include/tev/FalseColor.h
@@ -18,8 +18,6 @@
 
 #pragma once
 
-#include <tev/Common.h>
-
 #include <span>
 
 namespace tev { namespace colormap {

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -205,7 +205,9 @@ public:
 
     const Box2i& dataWindow() const { return mData.dataWindow; }
     const Box2i& displayWindow() const { return mData.displayWindow; }
-    Box2i toImageCoords(const Box2i& displayWindow) const { return displayWindow.translate(mData.displayWindow.min - mData.dataWindow.min); }
+    Box2i toImageCoords(const Box2i& displayWindow) const {
+        return displayWindow.translate(mData.displayWindow.min - mData.dataWindow.min);
+    }
 
     float whiteLevel() const { return mData.hdrMetadata.bestGuessWhiteLevel; }
 
@@ -242,7 +244,13 @@ public:
         getHdrImageData(std::shared_ptr<Image> reference, std::string_view requestedChannelGroup, EMetric metric, int priority) const;
 
     Task<HeapArray<float>> getRgbaHdrImageData(
-        std::shared_ptr<Image> reference, const Box2i& imageRegion, std::string_view requestedChannelGroup, EMetric metric, bool divideAlpha, int priority
+        std::shared_ptr<Image> reference,
+        const Box2i& imageRegion,
+        std::string_view requestedChannelGroup,
+        EMetric metric,
+        const nanogui::Color& bg,
+        bool divideAlpha,
+        int priority
     ) const;
 
     Task<HeapArray<uint8_t>>
@@ -253,6 +261,7 @@ public:
         const Box2i& imageRegion,
         std::string_view requestedChannelGroup,
         EMetric metric,
+        const nanogui::Color& bg,
         bool divideAlpha,
         ETonemap tonemap,
         float gamma,
@@ -267,6 +276,7 @@ public:
         const Box2i& imageRegion,
         std::string_view requestedChannelGroup,
         EMetric metric,
+        const nanogui::Color& bg,
         ETonemap tonemap,
         float gamma,
         float exposure,

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -237,6 +237,26 @@ public:
 
     void setStaleIdCallback(const std::function<void(int)>& callback) { mStaleIdCallback = callback; }
 
+    Task<std::vector<Channel>>
+        getHdrImageData(std::shared_ptr<Image> reference, std::string_view requestedChannelGroup, EMetric metric, int priority) const;
+
+    Task<HeapArray<float>> getRgbaHdrImageData(
+        std::shared_ptr<Image> reference, const Box2i& imageRegion, std::string_view requestedChannelGroup, EMetric metric, bool divideAlpha, int priority
+    ) const;
+
+    Task<HeapArray<uint8_t>> getRgbaLdrImageData(
+        std::shared_ptr<Image> reference,
+        const Box2i& imageRegion,
+        std::string_view requestedChannelGroup,
+        EMetric metric,
+        ETonemap tonemap,
+        float gamma,
+        float exposure,
+        float offset,
+        bool divideAlpha,
+        int priority
+    ) const;
+
     std::string toString() const;
 
     std::span<const AttributeNode> attributes() const { return mData.attributes; }

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -205,6 +205,7 @@ public:
 
     const Box2i& dataWindow() const { return mData.dataWindow; }
     const Box2i& displayWindow() const { return mData.displayWindow; }
+    Box2i toImageCoords(const Box2i& displayWindow) const { return displayWindow.translate(mData.displayWindow.min - mData.dataWindow.min); }
 
     float whiteLevel() const { return mData.hdrMetadata.bestGuessWhiteLevel; }
 

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -244,7 +244,24 @@ public:
         std::shared_ptr<Image> reference, const Box2i& imageRegion, std::string_view requestedChannelGroup, EMetric metric, bool divideAlpha, int priority
     ) const;
 
+    Task<HeapArray<uint8_t>>
+        getRgbaLdrImageData(const HeapArray<float>& hdrData, ETonemap tonemap, float gamma, float exposure, float offset, int priority) const;
+
     Task<HeapArray<uint8_t>> getRgbaLdrImageData(
+        std::shared_ptr<Image> reference,
+        const Box2i& imageRegion,
+        std::string_view requestedChannelGroup,
+        EMetric metric,
+        bool divideAlpha,
+        ETonemap tonemap,
+        float gamma,
+        float exposure,
+        float offset,
+        int priority
+    ) const;
+
+    Task<void> save(
+        const fs::path& path,
         std::shared_ptr<Image> reference,
         const Box2i& imageRegion,
         std::string_view requestedChannelGroup,
@@ -253,7 +270,6 @@ public:
         float gamma,
         float exposure,
         float offset,
-        bool divideAlpha,
         int priority
     ) const;
 

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -114,7 +114,7 @@ public:
     // does not currently hold an image, or no channels are displayed, then zero pixels are returned.
     nanogui::Vector2i imageDataSize() const { return cropInImageCoords().size(); }
     Task<HeapArray<float>> getHdrImageData(bool divideAlpha, int priority) const;
-    Task<HeapArray<char>> getLdrImageData(bool divideAlpha, int priority) const;
+    Task<HeapArray<uint8_t>> getLdrImageData(bool divideAlpha, int priority) const;
 
     void saveImage(const fs::path& filename) const;
 

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -60,8 +60,6 @@ public:
     void setOffset(float offset) { mOffset = offset; }
     void setGamma(float gamma) { mGamma = gamma; }
 
-    float applyExposureAndOffset(float value) const;
-
     void setImage(std::shared_ptr<Image> image) { mImage = image; }
     void setReference(std::shared_ptr<Image> reference) { mReference = reference; }
     void setRequestedChannelGroup(std::string_view groupName) { mRequestedChannelGroup = groupName; }
@@ -79,14 +77,8 @@ public:
     ETonemap tonemap() const { return mTonemap; }
     void setTonemap(ETonemap tonemap) { mTonemap = tonemap; }
 
-    static nanogui::Vector3f applyTonemap(const nanogui::Vector3f& value, float gamma, ETonemap tonemap);
-    nanogui::Vector3f applyTonemap(const nanogui::Vector3f& value) const { return applyTonemap(value, mGamma, mTonemap); }
-
     EMetric metric() const { return mMetric; }
     void setMetric(EMetric metric) { mMetric = metric; }
-
-    static float applyMetric(float value, float reference, EMetric metric);
-    float applyMetric(float value, float reference) const { return applyMetric(value, reference, mMetric); }
 
     std::optional<Box2i> crop() { return mCrop; }
     void setCrop(const std::optional<Box2i>& crop) { mCrop = crop; }
@@ -141,10 +133,6 @@ public:
     void applyInspectionParameters(std::vector<float>& values, bool hasAlpha);
 
 private:
-    static Task<std::vector<Channel>> channelsFromImages(
-        std::shared_ptr<Image> image, std::shared_ptr<Image> reference, std::string_view requestedChannelGroup, EMetric metric, int priority
-    );
-
     static Task<std::shared_ptr<CanvasStatistics>> computeCanvasStatistics(
         std::shared_ptr<Image> image,
         std::shared_ptr<Image> reference,

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -105,8 +105,8 @@ public:
     // The following functions return four values per pixel in RGBA order. The number of pixels is given by `imageDataSize()`. If the canvas
     // does not currently hold an image, or no channels are displayed, then zero pixels are returned.
     nanogui::Vector2i imageDataSize() const { return cropInImageCoords().size(); }
-    Task<HeapArray<float>> getHdrImageData(bool divideAlpha, int priority) const;
-    Task<HeapArray<uint8_t>> getLdrImageData(bool divideAlpha, int priority) const;
+    Task<HeapArray<float>> getRgbaHdrImageData(bool divideAlpha, int priority) const;
+    Task<HeapArray<uint8_t>> getRgbaLdrImageData(bool divideAlpha, int priority) const;
 
     void saveImage(const fs::path& filename) const;
 
@@ -138,7 +138,7 @@ private:
         std::shared_ptr<Image> reference,
         std::string_view requestedChannelGroup,
         EMetric metric,
-        const Box2i& region,
+        Box2i region,
         const chroma_t& chroma,
         ituth273::ETransfer transfer,
         bool adaptWhitePoint,

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -31,6 +31,7 @@
 #include <tev/imageio/Colors.h>
 
 #include <nanogui/button.h>
+#include <nanogui/colorwheel.h>
 #include <nanogui/opengl.h>
 #include <nanogui/screen.h>
 #include <nanogui/slider.h>
@@ -130,6 +131,8 @@ public:
 
     EMetric metric() const { return mImageCanvas->metric(); }
     void setMetric(EMetric metric);
+
+    void setBackgroundColorStraight(const nanogui::Color& color);
 
     float displayWhiteLevel() const;
     void setDisplayWhiteLevel(float value);
@@ -330,13 +333,17 @@ private:
 
     std::optional<ColorSpace> mSystemColorSpace;
 
+    nanogui::PopupButton* mColorsPopupButton = nullptr;
+
     nanogui::ComboBox* mInspectionPrimariesComboBox = nullptr;
     std::vector<nanogui::FloatBox<float>*> mInspectionPrimariesBoxes;
     nanogui::ComboBox* mInspectionTransferComboBox = nullptr;
     nanogui::Button* mInspectionAdaptWhitePointButton = nullptr;
     nanogui::Button* mInspectionPremultipliedAlphaButton = nullptr;
 
-    nanogui::PopupButton* mColorsPopupButton = nullptr;
+    nanogui::ColorWheel* mBackgroundColorWheel = nullptr;
+    nanogui::Slider* mBackgroundAlphaSlider = nullptr;
+
     nanogui::PopupButton* mHdrPopupButton = nullptr;
     nanogui::Button* mClipToLdrButton = nullptr;
 

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -45,7 +45,9 @@ chroma_t zeroChroma();
 nanogui::Matrix3f xyzToChromaMatrix(const chroma_t& chroma);
 nanogui::Matrix3f adaptWhiteBradford(const nanogui::Vector2f& srcWhite, const nanogui::Vector2f& dstWhite);
 
-nanogui::Matrix3f convertColorspaceMatrix(const chroma_t& srcChroma, const chroma_t& dstChroma, ERenderingIntent intent);
+nanogui::Matrix3f convertColorspaceMatrix(
+    const chroma_t& srcChroma, const chroma_t& dstChroma, ERenderingIntent intent, std::optional<nanogui::Vector2f> adoptedNeutral = std::nullopt
+);
 
 nanogui::Vector2f whiteD50();
 nanogui::Vector2f whiteD55();

--- a/include/tev/imageio/Colors.h
+++ b/include/tev/imageio/Colors.h
@@ -377,19 +377,6 @@ inline float bestGuessReferenceWhiteLevel(const ETransfer transfer) {
 }
 } // namespace ituth273
 
-enum class EAlphaKind {
-    // This refers to premultiplied alpha in nonlinear space, i.e. after a transfer function like gamma correction. This kind of
-    // premultiplied alpha has generally little use, since one should not blend in non-linear space. But, regrettably, some image formats
-    // represent premultiplied alpha this way. Our color management system (lcms2) for handling ICC color profiles unfortunately also
-    // expects this kind of premultiplied alpha, so we have to support it.
-    PremultipliedNonlinear,
-    // This refers to premultiplied alpha in linear space, i.e. before a transfer function like gamma correction. This is the most useful
-    // kind of premultiplied alpha.
-    Premultiplied,
-    Straight,
-    None,
-};
-
 class ColorProfile {
 public:
     ColorProfile(void* profile) : mProfile{profile} {}

--- a/include/tev/imageio/ExrImageSaver.h
+++ b/include/tev/imageio/ExrImageSaver.h
@@ -18,9 +18,11 @@
 
 #pragma once
 
+#include <tev/Common.h>
 #include <tev/imageio/ImageSaver.h>
 
 #include <ostream>
+#include <string_view>
 
 namespace tev {
 
@@ -30,7 +32,7 @@ public:
         std::ostream& oStream, const fs::path& path, std::span<const float> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 
-    bool hasPremultipliedAlpha() const override { return true; }
+    EAlphaKind alphaKind(std::string_view) const override { return EAlphaKind::Premultiplied; }
 
     virtual bool canSaveFile(std::string_view extension) const override { return toLower(extension) == ".exr"; }
 };

--- a/include/tev/imageio/ExrImageSaver.h
+++ b/include/tev/imageio/ExrImageSaver.h
@@ -28,7 +28,7 @@ namespace tev {
 
 class ExrImageSaver : public TypedImageSaver<float> {
 public:
-    void save(
+    Task<void> save(
         std::ostream& oStream, const fs::path& path, std::span<const float> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -133,13 +133,12 @@ public:
         const nanogui::Vector2i& size,
         EPixelFormat format,
         EPixelFormat desiredFormat,
-        std::string_view namePrefix,
+        std::string_view layer,
         int priority
     );
 
-    static std::vector<Channel> makeNChannels(
-        int numChannels, const nanogui::Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, std::string_view namePrefix = ""
-    );
+    static std::vector<Channel>
+        makeNChannels(int numChannels, const nanogui::Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, std::string_view layer);
 
     static Task<void> resizeChannelsAsync(const std::vector<Channel>& srcChannels, std::vector<Channel>& dstChannels, int priority);
 };

--- a/include/tev/imageio/ImageSaver.h
+++ b/include/tev/imageio/ImageSaver.h
@@ -24,6 +24,7 @@
 
 #include <ostream>
 #include <span>
+#include <string_view>
 #include <vector>
 
 namespace tev {
@@ -34,7 +35,8 @@ class ImageSaver {
 public:
     virtual ~ImageSaver() {}
 
-    virtual bool hasPremultipliedAlpha() const = 0;
+    virtual EAlphaKind alphaKind(std::string_view extension) const = 0;
+    EAlphaKind alphaKind(const fs::path& path) const { return alphaKind(std::string_view{toLower(toString(path.extension()))}); }
 
     virtual bool canSaveFile(std::string_view extension) const = 0;
     bool canSaveFile(const fs::path& path) const { return canSaveFile(std::string_view{toLower(toString(path.extension()))}); }

--- a/include/tev/imageio/ImageSaver.h
+++ b/include/tev/imageio/ImageSaver.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <tev/Common.h>
+#include <tev/Task.h>
 
 #include <nanogui/vector.h>
 
@@ -46,7 +47,7 @@ public:
 
 template <typename T> class TypedImageSaver : public ImageSaver {
 public:
-    virtual void save(
+    virtual Task<void> save(
         std::ostream& oStream, const fs::path& path, std::span<const T> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const = 0;
 };

--- a/include/tev/imageio/JxlImageSaver.h
+++ b/include/tev/imageio/JxlImageSaver.h
@@ -28,7 +28,7 @@ namespace tev {
 
 class JxlImageSaver : public TypedImageSaver<float> {
 public:
-    void save(
+    Task<void> save(
         std::ostream& oStream, const fs::path& path, std::span<const float> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 

--- a/include/tev/imageio/JxlImageSaver.h
+++ b/include/tev/imageio/JxlImageSaver.h
@@ -18,9 +18,11 @@
 
 #pragma once
 
+#include <tev/Common.h>
 #include <tev/imageio/ImageSaver.h>
 
 #include <ostream>
+#include <string_view>
 
 namespace tev {
 
@@ -30,7 +32,10 @@ public:
         std::ostream& oStream, const fs::path& path, std::span<const float> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 
-    bool hasPremultipliedAlpha() const override { return true; }
+    // JXL images technically support straight alpha. And, if a non-linear transfer function is used, premultiplied alpha is of the
+    // non-linear kind. However, tev saves JXLs only as lossless HDR image storage, which always uses linear transfer functions and
+    // premultiplied alpha.
+    EAlphaKind alphaKind(std::string_view) const override { return EAlphaKind::Premultiplied; }
 
     virtual bool canSaveFile(std::string_view extension) const override { return toLower(extension) == ".jxl"; }
 };

--- a/include/tev/imageio/QoiImageSaver.h
+++ b/include/tev/imageio/QoiImageSaver.h
@@ -28,7 +28,7 @@ namespace tev {
 
 class QoiImageSaver : public TypedImageSaver<uint8_t> {
 public:
-    void save(
+    Task<void> save(
         std::ostream& oStream, const fs::path& path, std::span<const uint8_t> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 

--- a/include/tev/imageio/QoiImageSaver.h
+++ b/include/tev/imageio/QoiImageSaver.h
@@ -24,10 +24,10 @@
 
 namespace tev {
 
-class QoiImageSaver : public TypedImageSaver<char> {
+class QoiImageSaver : public TypedImageSaver<uint8_t> {
 public:
     void save(
-        std::ostream& oStream, const fs::path& path, std::span<const char> data, const nanogui::Vector2i& imageSize, int nChannels
+        std::ostream& oStream, const fs::path& path, std::span<const uint8_t> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 
     bool hasPremultipliedAlpha() const override { return false; }

--- a/include/tev/imageio/QoiImageSaver.h
+++ b/include/tev/imageio/QoiImageSaver.h
@@ -18,9 +18,11 @@
 
 #pragma once
 
+#include <tev/Common.h>
 #include <tev/imageio/ImageSaver.h>
 
 #include <ostream>
+#include <string_view>
 
 namespace tev {
 
@@ -30,7 +32,7 @@ public:
         std::ostream& oStream, const fs::path& path, std::span<const uint8_t> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 
-    bool hasPremultipliedAlpha() const override { return false; }
+    EAlphaKind alphaKind(std::string_view) const override { return EAlphaKind::Straight; }
 
     virtual bool canSaveFile(std::string_view extension) const override { return toLower(extension) == ".qoi"; }
 };

--- a/include/tev/imageio/StbiHdrImageSaver.h
+++ b/include/tev/imageio/StbiHdrImageSaver.h
@@ -18,9 +18,11 @@
 
 #pragma once
 
+#include <tev/Common.h>
 #include <tev/imageio/ImageSaver.h>
 
 #include <ostream>
+#include <string_view>
 
 namespace tev {
 
@@ -30,7 +32,7 @@ public:
         std::ostream& oStream, const fs::path& path, std::span<const float> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 
-    bool hasPremultipliedAlpha() const override { return false; }
+    EAlphaKind alphaKind(std::string_view) const override { return EAlphaKind::None; }
 
     virtual bool canSaveFile(std::string_view extension) const override { return toLower(extension) == ".hdr"; }
 };

--- a/include/tev/imageio/StbiHdrImageSaver.h
+++ b/include/tev/imageio/StbiHdrImageSaver.h
@@ -28,7 +28,7 @@ namespace tev {
 
 class StbiHdrImageSaver : public TypedImageSaver<float> {
 public:
-    void save(
+    Task<void> save(
         std::ostream& oStream, const fs::path& path, std::span<const float> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 

--- a/include/tev/imageio/StbiLdrImageSaver.h
+++ b/include/tev/imageio/StbiLdrImageSaver.h
@@ -18,9 +18,11 @@
 
 #pragma once
 
+#include <tev/Common.h>
 #include <tev/imageio/ImageSaver.h>
 
 #include <ostream>
+#include <string_view>
 
 namespace tev {
 
@@ -30,7 +32,13 @@ public:
         std::ostream& oStream, const fs::path& path, std::span<const uint8_t> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 
-    bool hasPremultipliedAlpha() const override { return false; }
+    EAlphaKind alphaKind(std::string_view extension) const override {
+        if (extension == ".png" || extension == ".tga" || extension == ".bmp") {
+            return EAlphaKind::Straight;
+        } else {
+            return EAlphaKind::None;
+        }
+    }
 
     virtual bool canSaveFile(std::string_view extension) const override {
         std::string lowerExtension = toLower(extension);

--- a/include/tev/imageio/StbiLdrImageSaver.h
+++ b/include/tev/imageio/StbiLdrImageSaver.h
@@ -28,7 +28,7 @@ namespace tev {
 
 class StbiLdrImageSaver : public TypedImageSaver<uint8_t> {
 public:
-    void save(
+    Task<void> save(
         std::ostream& oStream, const fs::path& path, std::span<const uint8_t> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 

--- a/include/tev/imageio/StbiLdrImageSaver.h
+++ b/include/tev/imageio/StbiLdrImageSaver.h
@@ -24,10 +24,10 @@
 
 namespace tev {
 
-class StbiLdrImageSaver : public TypedImageSaver<char> {
+class StbiLdrImageSaver : public TypedImageSaver<uint8_t> {
 public:
     void save(
-        std::ostream& oStream, const fs::path& path, std::span<const char> data, const nanogui::Vector2i& imageSize, int nChannels
+        std::ostream& oStream, const fs::path& path, std::span<const uint8_t> data, const nanogui::Vector2i& imageSize, int nChannels
     ) const override;
 
     bool hasPremultipliedAlpha() const override { return false; }

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -35,6 +35,16 @@ pair<string_view, string_view> Channel::split(string_view channel) {
     return {"", channel};
 }
 
+string Channel::join(string_view layer, string_view channel) { return fmt::format("{}.{}", layer, channel); }
+
+string Channel::joinIfNonempty(string_view layer, string_view channel) {
+    if (layer.empty()) {
+        return string{channel};
+    } else {
+        return Channel::join(layer, channel);
+    }
+}
+
 string_view Channel::tail(string_view channel) { return split(channel).second; }
 
 string_view Channel::head(string_view channel) { return split(channel).first; }

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -187,6 +187,33 @@ string_view trimRight(string_view s) {
 
 string_view trim(string_view s) { return trimRight(trimLeft(s)); }
 
+string substituteCurly(string_view str, const function<string(string_view)>& replacer) {
+    ostringstream result;
+    size_t pos = 0;
+    while (true) {
+        const size_t openBrace = str.find('{', pos);
+        if (openBrace == string::npos) {
+            result << str.substr(pos);
+            break;
+        }
+
+        result << str.substr(pos, openBrace - pos);
+        const size_t closeBrace = str.find('}', openBrace + 1);
+        if (closeBrace == string::npos) {
+            // No matching closing brace, append the rest of the string and break.
+            result << str.substr(openBrace);
+            break;
+        }
+
+        const string_view key = str.substr(openBrace + 1, closeBrace - openBrace - 1);
+        result << replacer(key);
+
+        pos = closeBrace + 1;
+    }
+
+    return result.str();
+}
+
 bool matchesFuzzy(string_view text, string_view filter, size_t* matchedPartId) {
     if (matchedPartId) {
         // Default value of 0. Is returned when the filter is empty, when there is no match, or when the filter is a regex.

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -158,9 +158,7 @@ vector<string_view> split(string_view text, string_view delim, bool inclusive) {
     return result;
 }
 
-vector<string_view> splitWhitespace(string_view s, bool inclusive) {
-    return split(s, ws, inclusive);
-}
+vector<string_view> splitWhitespace(string_view s, bool inclusive) { return split(s, ws, inclusive); }
 
 string toLower(string_view str) {
     string result{str};
@@ -187,9 +185,7 @@ string_view trimRight(string_view s) {
     return s;
 }
 
-string_view trim(string_view s) {
-    return trimRight(trimLeft(s));
-}
+string_view trim(string_view s) { return trimRight(trimLeft(s)); }
 
 bool matchesFuzzy(string_view text, string_view filter, size_t* matchedPartId) {
     if (matchedPartId) {
@@ -407,6 +403,16 @@ const optional<FlatpakInfo>& flatpakInfo() {
 
     static optional<FlatpakInfo> sFlatpakInfo = getFlatpakInfo();
     return sFlatpakInfo;
+}
+
+string_view toString(EAlphaKind kind) {
+    switch (kind) {
+        case EAlphaKind::PremultipliedNonlinear: return "premultiplied_nonlinear";
+        case EAlphaKind::Premultiplied: return "premultiplied";
+        case EAlphaKind::Straight: return "straight";
+        case EAlphaKind::None: return "none";
+        default: throw runtime_error{"Unknown alpha kind."};
+    }
 }
 
 EInterpolationMode toInterpolationMode(string_view name) {

--- a/src/FalseColor.cpp
+++ b/src/FalseColor.cpp
@@ -18,6 +18,9 @@
 
 #include <tev/FalseColor.h>
 
+#include <span>
+#include <vector>
+
 using namespace std;
 
 namespace tev {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1184,10 +1184,10 @@ Task<void> Image::save(
         const auto rgbaHdrData = co_await getRgbaHdrImageData(reference, imageRegion, requestedChannelGroup, metric, divideAlpha, priority);
 
         if (hdrSaver) {
-            hdrSaver->save(f, path, rgbaHdrData, size, 4);
+            co_await hdrSaver->save(f, path, rgbaHdrData, size, 4);
         } else if (ldrSaver) {
             const auto rgbaLdrData = co_await getRgbaLdrImageData(rgbaHdrData, tonemap, gamma, exposure, offset, priority);
-            ldrSaver->save(f, path, rgbaLdrData, size, 4);
+            co_await ldrSaver->save(f, path, rgbaLdrData, size, 4);
         } else {
             TEV_ASSERT(false, "Each image saver must either be a HDR or an LDR saver.");
         }

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1055,7 +1055,7 @@ Task<HeapArray<float>> Image::getRgbaHdrImageData(
             int yresult = y - imageRegion.min.y();
             for (int x = imageRegion.min.x(); x < imageRegion.max.x(); ++x) {
                 for (int c = 0; c < 4; ++c) {
-                    const float val = c < nChannelsToSave ? channels[c].at({x, y}) : c == 3 ? 1.0f : 0.0f;
+                    const float val = c < nChannelsToSave ? channels[c].eval({x, y}) : c == 3 ? 1.0f : 0.0f;
                     const int xresult = x - imageRegion.min.x();
                     result[(yresult * imageRegion.size().x() + xresult) * 4 + c] = val;
                 }
@@ -1071,8 +1071,8 @@ Task<HeapArray<float>> Image::getRgbaHdrImageData(
             numPixels,
             numPixels * 4,
             [&result](size_t j) {
-                float alpha = result[j * 4 + 3];
-                float factor = alpha == 0 ? 0 : 1 / alpha;
+                const float alpha = result[j * 4 + 3];
+                const float factor = alpha == 0 ? 0 : 1 / alpha;
                 for (int c = 0; c < 3; ++c) {
                     result[j * 4 + c] *= factor;
                 }

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1180,8 +1180,8 @@ Task<void> Image::save(
         const auto* hdrSaver = dynamic_cast<const TypedImageSaver<float>*>(saver.get());
         const auto* ldrSaver = dynamic_cast<const TypedImageSaver<uint8_t>*>(saver.get());
 
-        const auto rgbaHdrData =
-            co_await getRgbaHdrImageData(reference, imageRegion, requestedChannelGroup, metric, !saver->hasPremultipliedAlpha(), priority);
+        const bool divideAlpha = saver->alphaKind(path) == EAlphaKind::Straight;
+        const auto rgbaHdrData = co_await getRgbaHdrImageData(reference, imageRegion, requestedChannelGroup, metric, divideAlpha, priority);
 
         if (hdrSaver) {
             hdrSaver->save(f, path, rgbaHdrData, size, 4);

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -454,11 +454,15 @@ Task<void> ImageData::ensureValid(string_view channelSelector, int taskPriority)
         displayWindow = channels.front().size();
     }
 
-    for (const auto& c : channels) {
+    for (auto& c : channels) {
         if (c.size() != size()) {
             throw ImageLoadError{
                 fmt::format("All channels must have the same size as the data window. ({}: {} != {})", c.name(), c.size(), size())
             };
+        }
+
+        if (!c.name().starts_with(partName)) {
+            c.setName(Channel::joinIfNonempty(partName, c.name()));
         }
     }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1164,8 +1164,6 @@ Task<void> Image::save(
         throw ImageSaveError{"Can not save image with zero pixels."};
     }
 
-    const auto start = chrono::steady_clock::now();
-
     ofstream f{path, ios_base::binary};
     if (!f) {
         throw ImageSaveError{fmt::format("Could not open file {}", path)};
@@ -1191,9 +1189,6 @@ Task<void> Image::save(
             TEV_ASSERT(false, "Each image saver must either be a HDR or an LDR saver.");
         }
 
-        const auto elapsedSeconds = chrono::duration<double>{chrono::steady_clock::now() - start};
-
-        tlog::success() << fmt::format("Saved {} after {:.3f} seconds.", path, elapsedSeconds.count());
         co_return;
     }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1164,7 +1164,6 @@ Task<void> Image::save(
         throw ImageSaveError{"Can not save image with zero pixels."};
     }
 
-    tlog::info() << "Saving currently displayed image as " << path << ".";
     const auto start = chrono::steady_clock::now();
 
     ofstream f{path, ios_base::binary};

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -616,7 +616,9 @@ Task<HeapArray<float>> ImageCanvas::getRgbaHdrImageData(bool divideAlpha, int pr
         co_return {};
     }
 
-    co_return co_await mImage->getRgbaHdrImageData(mReference, cropInImageCoords(), mRequestedChannelGroup, mMetric, divideAlpha, priority);
+    co_return co_await mImage->getRgbaHdrImageData(
+        mReference, cropInImageCoords(), mRequestedChannelGroup, mMetric, mBackgroundColor, divideAlpha, priority
+    );
 }
 
 Task<HeapArray<uint8_t>> ImageCanvas::getRgbaLdrImageData(bool divideAlpha, int priority) const {
@@ -625,7 +627,7 @@ Task<HeapArray<uint8_t>> ImageCanvas::getRgbaLdrImageData(bool divideAlpha, int 
     }
 
     co_return co_await mImage->getRgbaLdrImageData(
-        mReference, cropInImageCoords(), mRequestedChannelGroup, mMetric, divideAlpha, mTonemap, mGamma, mExposure, mOffset, priority
+        mReference, cropInImageCoords(), mRequestedChannelGroup, mMetric, mBackgroundColor, divideAlpha, mTonemap, mGamma, mExposure, mOffset, priority
     );
 }
 
@@ -645,6 +647,7 @@ void ImageCanvas::saveImage(const fs::path& path) const {
             cropInImageCoords(),
             mRequestedChannelGroup,
             mMetric,
+            mBackgroundColor,
             mTonemap,
             mGamma,
             mExposure,

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -636,6 +636,7 @@ void ImageCanvas::saveImage(const fs::path& path) const {
         throw ImageSaveError{"There is no image to save."};
     }
 
+    tlog::info() << "Saving currently displayed image as " << path << ".";
     mImage
         ->save(
             path,

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -637,6 +637,9 @@ void ImageCanvas::saveImage(const fs::path& path) const {
     }
 
     tlog::info() << "Saving currently displayed image as " << path << ".";
+
+    const auto start = chrono::steady_clock::now();
+
     mImage
         ->save(
             path,
@@ -651,6 +654,9 @@ void ImageCanvas::saveImage(const fs::path& path) const {
             numeric_limits<int>::max() // Use maximum priority for saving images.
         )
         .get();
+
+    const auto elapsedSeconds = chrono::duration<double>{chrono::steady_clock::now() - start};
+    tlog::success() << fmt::format("Saved {} after {:.3f} seconds.", path, elapsedSeconds.count());
 }
 
 shared_ptr<Lazy<shared_ptr<CanvasStatistics>>> ImageCanvas::canvasStatistics() {

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -596,9 +596,7 @@ Box2i ImageCanvas::cropInImageCoords() const {
         return Box2i{0};
     }
 
-    const auto region =
-        (mCrop.has_value() ? *mCrop : mImage->displayWindow()).translate(mImage->displayWindow().min - mImage->dataWindow().min);
-
+    const auto region = mImage->toImageCoords(mCrop.has_value() ? *mCrop : mImage->displayWindow());
     if (!region.isValid()) {
         return Box2i{0};
     }
@@ -814,7 +812,8 @@ Task<shared_ptr<CanvasStatistics>> ImageCanvas::computeCanvasStatistics(
     }
 
     const auto result = make_shared<CanvasStatistics>();
-    const size_t nColorChannels = result->nChannels = (int)(alphaChannel ? (flattened.size() - 1) : flattened.size());
+    const size_t nColorChannels = alphaChannel ? (flattened.size() - 1) : flattened.size();
+    result->nChannels = (int)nColorChannels;
 
     result->histogramColors.resize(nColorChannels);
     for (size_t i = 0; i < nColorChannels; ++i) {

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -2388,6 +2388,7 @@ void ImageViewer::copyImageCanvasToClipboard() const {
         throw std::runtime_error{"clip::set_image failed."};
     }
 #else
+    // TODO: make a dedicated PNG saver via libpng which should be faster than stb_image_write.
     const auto pngImageSaver = make_unique<StbiLdrImageSaver>();
 
     stringstream pngData;

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -2393,7 +2393,7 @@ void ImageViewer::copyImageCanvasToClipboard() const {
 
     stringstream pngData;
     try {
-        pngImageSaver->save(pngData, "clipboard.png", imageData, imageSize, 4);
+        pngImageSaver->save(pngData, "clipboard.png", imageData, imageSize, 4).get();
     } catch (const ImageSaveError& e) {
         throw std::runtime_error{fmt::format("Failed to save image data to clipboard as PNG: {}", e.what())};
     }

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -2364,7 +2364,7 @@ void ImageViewer::copyImageCanvasToClipboard() const {
         throw std::runtime_error{"Image canvas has no image data to copy to clipboard."};
     }
 
-    const auto imageData = mImageCanvas->getLdrImageData(true, std::numeric_limits<int>::max()).get();
+    const auto imageData = mImageCanvas->getRgbaLdrImageData(true, std::numeric_limits<int>::max()).get();
 
 #if defined(__APPLE__) or defined(_WIN32)
     clip::image_spec imageMetadata;

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -423,36 +423,21 @@ ImageViewer::ImageViewer(
             addSpacer(popup, 20);
 
             new Label{popup, "Background color", "sans-bold", 20};
-            auto colorwheel = new ColorWheel{popup, mImageCanvas->backgroundColor()};
+            mBackgroundColorWheel = new ColorWheel{popup};
+            mBackgroundColorWheel->set_callback([this](const Color& value) {
+                const float a = mBackgroundAlphaSlider->value();
+                mImageCanvas->setBackgroundColor(Color{value.r() * a, value.g() * a, value.b() * a, a});
+            });
 
             new Label{popup, "Background alpha"};
-            auto bgAlphaSlider = new Slider{popup};
-            bgAlphaSlider->set_range({0.0f, 1.0f});
-            bgAlphaSlider->set_callback([colorwheel, this](float a) {
-                const auto col = colorwheel->color();
-                mImageCanvas->setBackgroundColor(
-                    Color{
-                        col.r() * a,
-                        col.g() * a,
-                        col.b() * a,
-                        a,
-                    }
-                );
+            mBackgroundAlphaSlider = new Slider{popup};
+            mBackgroundAlphaSlider->set_range({0.0f, 1.0f});
+            mBackgroundAlphaSlider->set_callback([this](float a) {
+                const auto col = mBackgroundColorWheel->color();
+                mImageCanvas->setBackgroundColor(Color{col.r() * a, col.g() * a, col.b() * a, a});
             });
 
-            bgAlphaSlider->set_value(0);
-
-            colorwheel->set_callback([bgAlphaSlider, this](const Color& value) {
-                const float a = bgAlphaSlider->value();
-                mImageCanvas->setBackgroundColor(
-                    Color{
-                        value.r() * a,
-                        value.g() * a,
-                        value.b() * a,
-                        a,
-                    }
-                );
-            });
+            setBackgroundColorStraight(Color{0, 0, 0, 0});
         }
     }
 
@@ -1980,6 +1965,14 @@ void ImageViewer::setMetric(EMetric metric) {
         Button* b = dynamic_cast<Button*>(buttons[i]);
         b->set_pushed((EMetric)i == metric);
     }
+}
+
+void ImageViewer::setBackgroundColorStraight(const Color& color) {
+    mBackgroundColorWheel->set_color(color);
+    mBackgroundAlphaSlider->set_value(color.a());
+
+    const Color premul = Color{color.r() * color.a(), color.g() * color.a(), color.b() * color.a(), color.a()};
+    mImageCanvas->setBackgroundColor(premul);
 }
 
 float ImageViewer::displayWhiteLevel() const { return mDisplayWhiteLevelBox->value(); }

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -568,32 +568,29 @@ Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const fs::path& p
                 // AbsoluteColorimetric (no white point adaptation) is the intended behavior.
                 data.renderingIntent = ERenderingIntent::AbsoluteColorimetric;
 
-                // While OpenEXR images *can* have embedded `adoptedNeutral` values, those are to be used as suggested starting points for
-                // creative color grading (e.g. as a starting point for white balance adjustments) and not as actual white points for color
-                // space conversions.
+                // OpenEXR files may specify an "adoptedNeutral" white point that is meant to be rendered as neutral white. If this is the
+                // case, we want white point adaptation after all and switch to RelativeColorimetric.
+                optional<Vector2f> adoptedNeutral = nullopt;
                 if (Imf::hasAdoptedNeutral(part.header())) {
-                    const auto adoptedNeutral = Imf::adoptedNeutral(part.header());
-                    tlog::debug() << fmt::format(
-                        "EXR part '{}' has adopted neutral at ({}, {}). Ignoring for color space conversion.",
-                        part.header().name(),
-                        adoptedNeutral[0],
-                        adoptedNeutral[1]
-                    );
+                    const auto an = Imf::adoptedNeutral(part.header());
+
+                    adoptedNeutral = Vector2f{an.x, an.y};
+                    data.renderingIntent = ERenderingIntent::RelativeColorimetric;
+
+                    tlog::debug() << fmt::format("EXR part '{}' has adopted neutral {}. Adapting white.", data.partName, *adoptedNeutral);
                 }
 
+                chroma_t chroma = rec709Chroma(); // Assumption: EXR images are Rec. 709 unless specified otherwise
                 if (Imf::hasChromaticities(part.header())) {
-                    auto chroma = Imf::chromaticities(part.header());
-                    data.toRec709 = convertColorspaceMatrix(
-                        {
-                            {{chroma.red.x, chroma.red.y},
-                             {chroma.green.x, chroma.green.y},
-                             {chroma.blue.x, chroma.blue.y},
-                             {chroma.white.x, chroma.white.y}}
-                    },
-                        rec709Chroma(),
-                        data.renderingIntent
-                    );
+                    const auto c = Imf::chromaticities(part.header());
+                    chroma = {
+                        {{c.red.x, c.red.y}, {c.green.x, c.green.y}, {c.blue.x, c.blue.y}, {c.white.x, c.white.y}},
+                    };
+
+                    tlog::debug() << fmt::format("EXR part '{}' has chromaticities {}.", data.partName, chroma);
                 }
+
+                data.toRec709 = convertColorspaceMatrix(chroma, rec709Chroma(), data.renderingIntent, adoptedNeutral);
             } catch (const Iex::BaseExc& e) {
                 tlog::warning() << "Error reading EXR part " << partIdx << ": " << e.what();
 

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -468,12 +468,8 @@ Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const fs::path& p
 
             const Imf::ChannelList& imfChannels = part.header().channels();
 
-            auto channelName = [&](Imf::ChannelList::ConstIterator c) {
-                string name = c.name();
-                if (part.header().hasName()) {
-                    name = part.header().name() + "."s + name;
-                }
-                return name;
+            const auto channelName = [&](Imf::ChannelList::ConstIterator c) {
+                return part.header().hasName() ? Channel::join(part.header().name(), c.name()) : c.name();
             };
 
             Imath::Box2i dataWindow = part.header().dataWindow();
@@ -486,7 +482,7 @@ Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const fs::path& p
 
             bool matched = false;
             for (Imf::ChannelList::ConstIterator c = imfChannels.begin(); c != imfChannels.end(); ++c) {
-                string name = channelName(c);
+                const string name = channelName(c);
                 if (matchesFuzzy(name, channelSelector)) {
                     rawChannels.emplace_back(parts.size(), name, c.name(), c.channel(), size);
                     matched = true;

--- a/src/imageio/ExrImageSaver.cpp
+++ b/src/imageio/ExrImageSaver.cpp
@@ -70,8 +70,8 @@ private:
     ostream& mStream;
 };
 
-void ExrImageSaver::save(ostream& oStream, const fs::path& path, span<const float> data, const Vector2i& imageSize, int nChannels) const {
-    vector<string> channelNames = {
+Task<void> ExrImageSaver::save(ostream& oStream, const fs::path& path, span<const float> data, const Vector2i& imageSize, int nChannels) const {
+    const vector<string> channelNames = {
         "R",
         "G",
         "B",
@@ -102,6 +102,8 @@ void ExrImageSaver::save(ostream& oStream, const fs::path& path, span<const floa
     Imf::OutputFile file{imfOStream, header};
     file.setFrameBuffer(frameBuffer);
     file.writePixels(imageSize.y());
+
+    co_return;
 }
 
 } // namespace tev

--- a/src/imageio/ImageLoader.cpp
+++ b/src/imageio/ImageLoader.cpp
@@ -82,25 +82,33 @@ const vector<unique_ptr<ImageLoader>>& ImageLoader::getLoaders() {
 
 const vector<string_view>& ImageLoader::supportedMimeTypes() {
     static const vector<string_view> mimeTypes = {
-        "image/png",
-        "image/webp",
-        "image/jpeg",
-        "image/tiff",
-        "image/gif",
-        "image/tga",
-        "image/bmp",
 #ifdef TEV_SUPPORT_AVIF
         "image/avif",
 #endif
+        "image/apng",
+        "image/bmp",
+        "image/gif",
 #ifdef TEV_SUPPORT_HEIC
         "image/heic",
+        "image/heif",
 #endif
+        "image/jpeg",
+        "image/jxl",
+        "image/png",
+        "image/qoi",
+        "image/tga",
+        "image/tiff",
+        "image/vnd.mozilla.apng",
+        "image/vnd.radiance",
+        "image/webp",
+        "image/x-adobe-dng",
 #ifdef _WIN32
         "image/x-dds",
         "image/x-direct-draw-surface",
 #endif
-        "image/x-adobe-dng",
         "image/x-exr",
+        "image/x-hdr",
+        "image/x-pfm",
         "image/x-portable-anymap",
         "image/x-portable-arbitrarymap",
         "image/x-portable-bitmap",
@@ -168,9 +176,8 @@ Task<vector<Channel>> ImageLoader::makeRgbaInterleavedChannels(
     co_return channels;
 }
 
-vector<Channel> ImageLoader::makeNChannels(
-    int numChannels, const Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, string_view layer
-) {
+vector<Channel>
+    ImageLoader::makeNChannels(int numChannels, const Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, string_view layer) {
     vector<Channel> channels;
     for (int c = 0; c < numChannels; ++c) {
         channels.emplace_back(to_string(c), size, format, desiredFormat);

--- a/src/imageio/ImageLoader.cpp
+++ b/src/imageio/ImageLoader.cpp
@@ -113,21 +113,21 @@ const vector<string_view>& ImageLoader::supportedMimeTypes() {
 }
 
 Task<vector<Channel>> ImageLoader::makeRgbaInterleavedChannels(
-    int numChannels, bool hasAlpha, const Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, string_view namePrefix, int priority
+    int numChannels, bool hasAlpha, const Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, string_view layer, int priority
 ) {
     vector<Channel> channels;
     if (numChannels > 4) {
         throw ImageLoadError{"Image has too many RGBA channels."};
     }
 
-    int numColorChannels = numChannels - (hasAlpha ? 1 : 0);
+    const int numColorChannels = numChannels - (hasAlpha ? 1 : 0);
     if (numColorChannels <= 0 || numColorChannels > 3) {
         throw ImageLoadError{fmt::format("Image has invalid number of color channels: {}", numColorChannels)};
     }
 
     const size_t numPixels = (size_t)size.x() * size.y();
     const size_t numBytesPerSample = nBytes(format);
-    auto data = make_shared<Channel::Data>(numBytesPerSample * numPixels * 4);
+    const auto data = make_shared<Channel::Data>(numBytesPerSample * numPixels * 4);
 
     // Initialize pattern [0,0,0,1] efficiently using multi-byte writes
     const auto init = [numPixels, priority](auto* ptr) -> Task<void> {
@@ -149,28 +149,35 @@ Task<vector<Channel>> ImageLoader::makeRgbaInterleavedChannels(
     if (numColorChannels > 1) {
         const vector<string_view> channelNames = {"R", "G", "B"};
         for (int c = 0; c < numColorChannels; ++c) {
-            string name = fmt::format("{}{}", namePrefix, (c < (int)channelNames.size() ? channelNames[c] : to_string(c)));
-
-            // We assume that the channels are interleaved.
-            channels.emplace_back(name, size, format, desiredFormat, data, c * numBytesPerSample, 4 * numBytesPerSample);
+            channels.emplace_back(
+                c < (int)channelNames.size() ? channelNames[c] : to_string(c), size, format, desiredFormat, data, c * numBytesPerSample, 4 * numBytesPerSample
+            );
         }
     } else {
-        channels.emplace_back(fmt::format("{}L", namePrefix), size, format, desiredFormat, data, 0, 4 * numBytesPerSample);
+        channels.emplace_back("L", size, format, desiredFormat, data, 0, 4 * numBytesPerSample);
     }
 
     if (hasAlpha) {
-        channels.emplace_back(fmt::format("{}A", namePrefix), size, format, desiredFormat, data, 3 * numBytesPerSample, 4 * numBytesPerSample);
+        channels.emplace_back("A", size, format, desiredFormat, data, 3 * numBytesPerSample, 4 * numBytesPerSample);
+    }
+
+    for (auto& channel : channels) {
+        channel.setName(Channel::joinIfNonempty(layer, channel.name()));
     }
 
     co_return channels;
 }
 
 vector<Channel> ImageLoader::makeNChannels(
-    int numChannels, const Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, string_view namePrefix
+    int numChannels, const Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, string_view layer
 ) {
     vector<Channel> channels;
     for (int c = 0; c < numChannels; ++c) {
-        channels.emplace_back(fmt::format("{}{}", namePrefix, to_string(c)), size, format, desiredFormat);
+        channels.emplace_back(to_string(c), size, format, desiredFormat);
+    }
+
+    for (auto& channel : channels) {
+        channel.setName(Channel::joinIfNonempty(layer, channel.name()));
     }
 
     return channels;

--- a/src/imageio/QoiImageSaver.cpp
+++ b/src/imageio/QoiImageSaver.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 namespace tev {
 
-void QoiImageSaver::save(ostream& oStream, const fs::path&, span<const uint8_t> data, const Vector2i& imageSize, int nChannels) const {
+Task<void> QoiImageSaver::save(ostream& oStream, const fs::path&, span<const uint8_t> data, const Vector2i& imageSize, int nChannels) const {
     // The QOI image format expects nChannels to be either 3 for RGB data or 4 for RGBA.
     if (nChannels != 4 && nChannels != 3) {
         throw ImageSaveError{fmt::format("Invalid number of channels {}.", nChannels)};
@@ -41,16 +41,19 @@ void QoiImageSaver::save(ostream& oStream, const fs::path&, span<const uint8_t> 
         .channels = static_cast<unsigned char>(nChannels),
         .colorspace = QOI_SRGB,
     };
-    int sizeInBytes = 0;
-    void* encodedData = qoi_encode(data.data(), &desc, &sizeInBytes);
 
-    ScopeGuard encodedDataGuard{[encodedData] { free(encodedData); }};
+    int sizeInBytes = 0;
+    void* const encodedData = qoi_encode(data.data(), &desc, &sizeInBytes);
+
+    const ScopeGuard encodedDataGuard{[encodedData] { free(encodedData); }};
 
     if (!encodedData) {
         throw ImageSaveError{"Failed to encode data into the QOI format."};
     }
 
     oStream.write(reinterpret_cast<char*>(encodedData), sizeInBytes);
+
+    co_return;
 }
 
 } // namespace tev

--- a/src/imageio/QoiImageSaver.cpp
+++ b/src/imageio/QoiImageSaver.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 namespace tev {
 
-void QoiImageSaver::save(ostream& oStream, const fs::path&, span<const char> data, const Vector2i& imageSize, int nChannels) const {
+void QoiImageSaver::save(ostream& oStream, const fs::path&, span<const uint8_t> data, const Vector2i& imageSize, int nChannels) const {
     // The QOI image format expects nChannels to be either 3 for RGB data or 4 for RGBA.
     if (nChannels != 4 && nChannels != 3) {
         throw ImageSaveError{fmt::format("Invalid number of channels {}.", nChannels)};

--- a/src/imageio/StbiHdrImageSaver.cpp
+++ b/src/imageio/StbiHdrImageSaver.cpp
@@ -28,12 +28,14 @@ using namespace std;
 
 namespace tev {
 
-void StbiHdrImageSaver::save(ostream& oStream, const fs::path&, span<const float> data, const Vector2i& imageSize, int nChannels) const {
+Task<void> StbiHdrImageSaver::save(ostream& oStream, const fs::path&, span<const float> data, const Vector2i& imageSize, int nChannels) const {
     static const auto stbiOStreamWrite = [](void* context, void* stbidata, int size) {
         reinterpret_cast<ostream*>(context)->write(reinterpret_cast<char*>(stbidata), size);
     };
 
     stbi_write_hdr_to_func(stbiOStreamWrite, &oStream, imageSize.x(), imageSize.y(), nChannels, data.data());
+
+    co_return;
 }
 
 } // namespace tev

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -84,17 +84,17 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
     vector<ImageData> result(numFrames);
     for (int frameIdx = 0; frameIdx < numFrames; ++frameIdx) {
         ImageData& resultData = result[frameIdx];
-
-        // Unless the image is a .hdr file, it's 8 bits per channel, so we can comfortably fit it into F16.
-        resultData.channels = co_await makeRgbaInterleavedChannels(
-            numChannels, numChannels == 4, size, EPixelFormat::F32, isHdr ? EPixelFormat::F32 : EPixelFormat::F16, "", priority
-        );
-        resultData.hasPremultipliedAlpha = false;
         if (numFrames > 1) {
             resultData.partName = fmt::format("frames.{}", frameIdx);
         }
 
-        auto numPixels = (size_t)size.x() * size.y();
+        // Unless the image is a .hdr file, it's 8 bits per channel, so we can comfortably fit it into F16.
+        resultData.channels = co_await makeRgbaInterleavedChannels(
+            numChannels, numChannels == 4, size, EPixelFormat::F32, isHdr ? EPixelFormat::F32 : EPixelFormat::F16, resultData.partName, priority
+        );
+        resultData.hasPremultipliedAlpha = false;
+
+        const auto numPixels = (size_t)size.x() * size.y();
         if (isHdr) {
             // Treated like EXR: scene-referred by nature. Usually corresponds to linear light, so should not get its white point adjusted.
             resultData.renderingIntent = ERenderingIntent::AbsoluteColorimetric;

--- a/src/imageio/StbiLdrImageSaver.cpp
+++ b/src/imageio/StbiLdrImageSaver.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 namespace tev {
 
-void StbiLdrImageSaver::save(ostream& oStream, const fs::path& path, span<const char> data, const Vector2i& imageSize, int nChannels) const {
+void StbiLdrImageSaver::save(ostream& oStream, const fs::path& path, span<const uint8_t> data, const Vector2i& imageSize, int nChannels) const {
     static const auto stbiOStreamWrite = [](void* context, void* stbidata, int size) {
         reinterpret_cast<ostream*>(context)->write(reinterpret_cast<char*>(stbidata), size);
     };

--- a/src/imageio/StbiLdrImageSaver.cpp
+++ b/src/imageio/StbiLdrImageSaver.cpp
@@ -34,7 +34,7 @@ void StbiLdrImageSaver::save(ostream& oStream, const fs::path& path, span<const 
         reinterpret_cast<ostream*>(context)->write(reinterpret_cast<char*>(stbidata), size);
     };
 
-    auto extension = toLower(toString(path.extension()));
+    const auto extension = toLower(toString(path.extension()));
 
     if (extension == ".jpg" || extension == ".jpeg") {
         stbi_write_jpg_to_func(stbiOStreamWrite, &oStream, imageSize.x(), imageSize.y(), nChannels, data.data(), 100);

--- a/src/imageio/StbiLdrImageSaver.cpp
+++ b/src/imageio/StbiLdrImageSaver.cpp
@@ -29,7 +29,8 @@ using namespace std;
 
 namespace tev {
 
-void StbiLdrImageSaver::save(ostream& oStream, const fs::path& path, span<const uint8_t> data, const Vector2i& imageSize, int nChannels) const {
+Task<void>
+    StbiLdrImageSaver::save(ostream& oStream, const fs::path& path, span<const uint8_t> data, const Vector2i& imageSize, int nChannels) const {
     static const auto stbiOStreamWrite = [](void* context, void* stbidata, int size) {
         reinterpret_cast<ostream*>(context)->write(reinterpret_cast<char*>(stbidata), size);
     };
@@ -47,6 +48,8 @@ void StbiLdrImageSaver::save(ostream& oStream, const fs::path& path, span<const 
     } else {
         throw ImageSaveError{fmt::format("Image {} has unknown format.", path)};
     }
+
+    co_return;
 }
 
 } // namespace tev

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -456,7 +456,7 @@ static int mainFunc(span<const string> arguments) {
         return -3;
     }
 
-    auto ipc = convertToFlag ? nullptr : (hostnameFlag ? make_shared<Ipc>(get(hostnameFlag)) : make_shared<Ipc>());
+    const auto ipc = convertToFlag ? nullptr : (hostnameFlag ? make_shared<Ipc>(get(hostnameFlag)) : make_shared<Ipc>());
 
     // If we're not the primary instance and did not request to open a new window, simply send the to-be-opened images to the primary
     // instance.
@@ -493,7 +493,7 @@ static int mainFunc(span<const string> arguments) {
 
     Imf::setGlobalThreadCount(thread::hardware_concurrency());
 
-    shared_ptr<BackgroundImagesLoader> imagesLoader = make_shared<BackgroundImagesLoader>();
+    const shared_ptr<BackgroundImagesLoader> imagesLoader = make_shared<BackgroundImagesLoader>();
     imagesLoader->setRecursiveDirectories(recursiveFlag);
     imagesLoader->setApplyGainmaps(!gainmapFlagOff);
     imagesLoader->setGroupChannels(!channelGroupingFlagOff);
@@ -553,7 +553,7 @@ static int mainFunc(span<const string> arguments) {
         } catch (const runtime_error& e) { tlog::warning() << "Uncaught exception in IPC thread: " << e.what(); }
     }};
 
-    ScopeGuard backgroundThreadShutdownGuard{[&]() {
+    const ScopeGuard backgroundThreadShutdownGuard{[&]() {
         setShuttingDown();
 
         ThreadPool::global().waitUntilFinished();
@@ -596,7 +596,7 @@ static int mainFunc(span<const string> arguments) {
     // Init nanogui application
     nanogui::init(!get(ldrFlag));
 
-    ScopeGuard nanoguiShutdownGuard{[&]() {
+    const ScopeGuard nanoguiShutdownGuard{[&]() {
     // On some linux distributions glfwTerminate() (which is called by nanogui::shutdown()) causes segfaults. Since we are done with our
     // program here anyways, let's let the OS clean up after us.
 #if defined(__APPLE__) or defined(_WIN32)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -416,19 +416,19 @@ static int mainFunc(span<const string> arguments) {
     };
 
     // Parse command line arguments and react to parsing errors using exceptions.
-    try {
-        TEV_ASSERT(arguments.size() > 0, "Number of arguments must be bigger than 0.");
+    TEV_ASSERT(arguments.size() > 0, "Number of arguments must be bigger than 0.");
 
+    try {
         parser.Prog(arguments.front());
         parser.ParseArgs(begin(arguments) + 1, end(arguments));
     } catch (const Help&) {
         cout << parser;
         return 0;
     } catch (const ParseError& e) {
-        cerr << e.what() << endl;
+        cerr << fmt::format("{}\nUsage: {} --help\n", e.what(), arguments.front());
         return -1;
     } catch (const ValidationError& e) {
-        cerr << e.what() << endl;
+        cerr << fmt::format("{}\nUsage: {} --help\n", e.what(), arguments.front());
         return -2;
     }
 


### PR DESCRIPTION
Adds a `--convert-to` CLI option for (batch) conversion of images to any of the formats **tev** supports saving to. (Currently not that many, and only RGBA.)

Also adds a bunch of related features, such as
- the ability to select image parts (e.g. frames of an animation) with the channel selector (e.g. :frames.5 for the 6th frame),
- a `--bg` CLI option for specifying **tev**'s background color which is
- from now on blended with the image upon save.
- And better stdout vs. stderr hygiene

And a few bugfixes / misc. things that aren't worth getting into here.