### PR TITLE
Direct storage into interleaved RGBA/RGB/LA/L layouts

### DIFF
--- a/include/tev/Common.h
+++ b/include/tev/Common.h
@@ -472,6 +472,7 @@ inline bool matchesFuzzyOrRegex(std::string_view text, std::string_view filter, 
 void drawTextWithShadow(NVGcontext* ctx, float x, float y, std::string_view text, float shadowAlpha = 1.0f);
 
 int maxTextureSize();
+size_t nextSupportedTextureChannelCount(size_t channelCount);
 
 inline float toSRGB(float val, float gamma = 2.4f) {
     static constexpr float a = 0.055f;

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -130,7 +130,8 @@ public:
     static const std::vector<std::string_view>& supportedMimeTypes();
 
     static Task<std::vector<Channel>> makeRgbaInterleavedChannels(
-        int numChannels,
+        size_t numChannels,
+        size_t numInterleavedDims,
         bool hasAlpha,
         const nanogui::Vector2i& size,
         EPixelFormat format,
@@ -140,7 +141,7 @@ public:
     );
 
     static std::vector<Channel>
-        makeNChannels(int numChannels, const nanogui::Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, std::string_view layer);
+        makeNChannels(size_t numChannels, const nanogui::Vector2i& size, EPixelFormat format, EPixelFormat desiredFormat, std::string_view layer);
 
     static Task<void> resizeChannelsAsync(std::span<const Channel> srcChannels, std::vector<Channel>& dstChannels, int priority);
     static Task<void> resizeImageData(ImageData& resultData, const nanogui::Vector2i& targetSize, int priority);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -366,6 +366,21 @@ int maxTextureSize() {
 #endif
 }
 
+size_t nextSupportedTextureChannelCount(size_t channelCount) {
+    if (channelCount == 0 || channelCount > 4) {
+        throw runtime_error{fmt::format("Unsupported number of texture channels: {}", channelCount)};
+    }
+
+#if NANOGUI_USE_METAL
+    // Metal only supports 1, 2, and 4 channel textures.
+    if (channelCount == 3) {
+        return 4;
+    }
+#endif
+
+    return channelCount;
+}
+
 int lastError() {
 #ifdef _WIN32
     return GetLastError();

--- a/src/imageio/BmpImageLoader.cpp
+++ b/src/imageio/BmpImageLoader.cpp
@@ -1460,7 +1460,7 @@ Task<vector<ImageData>> BmpImageLoader::loadWithoutFileHeader(
     ImageData& resultData = result[0];
 
     resultData.channels = co_await makeRgbaInterleavedChannels(
-        numChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
+        numChannels, 4, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
     );
     resultData.hasPremultipliedAlpha = !hasAlpha;
 

--- a/src/imageio/ClipboardImageLoader.cpp
+++ b/src/imageio/ClipboardImageLoader.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <tev/Common.h>
 #include <tev/ThreadPool.h>
 #include <tev/imageio/ClipboardImageLoader.h>
 
@@ -49,21 +50,23 @@ Task<vector<ImageData>> ClipboardImageLoader::load(istream& iStream, const fs::p
         throw ImageLoadError{"Image has zero pixels."};
     }
 
-    const auto numChannels = (int)(spec.bits_per_pixel / 8);
+    const auto numChannels = (size_t)(spec.bits_per_pixel / 8);
     if (numChannels > 4) {
         throw ImageLoadError{"Image has too many channels."};
     }
 
     const size_t numBytesPerRow = spec.bytes_per_row;
     const size_t numBytes = numBytesPerRow * size.y();
-    const int alphaChannelIndex = 3;
+    const size_t alphaChannelIndex = 3;
 
     vector<ImageData> result(1);
     ImageData& resultData = result.front();
 
     // Clipboard images are always 32 bit RGBA. Can be comfortably represented as F16.
-    resultData.channels =
-        co_await makeRgbaInterleavedChannels(numChannels, 4, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
+    const auto numInterleavedChannels = nextSupportedTextureChannelCount(numChannels);
+    resultData.channels = co_await makeRgbaInterleavedChannels(
+        numChannels, numInterleavedChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority
+    );
 
     HeapArray<char> data(numBytes);
     iStream.read(reinterpret_cast<char*>(data.data()), numBytes);
@@ -78,8 +81,8 @@ Task<vector<ImageData>> ClipboardImageLoader::load(istream& iStream, const fs::p
         (size_t)(spec.alpha_shift / 8),
     };
 
-    for (int c = 0; c < numChannels; ++c) {
-        if (shifts[c] >= (size_t)numChannels) {
+    for (size_t c = 0; c < numChannels; ++c) {
+        if (shifts[c] >= numChannels) {
             throw ImageLoadError{"Invalid shift encountered in clipboard image."};
         }
     }
@@ -90,20 +93,20 @@ Task<vector<ImageData>> ClipboardImageLoader::load(istream& iStream, const fs::p
         size.y(),
         numPixels * numChannels,
         [&](int y) {
-            size_t rowIdxIn = y * numBytesPerRow;
-            size_t rowIdxOut = y * size.x() * numChannels;
+            const size_t rowIdxIn = y * numBytesPerRow;
+            const size_t rowIdxOut = y * size.x() * numInterleavedChannels;
 
             for (int x = 0; x < size.x(); ++x) {
                 float alpha = 1.0f;
 
                 const size_t baseIdxIn = rowIdxIn + x * numChannels;
-                const size_t baseIdxOut = rowIdxOut + x * numChannels;
+                const size_t baseIdxOut = rowIdxOut + x * numInterleavedChannels;
 
-                for (int c = numChannels - 1; c >= 0; --c) {
+                for (int c = (int)numChannels - 1; c >= 0; ++c) {
                     const unsigned char val = data[baseIdxIn + shifts[c]];
                     if (c == alphaChannelIndex) {
                         alpha = val / 255.0f;
-                        floatData[baseIdxOut + c] = alpha;
+                        floatData[baseIdxOut + numInterleavedChannels - 1] = alpha;
                     } else {
                         floatData[baseIdxOut + c] = toLinear(val / 255.0f) * alpha;
                     }

--- a/src/imageio/ClipboardImageLoader.cpp
+++ b/src/imageio/ClipboardImageLoader.cpp
@@ -63,7 +63,7 @@ Task<vector<ImageData>> ClipboardImageLoader::load(istream& iStream, const fs::p
 
     // Clipboard images are always 32 bit RGBA. Can be comfortably represented as F16.
     resultData.channels =
-        co_await makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
+        co_await makeRgbaInterleavedChannels(numChannels, 4, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
 
     HeapArray<char> data(numBytes);
     iStream.read(reinterpret_cast<char*>(data.data()), numBytes);

--- a/src/imageio/DdsImageLoader.cpp
+++ b/src/imageio/DdsImageLoader.cpp
@@ -218,7 +218,7 @@ Task<vector<ImageData>> DdsImageLoader::load(istream& iStream, const fs::path&, 
     ImageData& resultData = result.front();
 
     resultData.channels = co_await makeRgbaInterleavedChannels(
-        numChannels, DirectX::HasAlpha(metadata.format), size, EPixelFormat::F32, EPixelFormat::F32, "", priority
+        numChannels, 4, DirectX::HasAlpha(metadata.format), size, EPixelFormat::F32, EPixelFormat::F32, "", priority
     );
 
     const auto numPixels = (size_t)size.x() * size.y();

--- a/src/imageio/DdsImageLoader.cpp
+++ b/src/imageio/DdsImageLoader.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <tev/Common.h>
 #include <tev/ThreadPool.h>
 #include <tev/imageio/DdsImageLoader.h>
 
@@ -26,7 +27,7 @@ using namespace std;
 
 namespace tev {
 
-static int getDxgiChannelCount(DXGI_FORMAT fmt) {
+static size_t getDxgiChannelCount(DXGI_FORMAT fmt) {
     switch (fmt) {
         case DXGI_FORMAT_R32G32B32A32_TYPELESS:
         case DXGI_FORMAT_R32G32B32A32_FLOAT:
@@ -183,13 +184,12 @@ Task<vector<ImageData>> DdsImageLoader::load(istream& iStream, const fs::path&, 
     }
 
     DXGI_FORMAT format;
-    int numChannels = getDxgiChannelCount(metadata.format);
+    const size_t numChannels = getDxgiChannelCount(metadata.format);
     switch (numChannels) {
         case 4: format = DXGI_FORMAT_R32G32B32A32_FLOAT; break;
         case 3: format = DXGI_FORMAT_R32G32B32_FLOAT; break;
         case 2: format = DXGI_FORMAT_R32G32_FLOAT; break;
         case 1: format = DXGI_FORMAT_R32_FLOAT; break;
-        case 0:
         default: throw ImageLoadError{fmt::format("Unsupported DXGI format: {}", static_cast<int>(metadata.format))};
     }
 
@@ -217,8 +217,11 @@ Task<vector<ImageData>> DdsImageLoader::load(istream& iStream, const fs::path&, 
     vector<ImageData> result(1);
     ImageData& resultData = result.front();
 
+    const size_t numInterleavedChannels = nextSupportedTextureChannelCount(numChannels);
+    const bool hasAlpha = DirectX::HasAlpha(metadata.format);
+
     resultData.channels = co_await makeRgbaInterleavedChannels(
-        numChannels, 4, DirectX::HasAlpha(metadata.format), size, EPixelFormat::F32, EPixelFormat::F32, "", priority
+        numChannels, numInterleavedChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F32, "", priority
     );
 
     const auto numPixels = (size_t)size.x() * size.y();
@@ -231,13 +234,13 @@ Task<vector<ImageData>> DdsImageLoader::load(istream& iStream, const fs::path&, 
         // Assume that the image data is already in linear space.
         assert(!DirectX::IsSRGB(metadata.format));
         co_await toFloat32(
-            (float*)scratchImage.GetPixels(), numChannels, resultData.channels.front().floatData(), 4, size, numChannels == 4, priority
+            (float*)scratchImage.GetPixels(), numChannels, resultData.channels.front().floatData(), numInterleavedChannels, size, hasAlpha, priority
         );
     } else {
         // Ideally, we'd be able to assume that only *_SRGB format images were in sRGB space, and only they need to converted to linear.
         // However, RGB(A) DDS images tend to be in sRGB space, even those not explicitly stored in an *_SRGB format.
         co_await toFloat32<float, true>(
-            (float*)scratchImage.GetPixels(), numChannels, resultData.channels.front().floatData(), 4, size, numChannels == 4, priority
+            (float*)scratchImage.GetPixels(), numChannels, resultData.channels.front().floatData(), numInterleavedChannels, size, hasAlpha, priority
         );
     }
 

--- a/src/imageio/Jpeg2000ImageLoader.cpp
+++ b/src/imageio/Jpeg2000ImageLoader.cpp
@@ -404,7 +404,7 @@ Task<vector<ImageData>> Jpeg2000ImageLoader::load(
         resultData.channels.emplace_back(Channel::joinIfNonempty(resultData.partName, "L"), size, EPixelFormat::F32, EPixelFormat::F16);
     } else {
         resultData.channels = co_await makeRgbaInterleavedChannels(
-            numRgbaChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
+            numRgbaChannels, 4, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
         );
     }
 

--- a/src/imageio/JpegTurboImageLoader.cpp
+++ b/src/imageio/JpegTurboImageLoader.cpp
@@ -441,7 +441,7 @@ Task<vector<ImageData>>
             resultData.channels.emplace_back(Channel::joinIfNonempty(resultData.partName, "L"), size, EPixelFormat::F32, EPixelFormat::F16);
         } else {
             resultData.channels = co_await makeRgbaInterleavedChannels(
-                numColorChannels, false, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
+                numColorChannels, 4, false, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
             );
         }
 

--- a/src/imageio/JpegTurboImageLoader.cpp
+++ b/src/imageio/JpegTurboImageLoader.cpp
@@ -299,9 +299,8 @@ Task<vector<ImageData>>
                                 continue;
                             }
 
-                            tlog::debug() << fmt::format(
-                                "Adding MPF image #{} slice at offset {} of size {} bytes", i, imageDataOffset, slice.size()
-                            );
+                            tlog::debug()
+                                << fmt::format("Adding MPF image #{} slice at offset {} of size {} bytes", i, imageDataOffset, slice.size());
                             imageInfos.emplace_back(slice, idx, mfpTypeToString(iie.type()));
                         }
                     }
@@ -436,14 +435,10 @@ Task<vector<ImageData>>
 
         // This JPEG loader is at most 8 bits per channel (technically, JPEG can hold more, but we don't support that here). Thus easily
         // fits into F16.
-        const size_t numInterleavedChannels = numColorChannels == 1 ? 1 : 4;
-        if (numInterleavedChannels == 1) {
-            resultData.channels.emplace_back(Channel::joinIfNonempty(resultData.partName, "L"), size, EPixelFormat::F32, EPixelFormat::F16);
-        } else {
-            resultData.channels = co_await makeRgbaInterleavedChannels(
-                numColorChannels, 4, false, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
-            );
-        }
+        const size_t numInterleavedChannels = nextSupportedTextureChannelCount(numColorChannels);
+        resultData.channels = co_await makeRgbaInterleavedChannels(
+            numColorChannels, numInterleavedChannels, false, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
+        );
 
         // Since JPEG always has no alpha channel, we default to 1, where premultiplied and straight are equivalent.
         resultData.hasPremultipliedAlpha = true;

--- a/src/imageio/JxlImageLoader.cpp
+++ b/src/imageio/JxlImageLoader.cpp
@@ -478,6 +478,7 @@ Task<vector<ImageData>> JxlImageLoader::load(
 
                 data.channels = co_await makeRgbaInterleavedChannels(
                     numColorChannels,
+                    4,
                     info.alpha_bits,
                     size,
                     EPixelFormat::F32,

--- a/src/imageio/JxlImageLoader.cpp
+++ b/src/imageio/JxlImageLoader.cpp
@@ -385,13 +385,13 @@ Task<vector<ImageData>> JxlImageLoader::load(
             case JXL_DEC_NEED_IMAGE_OUT_BUFFER: {
                 // libjxl expects the alpha channels to be decoded as part of the image (despite counting as an extra channel) and all
                 // other extra channels to be decoded as separate channels.
-                int numColorChannels = info.num_color_channels + (info.alpha_bits ? 1 : 0);
-                int numExtraChannels = info.num_extra_channels;
+                const size_t numChannels = info.num_color_channels + (info.alpha_bits ? 1 : 0);
+                const size_t numExtraChannels = info.num_extra_channels;
 
                 size_t bufferSize;
 
                 // Main image buffer & decode setup
-                JxlPixelFormat imageFormat = {(uint32_t)numColorChannels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, 0};
+                JxlPixelFormat imageFormat = {(uint32_t)numChannels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, 0};
                 if (JXL_DEC_SUCCESS != JxlDecoderImageOutBufferSize(decoder.get(), &imageFormat, &bufferSize)) {
                     throw ImageLoadError{"Failed to get output buffer size."};
                 }
@@ -418,7 +418,7 @@ Task<vector<ImageData>> JxlImageLoader::load(
                 vector<ExtraChannelInfo> extraChannels(numExtraChannels);
 
                 JxlPixelFormat extraChannelFormat = {1, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, 0};
-                for (int i = 0; i < numExtraChannels; ++i) {
+                for (size_t i = 0; i < numExtraChannels; ++i) {
                     ExtraChannelInfo& extraChannel = extraChannels[i];
 
                     JxlExtraChannelInfo extraChannelInfo;
@@ -476,9 +476,10 @@ Task<vector<ImageData>> JxlImageLoader::load(
 
                 const Vector2i size{(int)info.xsize, (int)info.ysize};
 
+                const int numInterleavedChannels = nextSupportedTextureChannelCount(numChannels);
                 data.channels = co_await makeRgbaInterleavedChannels(
-                    numColorChannels,
-                    4,
+                    numChannels,
+                    numInterleavedChannels,
                     info.alpha_bits,
                     size,
                     EPixelFormat::F32,
@@ -521,7 +522,7 @@ Task<vector<ImageData>> JxlImageLoader::load(
                             EPixelFormat::F32,
                             (uint8_t*)colorData.data(),
                             data.channels.front().floatData(),
-                            4,
+                            numInterleavedChannels,
                             nullopt,
                             priority
                         );
@@ -536,7 +537,7 @@ Task<vector<ImageData>> JxlImageLoader::load(
                 // If we didn't load the channels via the ICC profile, we need to load them manually.
                 if (!colorChannelsLoaded) {
                     co_await toFloat32(
-                        (float*)colorData.data(), numColorChannels, data.channels.front().floatData(), 4, size, info.alpha_bits, priority
+                        (float*)colorData.data(), numChannels, data.channels.front().floatData(), numInterleavedChannels, size, info.alpha_bits, priority
                     );
 
                     // If color encoding information is available, we need to use it to convert to linear sRGB. Otherwise, assume the
@@ -595,18 +596,19 @@ Task<vector<ImageData>> JxlImageLoader::load(
                         co_await ThreadPool::global().parallelForAsync<size_t>(
                             0,
                             numPixels,
-                            numPixels * 4,
+                            numPixels * numInterleavedChannels,
                             [&](size_t i) {
                                 // Jxl unfortunately premultiplies the alpha channel in non-linear space (after application of the
                                 // transfer), so we must unpremultiply prior to the color space conversion and transfer function inversion.
                                 // See https://github.com/libjxl/conformance/issues/39#issuecomment-3004735767
-                                const float alpha = info.alpha_bits ? pixelData[i * 4 + 3] : 1.0f;
+                                const float alpha = info.alpha_bits ? pixelData[i * numInterleavedChannels + numInterleavedChannels - 1] :
+                                                                      1.0f;
                                 const float factor = info.alpha_premultiplied && alpha > 0.0001f ? (1.0f / alpha) : 1.0f;
                                 const float invFactor = info.alpha_premultiplied && alpha > 0.0001f ? alpha : 1.0f;
 
                                 Vector3f color;
-                                for (size_t c = 0; c < 3; ++c) {
-                                    color[c] = pixelData[i * 4 + c];
+                                for (uint32_t c = 0; c < info.num_color_channels; ++c) {
+                                    color[c] = pixelData[i * numInterleavedChannels + c];
                                 }
 
                                 if (hasGamma) {
@@ -615,8 +617,8 @@ Task<vector<ImageData>> JxlImageLoader::load(
                                     color = ituth273::invTransfer(cicpTransfer, color * factor) * invFactor;
                                 }
 
-                                for (size_t c = 0; c < 3; ++c) {
-                                    pixelData[i * 4 + c] = color[c];
+                                for (uint32_t c = 0; c < info.num_color_channels; ++c) {
+                                    pixelData[i * numInterleavedChannels + c] = color[c];
                                 }
                             },
                             priority

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -331,15 +331,11 @@ Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, 
 
         const EPixelFormat desiredFormat = bitsPerChannel == 32 ? EPixelFormat::F32 : EPixelFormat::F16;
 
-        const size_t numInterleavedChannels = numChannels == 1 ? 1 : 4;
+        const size_t numInterleavedChannels = nextSupportedTextureChannelCount(numChannels);
         const bool hasAlpha = numChannels == 2 || numChannels == 4;
-        if (numInterleavedChannels == 1) {
-            resultData.channels.emplace_back(Channel::joinIfNonempty(resultData.partName, "L"), size, EPixelFormat::F32, desiredFormat);
-        } else {
-            resultData.channels = co_await makeRgbaInterleavedChannels(
-                numChannels, 4, hasAlpha, size, EPixelFormat::F32, desiredFormat, resultData.partName, priority
-            );
-        }
+        resultData.channels = co_await makeRgbaInterleavedChannels(
+            numChannels, numInterleavedChannels, hasAlpha, size, EPixelFormat::F32, desiredFormat, resultData.partName, priority
+        );
 
         const auto numSamplesPerRow = (size_t)size.x() * numChannels;
         const auto numSamples = numSamplesPerRow * size.y();

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -337,7 +337,7 @@ Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, 
             resultData.channels.emplace_back(Channel::joinIfNonempty(resultData.partName, "L"), size, EPixelFormat::F32, desiredFormat);
         } else {
             resultData.channels = co_await makeRgbaInterleavedChannels(
-                numChannels, hasAlpha, size, EPixelFormat::F32, desiredFormat, resultData.partName, priority
+                numChannels, 4, hasAlpha, size, EPixelFormat::F32, desiredFormat, resultData.partName, priority
             );
         }
 

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <tev/Common.h>
 #include <tev/ThreadPool.h>
 #include <tev/imageio/Colors.h>
 #include <tev/imageio/Exif.h>
@@ -84,8 +85,8 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
     }
 
     // Determine number of channels
-    int numColorChannels = 0;
-    int numChannels = 0;
+    size_t numColorChannels = 0;
+    size_t numChannels = 0;
     switch (colorType) {
         case PNG_COLOR_TYPE_GRAY: numColorChannels = numChannels = 1; break;
         case PNG_COLOR_TYPE_GRAY_ALPHA:
@@ -309,6 +310,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
     }
 
     const bool hasAlpha = numChannels > numColorChannels;
+    const auto numInterleavedChannels = nextSupportedTextureChannelCount(numChannels);
 
     png_bytep iccProfileData = nullptr;
     png_charp iccProfileName = nullptr;
@@ -330,7 +332,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
 
     // Allocate enough memory for each frame. By making the data as big as the whole canvas, all frames should fit.
     HeapArray<png_byte> pngData(numPixels * numBytesPerPixel);
-    HeapArray<float> frameData(numSamples);
+    HeapArray<float> frameData(numPixels * numInterleavedChannels);
     HeapArray<float> iccTmpFloatData;
     if (iccProfileData) {
         // If we have an ICC profile, we need to convert the frame data to float first.
@@ -355,7 +357,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
         // PNG images have a fixed point representation of up to 16 bits per channel in TF space. FP16 is perfectly adequate to represent
         // such values after conversion to linear space.
         resultData.channels = co_await makeRgbaInterleavedChannels(
-            numChannels, 4, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
+            numChannels, numInterleavedChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
         );
 
         resultData.orientation = orientation;
@@ -418,17 +420,19 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
 
         const size_t numFramePixels = (size_t)frameSize.x() * frameSize.y();
         const size_t numFrameSamples = numFramePixels * numChannels;
-        if (numFrameSamples > frameData.size()) {
+        const size_t numInterleavedFrameSamples = numFramePixels * numInterleavedChannels;
+        if (numInterleavedFrameSamples > frameData.size()) {
             tlog::warning() << fmt::format(
                 "PNG frame data is larger than allocated buffer. Allocating {} bytes instead of {} bytes.",
-                numFrameSamples * sizeof(float),
+                numInterleavedFrameSamples * sizeof(float),
                 frameData.size() * sizeof(float)
             );
 
-            frameData = HeapArray<float>(numFrameSamples);
-            if (iccProfileData) {
-                iccTmpFloatData = HeapArray<float>(numFrameSamples);
-            }
+            frameData = HeapArray<float>(numInterleavedFrameSamples);
+        }
+
+        if (iccProfileData && numFrameSamples > iccTmpFloatData.size()) {
+            iccTmpFloatData = HeapArray<float>(numFrameSamples);
         }
 
         for (int y = 0; y < frameSize.y(); ++y) {
@@ -503,9 +507,11 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                 }
 
                 if (bitDepth == 16) {
-                    co_await toFloat32<uint16_t, false>((uint16_t*)pngData.data(), numChannels, dstData, 4, size, hasAlpha, priority);
+                    co_await toFloat32<uint16_t, false>(
+                        (uint16_t*)pngData.data(), numChannels, dstData, numInterleavedChannels, size, hasAlpha, priority
+                    );
                 } else {
-                    co_await toFloat32<uint8_t, false>(pngData.data(), numChannels, dstData, 4, size, hasAlpha, priority);
+                    co_await toFloat32<uint8_t, false>(pngData.data(), numChannels, dstData, numInterleavedChannels, size, hasAlpha, priority);
                 }
 
                 co_await ThreadPool::global().parallelForAsync<size_t>(
@@ -513,15 +519,15 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                     numPixels,
                     numSamples,
                     [&](size_t i) {
-                        const float alpha = dstData[i * 4 + 3];
-                        Vector3f color;
-                        for (int c = 0; c < 3; ++c) {
-                            color[c] = (dstData[i * 4 + c] - range.offset) * range.scale;
+                        const float alpha = hasAlpha ? dstData[i * numInterleavedChannels + numInterleavedChannels - 1] : 1.0f;
+                        Vector3f color = {0.0f};
+                        for (size_t c = 0; c < numColorChannels; ++c) {
+                            color[c] = (dstData[i * numInterleavedChannels + c] - range.offset) * range.scale;
                         }
 
                         color = ituth273::invTransfer(cicp.transfer, color) * alpha;
-                        for (int c = 0; c < 3; ++c) {
-                            dstData[i * 4 + c] = color[c];
+                        for (size_t c = 0; c < numColorChannels; ++c) {
+                            dstData[i * numInterleavedChannels + c] = color[c];
                         }
                     },
                     priority
@@ -553,7 +559,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                         EPixelFormat::F32,
                         (uint8_t*)iccTmpFloatData.data(),
                         dstData,
-                        4,
+                        numInterleavedChannels,
                         nullopt,
                         priority
                     );
@@ -590,9 +596,13 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                 }
 
                 if (bitDepth == 16) {
-                    co_await toFloat32<uint16_t, true, true>((uint16_t*)pngData.data(), numChannels, dstData, 4, size, hasAlpha, priority);
+                    co_await toFloat32<uint16_t, true, true>(
+                        (uint16_t*)pngData.data(), numChannels, dstData, numInterleavedChannels, size, hasAlpha, priority
+                    );
                 } else {
-                    co_await toFloat32<uint8_t, true, true>(pngData.data(), numChannels, dstData, 4, size, hasAlpha, priority);
+                    co_await toFloat32<uint8_t, true, true>(
+                        pngData.data(), numChannels, dstData, numInterleavedChannels, size, hasAlpha, priority
+                    );
                 }
 
                 resultData.hasPremultipliedAlpha = true;
@@ -602,9 +612,11 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
 
             tlog::debug() << fmt::format("Using gamma={}", invGamma64);
             if (bitDepth == 16) {
-                co_await toFloat32<uint16_t, false>((uint16_t*)pngData.data(), numChannels, dstData, 4, size, hasAlpha, priority);
+                co_await toFloat32<uint16_t, false>(
+                    (uint16_t*)pngData.data(), numChannels, dstData, numInterleavedChannels, size, hasAlpha, priority
+                );
             } else {
-                co_await toFloat32<uint8_t, false>(pngData.data(), numChannels, dstData, 4, size, hasAlpha, priority);
+                co_await toFloat32<uint8_t, false>(pngData.data(), numChannels, dstData, numInterleavedChannels, size, hasAlpha, priority);
             }
 
             co_await ThreadPool::global().parallelForAsync<size_t>(
@@ -612,9 +624,9 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
                 numPixels,
                 numSamples,
                 [&](size_t i) {
-                    const float alpha = dstData[i * 4 + 3];
-                    for (int c = 0; c < 3; ++c) {
-                        dstData[i * 4 + c] = pow(dstData[i * 4 + c], gamma) * alpha;
+                    const float alpha = hasAlpha ? dstData[i * numInterleavedChannels + numInterleavedChannels - 1] : 1.0f;
+                    for (size_t c = 0; c < numColorChannels; ++c) {
+                        dstData[i * numInterleavedChannels + c] = pow(dstData[i * numInterleavedChannels + c], gamma) * alpha;
                     }
                 },
                 priority
@@ -659,21 +671,22 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
 
                         bool isInFrame = Box2i{frameSize}.contains(framePos);
 
-                        for (int c = 0; c < numChannels; ++c) {
-                            const size_t canvasSampleIdx = canvasPixelIdx * numChannels + c;
+                        for (size_t c = 0; c < numChannels; ++c) {
+                            const auto canvasSampleIdx = canvasPixelIdx * numInterleavedChannels + c;
                             float val;
 
                             // The background (if no previous canvas is set) is defined as transparent black per the spec.
                             const float bg = prevCanvas ? prevCanvas[canvasSampleIdx] : 0.0f;
                             if (isInFrame) {
-                                const size_t framePixelIdx = (size_t)framePos.y() * frameSize.x() + (size_t)framePos.x();
-                                const size_t frameSampleIdx = framePixelIdx * numChannels + c;
-                                const size_t frameAlphaIdx = framePixelIdx * numChannels + 3;
+                                const auto framePixelIdx = (size_t)framePos.y() * frameSize.x() + framePos.x();
+                                const auto frameSampleIdx = framePixelIdx * numInterleavedChannels + c;
+                                const auto frameAlphaIdx = framePixelIdx * numInterleavedChannels + numInterleavedChannels - 1;
 
                                 if (blendOp == EBlendOp::Source) {
                                     val = dstData[frameSampleIdx];
                                 } else {
-                                    val = dstData[frameSampleIdx] + bg * (1.0f - dstData[frameAlphaIdx]);
+                                    const float alpha = hasAlpha ? dstData[frameAlphaIdx] : 1.0f;
+                                    val = dstData[frameSampleIdx] + bg * (1.0f - alpha);
                                 }
                             } else {
                                 val = bg;

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -355,7 +355,7 @@ Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, 
         // PNG images have a fixed point representation of up to 16 bits per channel in TF space. FP16 is perfectly adequate to represent
         // such values after conversion to linear space.
         resultData.channels = co_await makeRgbaInterleavedChannels(
-            numChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
+            numChannels, 4, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
         );
 
         resultData.orientation = orientation;

--- a/src/imageio/QoiImageLoader.cpp
+++ b/src/imageio/QoiImageLoader.cpp
@@ -69,7 +69,7 @@ Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, 
     ImageData& resultData = result.front();
 
     // QOI images are 8 bit per pixel which easily fits into F16.
-    resultData.channels = co_await makeRgbaInterleavedChannels(numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
+    resultData.channels = co_await makeRgbaInterleavedChannels(numChannels, 4, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
     resultData.hasPremultipliedAlpha = false;
 
     resultData.nativeMetadata.chroma = rec709Chroma();

--- a/src/imageio/QoiImageLoader.cpp
+++ b/src/imageio/QoiImageLoader.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <tev/Common.h>
 #include <tev/ThreadPool.h>
 #include <tev/imageio/QoiImageLoader.h>
 
@@ -46,43 +47,48 @@ Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, 
     iStream.read(data.data(), dataSize);
 
     qoi_desc desc;
-    void* decodedData = qoi_decode(data.data(), static_cast<int>(dataSize), &desc, 0);
+    void* decodedData = qoi_decode(data.data(), (int)dataSize, &desc, 0);
 
-    ScopeGuard decodedDataGuard{[decodedData] { free(decodedData); }};
+    const ScopeGuard decodedDataGuard{[decodedData] { free(decodedData); }};
 
     if (!decodedData) {
         throw ImageLoadError{"Failed to decode data from the QOI format."};
     }
 
-    Vector2i size{static_cast<int>(desc.width), static_cast<int>(desc.height)};
-    auto numPixels = (size_t)size.x() * size.y();
+    const Vector2i size{(int)desc.width, (int)desc.height};
+    const auto numPixels = (size_t)size.x() * size.y();
     if (numPixels == 0) {
         throw ImageLoadError{"Image has zero pixels."};
     }
 
-    int numChannels = static_cast<int>(desc.channels);
+    const auto numChannels = (size_t)desc.channels;
     if (numChannels != 4 && numChannels != 3) {
         throw ImageLoadError{fmt::format("Invalid number of channels {}.", numChannels)};
     }
+
+    const bool hasAlpha = numChannels == 4;
+    const auto numInterleavedChannels = nextSupportedTextureChannelCount(numChannels);
 
     vector<ImageData> result(1);
     ImageData& resultData = result.front();
 
     // QOI images are 8 bit per pixel which easily fits into F16.
-    resultData.channels = co_await makeRgbaInterleavedChannels(numChannels, 4, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, "", priority);
+    resultData.channels = co_await makeRgbaInterleavedChannels(
+        numChannels, numInterleavedChannels, hasAlpha, size, EPixelFormat::F32, EPixelFormat::F16, "", priority
+    );
     resultData.hasPremultipliedAlpha = false;
 
     resultData.nativeMetadata.chroma = rec709Chroma();
 
     if (desc.colorspace == QOI_LINEAR) {
         co_await toFloat32<uint8_t, false>(
-            (uint8_t*)decodedData, numChannels, resultData.channels.front().floatData(), 4, size, numChannels == 4, priority
+            (uint8_t*)decodedData, numChannels, resultData.channels.front().floatData(), numInterleavedChannels, size, hasAlpha, priority
         );
 
         resultData.nativeMetadata.transfer = ituth273::ETransfer::Linear;
     } else {
         co_await toFloat32<uint8_t, true>(
-            (uint8_t*)decodedData, numChannels, resultData.channels.front().floatData(), 4, size, numChannels == 4, priority
+            (uint8_t*)decodedData, numChannels, resultData.channels.front().floatData(), numInterleavedChannels, size, hasAlpha, priority
         );
 
         resultData.nativeMetadata.transfer = ituth273::ETransfer::SRGB;

--- a/src/imageio/RawImageLoader.cpp
+++ b/src/imageio/RawImageLoader.cpp
@@ -286,7 +286,7 @@ Task<vector<ImageData>> RawImageLoader::load(istream& iStream, const fs::path& p
 
     const int numChannels = 3;
     resultData.channels = co_await makeRgbaInterleavedChannels(
-        numChannels, numChannels == 4, orientedSize, EPixelFormat::F32, EPixelFormat::F16, "", priority
+        numChannels, 4, numChannels == 4, orientedSize, EPixelFormat::F32, EPixelFormat::F16, "", priority
     );
     resultData.hasPremultipliedAlpha = false;
     // resultData.displayWindow = displayWindow; // This seems to be wrong

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <tev/Common.h>
 #include <tev/ThreadPool.h>
 #include <tev/imageio/StbiImageLoader.h>
 
@@ -45,7 +46,7 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
     int numChannels;
     int numFrames = 1;
     Vector2i size;
-    bool isHdr = stbi_is_hdr_from_callbacks(&callbacks, &iStream) != 0;
+    const bool isHdr = stbi_is_hdr_from_callbacks(&callbacks, &iStream) != 0;
     iStream.clear();
     iStream.seekg(0);
 
@@ -79,6 +80,9 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
         throw ImageLoadError{"Image has zero pixels."};
     }
 
+    const bool hasAlpha = numChannels == 4;
+    const auto numInterleavedChannels = nextSupportedTextureChannelCount((size_t)numChannels);
+
     ScopeGuard dataGuard{[data] { stbi_image_free(data); }};
 
     vector<ImageData> result(numFrames);
@@ -90,7 +94,14 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
 
         // Unless the image is a .hdr file, it's 8 bits per channel, so we can comfortably fit it into F16.
         resultData.channels = co_await makeRgbaInterleavedChannels(
-            numChannels, 4, numChannels == 4, size, EPixelFormat::F32, isHdr ? EPixelFormat::F32 : EPixelFormat::F16, resultData.partName, priority
+            numChannels,
+            numInterleavedChannels,
+            hasAlpha,
+            size,
+            EPixelFormat::F32,
+            isHdr ? EPixelFormat::F32 : EPixelFormat::F16,
+            resultData.partName,
+            priority
         );
         resultData.hasPremultipliedAlpha = false;
         resultData.nativeMetadata.chroma = rec709Chroma();
@@ -101,7 +112,9 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
             resultData.renderingIntent = ERenderingIntent::AbsoluteColorimetric;
             resultData.nativeMetadata.transfer = ituth273::ETransfer::Linear;
 
-            co_await toFloat32((float*)data, numChannels, resultData.channels.front().floatData(), 4, size, numChannels == 4, priority);
+            co_await toFloat32(
+                (float*)data, numChannels, resultData.channels.front().floatData(), numInterleavedChannels, size, hasAlpha, priority
+            );
             data = (float*)data + numPixels * numChannels;
         } else {
             // Assume sRGB-encoded LDR images are display-referred.
@@ -109,7 +122,7 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
             resultData.nativeMetadata.transfer = ituth273::ETransfer::SRGB;
 
             co_await toFloat32<uint8_t, true>(
-                (uint8_t*)data, numChannels, resultData.channels.front().floatData(), 4, size, numChannels == 4, priority
+                (uint8_t*)data, numChannels, resultData.channels.front().floatData(), numInterleavedChannels, size, hasAlpha, priority
             );
             data = (uint8_t*)data + numPixels * numChannels;
         }

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -90,7 +90,7 @@ Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&,
 
         // Unless the image is a .hdr file, it's 8 bits per channel, so we can comfortably fit it into F16.
         resultData.channels = co_await makeRgbaInterleavedChannels(
-            numChannels, numChannels == 4, size, EPixelFormat::F32, isHdr ? EPixelFormat::F32 : EPixelFormat::F16, resultData.partName, priority
+            numChannels, 4, numChannels == 4, size, EPixelFormat::F32, isHdr ? EPixelFormat::F32 : EPixelFormat::F16, resultData.partName, priority
         );
         resultData.hasPremultipliedAlpha = false;
         resultData.nativeMetadata.chroma = rec709Chroma();

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -1198,19 +1198,20 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, string_view p
         numExtraChannels = 0;
     }
 
-    // Determine number of color channels
-    int numColorChannels = samplesPerPixel - numExtraChannels;
-    int numChannels = samplesPerPixel;
+    if (numExtraChannels >= samplesPerPixel) {
+        throw ImageLoadError{fmt::format("Invalid number of extra channels: {}", numExtraChannels)};
+    }
 
-    int numRgbaChannels = numColorChannels + (hasAlpha ? 1 : 0);
+    // Determine number of color channels
+    size_t numColorChannels = samplesPerPixel - numExtraChannels;
+    const size_t numChannels = samplesPerPixel;
+
+    size_t numRgbaChannels = numColorChannels + (hasAlpha ? 1 : 0);
     if (numRgbaChannels < 1 || numRgbaChannels > 4) {
         throw ImageLoadError{fmt::format("Unsupported number of RGBA channels: {}", numRgbaChannels)};
     }
 
-    int numNonRgbaChannels = numChannels - numRgbaChannels;
-    if (numNonRgbaChannels < 0) {
-        throw ImageLoadError{fmt::format("Invalid number of non-RGBA channels: {}", numNonRgbaChannels)};
-    }
+    const size_t numNonRgbaChannels = numChannels - numRgbaChannels;
 
     const uint16_t* palette[3] = {};
     if (photometric == PHOTOMETRIC_PALETTE) {
@@ -1262,11 +1263,13 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, string_view p
 
     resultData.orientation = static_cast<EOrientation>(orientation);
 
+    const auto numInterleavedChannels = nextSupportedTextureChannelCount(numRgbaChannels);
+
     // Local scope to prevent use-after-move
     {
         const auto desiredPixelFormat = bitsPerSample > 16 ? EPixelFormat::F32 : EPixelFormat::F16;
         auto rgbaChannels = co_await ImageLoader::makeRgbaInterleavedChannels(
-            numRgbaChannels, 4, hasAlpha, size, EPixelFormat::F32, desiredPixelFormat, partName, priority
+            numRgbaChannels, numInterleavedChannels, hasAlpha, size, EPixelFormat::F32, desiredPixelFormat, partName, priority
         );
         auto extraChannels = ImageLoader::makeNChannels(numNonRgbaChannels, size, EPixelFormat::F32, desiredPixelFormat, partName);
 
@@ -1615,10 +1618,10 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, string_view p
         default: throw ImageLoadError{fmt::format("Unsupported sample format: {}", sampleFormat)};
     }
 
-    bool flipWhiteAndBlack = photometric == PHOTOMETRIC_MINISWHITE;
+    const bool flipWhiteAndBlack = photometric == PHOTOMETRIC_MINISWHITE;
 
     // Convert all the extra channels to float and store them in the result data. No further processing needed.
-    for (int c = numChannels - numExtraChannels + (hasAlpha ? 1 : 0); c < numChannels; ++c) {
+    for (size_t c = numChannels - numExtraChannels + (hasAlpha ? 1 : 0); c < numChannels; ++c) {
         co_await tiffDataToFloat32<false>(
             kind,
             nullptr,
@@ -1635,7 +1638,55 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, string_view p
     }
 
     // The RGBA channels might need color space conversion: store them in a staging buffer first and then try ICC conversion
-    HeapArray<float> floatRgbaData(size.x() * (size_t)size.y() * numRgbaChannels);
+    // Try color space conversion using ICC profile if available. This is going to be the most accurate method.
+    if (iccProfileData && iccProfileSize > 0) {
+        try {
+            HeapArray<float> iccTmpFloatData(size.x() * (size_t)size.y() * numRgbaChannels);
+            co_await tiffDataToFloat32<false>(
+                kind,
+                palette,
+                (uint32_t*)imageData.data(),
+                numChannels,
+                iccTmpFloatData.data(),
+                numRgbaChannels,
+                size,
+                hasAlpha,
+                priority,
+                intConversionScale,
+                flipWhiteAndBlack
+            );
+
+            const auto profile = ColorProfile::fromIcc({(uint8_t*)iccProfileData, iccProfileSize});
+            co_await toLinearSrgbPremul(
+                profile,
+                size,
+                numColorChannels,
+                hasAlpha ? (hasPremultipliedAlpha ? EAlphaKind::Premultiplied : EAlphaKind::Straight) : EAlphaKind::None,
+                EPixelFormat::F32,
+                (uint8_t*)iccTmpFloatData.data(),
+                resultData.channels.front().floatData(),
+                numInterleavedChannels,
+                nullopt,
+                priority
+            );
+
+            resultData.hasPremultipliedAlpha = true;
+            resultData.readMetadataFromIcc(profile);
+
+            co_return resultData;
+        } catch (const runtime_error& e) { tlog::warning() << fmt::format("Failed to apply ICC color profile: {}", e.what()); }
+    }
+
+    // Write directly into the final RGBA buffer if possible to save one copy, otherwise use a staging buffer.
+    HeapArray<float> floatRgbaDataBuffer;
+    span<float> floatRgbaData;
+    if (numRgbaChannels == numInterleavedChannels) {
+        floatRgbaData = {resultData.channels.front().floatData(), (size_t)size.x() * size.y() * numRgbaChannels};
+    } else {
+        floatRgbaDataBuffer.resize((size_t)size.x() * size.y() * numRgbaChannels);
+        floatRgbaData = floatRgbaDataBuffer;
+    }
+
     co_await tiffDataToFloat32<false>(
         kind,
         palette,
@@ -1649,30 +1700,6 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, string_view p
         intConversionScale,
         flipWhiteAndBlack
     );
-
-    // Try color space conversion using ICC profile if available. This is going to be the most accurate method.
-    if (iccProfileData && iccProfileSize > 0) {
-        try {
-            const auto profile = ColorProfile::fromIcc({(uint8_t*)iccProfileData, iccProfileSize});
-            co_await toLinearSrgbPremul(
-                profile,
-                size,
-                numColorChannels,
-                hasAlpha ? (hasPremultipliedAlpha ? EAlphaKind::Premultiplied : EAlphaKind::Straight) : EAlphaKind::None,
-                EPixelFormat::F32,
-                (uint8_t*)floatRgbaData.data(),
-                resultData.channels.front().floatData(),
-                4,
-                nullopt,
-                priority
-            );
-
-            resultData.hasPremultipliedAlpha = true;
-            resultData.readMetadataFromIcc(profile);
-
-            co_return resultData;
-        } catch (const runtime_error& e) { tlog::warning() << fmt::format("Failed to apply ICC color profile: {}", e.what()); }
-    }
 
     // If no ICC profile is available, we can try to convert the color space manually using TIFF's chromaticity data and transfer function.
     if (compression == COMPRESSION_PIXARLOG) {
@@ -1695,9 +1722,11 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, string_view p
         resultData.nativeMetadata.transfer = ituth273::ETransfer::Linear;
     }
 
-    co_await toFloat32<float, false>(
-        (const float*)floatRgbaData.data(), numRgbaChannels, resultData.channels.front().floatData(), 4, size, hasAlpha, priority
-    );
+    if (floatRgbaData.data() != resultData.channels.front().floatData()) {
+        co_await toFloat32<float, false>(
+            (const float*)floatRgbaData.data(), numRgbaChannels, resultData.channels.front().floatData(), numInterleavedChannels, size, hasAlpha, priority
+        );
+    }
 
     co_return resultData;
 }

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -1266,7 +1266,7 @@ Task<ImageData> readTiffImage(TIFF* tif, const bool reverseEndian, string_view p
     {
         const auto desiredPixelFormat = bitsPerSample > 16 ? EPixelFormat::F32 : EPixelFormat::F16;
         auto rgbaChannels = co_await ImageLoader::makeRgbaInterleavedChannels(
-            numRgbaChannels, hasAlpha, size, EPixelFormat::F32, desiredPixelFormat, partName, priority
+            numRgbaChannels, 4, hasAlpha, size, EPixelFormat::F32, desiredPixelFormat, partName, priority
         );
         auto extraChannels = ImageLoader::makeNChannels(numNonRgbaChannels, size, EPixelFormat::F32, desiredPixelFormat, partName);
 

--- a/src/imageio/WebpImageLoader.cpp
+++ b/src/imageio/WebpImageLoader.cpp
@@ -175,7 +175,7 @@ Task<vector<ImageData>> WebpImageLoader::load(istream& iStream, const fs::path&,
             // WebP is always 8bit per channel, so we can comfortably use F16 for the decoded data.
             resultData.partName = isAnimation ? fmt::format("frames.{}", frameIdx++) : "";
             resultData.channels = co_await makeRgbaInterleavedChannels(
-                numChannels, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
+                numChannels, 4, numChannels == 4, size, EPixelFormat::F32, EPixelFormat::F16, resultData.partName, priority
             );
 
             resultData.hasPremultipliedAlpha = false;


### PR DESCRIPTION
tev has been storing loaded images in interleaved RGBA for a while now, mostly to allow for efficient uploads to the GPU on image selection (can copy the data directly, rather than transforming it). However, depending on the system one is on, the GPU may or may not support 3-channel interleaved RGB which can save 25% memory and bandwidth. With this PR, tev can take advantage of this (and also grayscale L and LA formats, but those are less frequent).