### PR TITLE
Imageloader settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ set(TEV_SOURCES
     include/tev/imageio/WebpImageLoader.h src/imageio/WebpImageLoader.cpp
     include/tev/imageio/Xmp.h src/imageio/Xmp.cpp
 
+    include/tev/BackgroundImagesLoader.h src/BackgroundImagesLoader.cpp
     include/tev/Box.h src/Box.cpp
     include/tev/Channel.h src/Channel.cpp
     include/tev/Common.h src/Common.cpp

--- a/include/tev/BackgroundImagesLoader.h
+++ b/include/tev/BackgroundImagesLoader.h
@@ -65,9 +65,8 @@ public:
     bool recursiveDirectories() const { return mRecursiveDirectories; }
     void setRecursiveDirectories(bool value) { mRecursiveDirectories = value; }
 
-    const ImageLoaderSettings& imageLoaderSettings() const { return mImageLoaderSettings; }
-    ImageLoaderSettings& imageLoaderSettings() { return mImageLoaderSettings; }
-    void setImageLoaderSettings(const ImageLoaderSettings& imageLoaderSettings) { mImageLoaderSettings = imageLoaderSettings; }
+    ImageLoaderSettings& imageLoaderSettings() & { return mImageLoaderSettings; }
+    const ImageLoaderSettings& imageLoaderSettings() const & { return mImageLoaderSettings; }
 
     bool groupChannels() const { return mGroupChannels; }
     void setGroupChannels(bool value) { mGroupChannels = value; }

--- a/include/tev/BackgroundImagesLoader.h
+++ b/include/tev/BackgroundImagesLoader.h
@@ -1,0 +1,95 @@
+/*
+ * tev -- the EDR viewer
+ *
+ * Copyright (C) 2026 Thomas Müller <contact@tom94.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <tev/Common.h>
+#include <tev/Image.h>
+#include <tev/SharedQueue.h>
+#include <tev/imageio/ImageLoader.h>
+
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace tev {
+
+struct ImageAddition {
+    int loadId;
+    bool shallSelect;
+    std::vector<std::shared_ptr<Image>> images;
+    std::shared_ptr<Image> toReplace;
+
+    struct Comparator {
+        bool operator()(const ImageAddition& a, const ImageAddition& b) { return a.loadId > b.loadId; }
+    };
+};
+
+struct PathAndChannelSelector {
+    fs::path path;
+    std::string channelSelector;
+
+    bool operator<(const PathAndChannelSelector& other) const {
+        return path == other.path ? (channelSelector < other.channelSelector) : (path < other.path);
+    }
+};
+
+class BackgroundImagesLoader {
+public:
+    void enqueue(const fs::path& path, std::string_view channelSelector, bool shallSelect, const std::shared_ptr<Image>& toReplace = nullptr);
+    void checkDirectoriesForNewFilesAndLoadThose();
+
+    std::optional<ImageAddition> tryPop();
+    std::optional<nanogui::Vector2i> firstImageSize() const;
+
+    bool publishSortedLoads();
+    bool hasPendingLoads() const;
+
+    bool recursiveDirectories() const { return mRecursiveDirectories; }
+    void setRecursiveDirectories(bool value) { mRecursiveDirectories = value; }
+
+    const ImageLoaderSettings& imageLoaderSettings() const { return mImageLoaderSettings; }
+    ImageLoaderSettings& imageLoaderSettings() { return mImageLoaderSettings; }
+    void setImageLoaderSettings(const ImageLoaderSettings& imageLoaderSettings) { mImageLoaderSettings = imageLoaderSettings; }
+
+    bool groupChannels() const { return mGroupChannels; }
+    void setGroupChannels(bool value) { mGroupChannels = value; }
+
+private:
+    SharedQueue<ImageAddition> mLoadedImages;
+
+    std::priority_queue<ImageAddition, std::vector<ImageAddition>, ImageAddition::Comparator> mPendingLoadedImages;
+    mutable std::mutex mPendingLoadedImagesMutex;
+
+    std::atomic<int> mLoadCounter{0};
+    std::atomic<int> mUnsortedLoadCounter{0};
+
+    bool mRecursiveDirectories = false;
+    std::map<fs::path, std::set<std::string>> mDirectories;
+    std::set<PathAndChannelSelector> mFilesFoundInDirectories;
+
+    ImageLoaderSettings mImageLoaderSettings;
+    bool mGroupChannels = true;
+
+    std::chrono::system_clock::time_point mLoadStartTime;
+    int mLoadStartCounter = 0;
+};
+
+} // namespace tev

--- a/include/tev/Image.h
+++ b/include/tev/Image.h
@@ -144,7 +144,7 @@ struct ImageData {
 
     bool hasChannel(std::string_view channelName) const { return channel(channelName) != nullptr; }
 
-    const Channel* channel(std::string_view channelName) const {
+    const Channel* channel(std::string_view channelName) const & {
         const auto it = std::ranges::find(channels, channelName, [](const auto& c) { return c.name(); });
         if (it != std::end(channels)) {
             return &(*it);
@@ -153,7 +153,7 @@ struct ImageData {
         }
     }
 
-    Channel* mutableChannel(std::string_view channelName) {
+    Channel* mutableChannel(std::string_view channelName) & {
         const auto it = std::ranges::find(channels, channelName, [](const auto& c) { return c.name(); });
         if (it != std::end(channels)) {
             return &(*it);
@@ -181,21 +181,21 @@ public:
     Image(const fs::path& path, fs::file_time_type fileLastModified, ImageData&& data, std::string_view channelSelector, bool groupChannels);
     virtual ~Image();
 
-    const fs::path& path() const { return mPath; }
+    const fs::path& path() const & { return mPath; }
 
     fs::file_time_type fileLastModified() const { return mFileLastModified; }
 
     void setFileLastModified(fs::file_time_type value) { mFileLastModified = value; }
 
-    std::string_view channelSelector() const { return mChannelSelector; }
+    std::string_view channelSelector() const & { return mChannelSelector; }
 
-    std::string_view name() const { return mName; }
+    std::string_view name() const & { return mName; }
 
     std::string shortName() const;
 
     bool hasChannel(std::string_view channelName) const { return mData.hasChannel(channelName); }
 
-    const Channel* channel(std::string_view channelName) const { return mData.channel(channelName); }
+    const Channel* channel(std::string_view channelName) const & { return mData.channel(channelName); }
     std::vector<const Channel*> channels(std::span<const std::string> channelNames) const {
         std::vector<const Channel*> result;
         for (const auto& channelName : channelNames) {
@@ -207,12 +207,10 @@ public:
 
     bool isInterleaved(std::span<const std::string> channelNames, size_t desiredBytesPerSample, size_t desiredStride) const;
 
-    nanogui::Texture* texture(std::span<const std::string> channelNames, EInterpolationMode minFilter, EInterpolationMode magFilter);
+    nanogui::Texture* texture(std::span<const std::string> channelNames, EInterpolationMode minFilter, EInterpolationMode magFilter) &;
 
-    std::vector<std::string> channelsInGroup(std::string_view groupName) const;
+    std::span<const std::string> channelsInGroup(std::string_view groupName) const &;
     void decomposeChannelGroup(std::string_view groupName);
-
-    std::vector<std::string> getExistingChannels(std::span<const std::string> requestedChannels) const;
 
     nanogui::Vector2i size() const { return mData.size(); }
 
@@ -222,8 +220,8 @@ public:
         return pos.x() >= 0 && pos.y() >= 0 && pos.x() < mData.size().x() && pos.y() < mData.size().y();
     }
 
-    const Box2i& dataWindow() const { return mData.dataWindow; }
-    const Box2i& displayWindow() const { return mData.displayWindow; }
+    const Box2i& dataWindow() const & { return mData.dataWindow; }
+    const Box2i& displayWindow() const & { return mData.displayWindow; }
     Box2i toImageCoords(const Box2i& displayWindow) const {
         return displayWindow.translate(mData.displayWindow.min - mData.dataWindow.min);
     }
@@ -236,7 +234,7 @@ public:
 
     size_t numPixels() const { return mData.numPixels(); }
 
-    std::span<const ChannelGroup> channelGroups() const { return mChannelGroups; }
+    std::span<const ChannelGroup> channelGroups() const & { return mChannelGroups; }
 
     int id() const { return mId; }
 
@@ -255,7 +253,7 @@ public:
 
     void updateVectorGraphics(bool append, std::span<const VgCommand> commands);
 
-    std::span<const VgCommand> vgCommands() const { return mVgCommands; }
+    std::span<const VgCommand> vgCommands() const & { return mVgCommands; }
 
     void setStaleIdCallback(const std::function<void(int)>& callback) { mStaleIdCallback = callback; }
 
@@ -305,12 +303,12 @@ public:
 
     std::string toString() const;
 
-    std::span<const AttributeNode> attributes() const { return mData.attributes; }
+    std::span<const AttributeNode> attributes() const & { return mData.attributes; }
 
 private:
     static std::atomic<int> sId;
 
-    Channel* mutableChannel(std::string_view channelName) { return mData.mutableChannel(channelName); }
+    Channel* mutableChannel(std::string_view channelName) & { return mData.mutableChannel(channelName); }
 
     std::vector<ChannelGroup> getGroupedChannels(std::string_view layerName) const;
 

--- a/include/tev/ImageCanvas.h
+++ b/include/tev/ImageCanvas.h
@@ -67,8 +67,8 @@ public:
     nanogui::Vector2i getImageCoords(const Image* image, nanogui::Vector2i mousePos);
     nanogui::Vector2i getDisplayWindowCoords(const Image* image, nanogui::Vector2i mousePos);
 
-    void getValuesAtNanoPos(nanogui::Vector2i nanoPos, std::vector<float>& result, std::span<const std::string> channels);
-    std::vector<float> getValuesAtNanoPos(nanogui::Vector2i nanoPos, std::span<const std::string> channels) {
+    void getValuesAtNanoPos(nanogui::Vector2i nanoPos, std::vector<float>& result, std::span<std::string_view> channels);
+    std::vector<float> getValuesAtNanoPos(nanogui::Vector2i nanoPos, std::span<std::string_view> channels) {
         std::vector<float> result;
         getValuesAtNanoPos(nanoPos, result, channels);
         return result;

--- a/include/tev/ImageViewer.h
+++ b/include/tev/ImageViewer.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <tev/BackgroundImagesLoader.h>
 #include <tev/HelpWindow.h>
 #include <tev/Image.h>
 #include <tev/ImageButton.h>

--- a/include/tev/WaylandClipboard.h
+++ b/include/tev/WaylandClipboard.h
@@ -20,9 +20,11 @@
 
 #include <tev/Common.h>
 
+#include <string_view>
+
 namespace tev {
 
-void waylandSetClipboardPngImage(const char* data, size_t size);
-const char* waylandGetClipboardPngImage(size_t* size);
+void waylandSetClipboardPngImage(std::string_view data);
+std::string_view waylandGetClipboardPngImage();
 
 } // namespace tev

--- a/include/tev/imageio/BmpImageLoader.h
+++ b/include/tev/imageio/BmpImageLoader.h
@@ -32,8 +32,8 @@ public:
         std::istream& iStream,
         const fs::path& path,
         std::string_view channelSelector,
+        const ImageLoaderSettings& settings,
         int priority,
-        const GainmapHeadroom& gainmapHeadroom,
         std::optional<size_t> pixelDataOffset,
         // If provided, this will be used as the image size instead of the size specified in the BMP headers. The value will be modified to
         // the size from the bmp header in case of a mismatch, so the caller can detect that and react accordingly. Necessary for loading
@@ -46,7 +46,7 @@ public:
     ) const;
 
     Task<std::vector<ImageData>> load(
-        std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom
+        std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority
     ) const override;
 
     std::string name() const override { return "BMP"; }

--- a/include/tev/imageio/ClipboardImageLoader.h
+++ b/include/tev/imageio/ClipboardImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class ClipboardImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>> load(
-        std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom
+        std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority
     ) const override;
 
     std::string name() const override { return "clipboard"; }

--- a/include/tev/imageio/DdsImageLoader.h
+++ b/include/tev/imageio/DdsImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class DdsImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "DDS"; }
 };

--- a/include/tev/imageio/EmptyImageLoader.h
+++ b/include/tev/imageio/EmptyImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class EmptyImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "IPC"; }
 };

--- a/include/tev/imageio/ExrImageLoader.h
+++ b/include/tev/imageio/ExrImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class ExrImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "OpenEXR"; }
 };

--- a/include/tev/imageio/HeifImageLoader.h
+++ b/include/tev/imageio/HeifImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class HeifImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "HEIF"; }
 };

--- a/include/tev/imageio/IcoImageLoader.h
+++ b/include/tev/imageio/IcoImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class IcoImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>> load(
-        std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom
+        std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority
     ) const override;
 
     std::string name() const override { return "ICO"; }

--- a/include/tev/imageio/ImageLoader.h
+++ b/include/tev/imageio/ImageLoader.h
@@ -151,6 +151,11 @@ Task<void> toFloat32(
     );
 }
 
+struct ImageLoaderSettings {
+    GainmapHeadroom gainmapHeadroom = {};
+    bool dngApplyCameraProfile = false;
+};
+
 class ImageLoader {
 public:
     class FormatNotSupported : public std::runtime_error {
@@ -161,7 +166,7 @@ public:
     virtual ~ImageLoader() {}
 
     virtual Task<std::vector<ImageData>> load(
-        std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom
+        std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority
     ) const = 0;
 
     virtual std::string name() const = 0;

--- a/include/tev/imageio/Jpeg2000ImageLoader.h
+++ b/include/tev/imageio/Jpeg2000ImageLoader.h
@@ -28,15 +28,15 @@ namespace tev {
 class Jpeg2000ImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>> load(
-        std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom
+        std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority
     ) const override;
 
     Task<std::vector<ImageData>> load(
         std::span<const uint8_t> data,
         const fs::path& path,
         std::string_view channelSelector,
+        const ImageLoaderSettings& settings,
         int priority,
-        const GainmapHeadroom& gainmapHeadroom,
         bool skipColorProcessing,
         size_t* bitsPerSampleOut = nullptr,
         EPixelType* pixelTypeOut = nullptr

--- a/include/tev/imageio/JpegTurboImageLoader.h
+++ b/include/tev/imageio/JpegTurboImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class JpegTurboImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "JPEG Turbo"; }
 };

--- a/include/tev/imageio/JxlImageLoader.h
+++ b/include/tev/imageio/JxlImageLoader.h
@@ -30,15 +30,15 @@ namespace tev {
 class JxlImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>> load(
-        std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom
+        std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority
     ) const override;
 
     Task<std::vector<ImageData>> load(
         std::span<const uint8_t> data,
         const fs::path& path,
         std::string_view channelSelector,
+        const ImageLoaderSettings& settings,
         int priority,
-        const GainmapHeadroom& gainmapHeadroom,
         bool skipColorProcessing,
         size_t* bitsPerSampleOut = nullptr,
         EPixelType* pixelTypeOut = nullptr

--- a/include/tev/imageio/PfmImageLoader.h
+++ b/include/tev/imageio/PfmImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class PfmImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "PFM/PAM"; }
 };

--- a/include/tev/imageio/PngImageLoader.h
+++ b/include/tev/imageio/PngImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class PngImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "PNG"; }
 };

--- a/include/tev/imageio/QoiImageLoader.h
+++ b/include/tev/imageio/QoiImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class QoiImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "QOI"; }
 };

--- a/include/tev/imageio/RawImageLoader.h
+++ b/include/tev/imageio/RawImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class RawImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "RAW"; }
 };

--- a/include/tev/imageio/StbiImageLoader.h
+++ b/include/tev/imageio/StbiImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class StbiImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "STBI"; }
 };

--- a/include/tev/imageio/TiffImageLoader.h
+++ b/include/tev/imageio/TiffImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class TiffImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "TIFF"; }
 };

--- a/include/tev/imageio/WebpImageLoader.h
+++ b/include/tev/imageio/WebpImageLoader.h
@@ -28,7 +28,7 @@ namespace tev {
 class WebpImageLoader : public ImageLoader {
 public:
     Task<std::vector<ImageData>>
-        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom) const override;
+        load(std::istream& iStream, const fs::path& path, std::string_view channelSelector, const ImageLoaderSettings& settings, int priority) const override;
 
     std::string name() const override { return "WEBP"; }
 };

--- a/src/BackgroundImagesLoader.cpp
+++ b/src/BackgroundImagesLoader.cpp
@@ -1,0 +1,154 @@
+/*
+ * tev -- the EDR viewer
+ *
+ * Copyright (C) 2025 Thomas Müller <contact@tom94.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <tev/BackgroundImagesLoader.h>
+#include <tev/Common.h>
+#include <tev/Image.h>
+#include <tev/ThreadPool.h>
+#include <tev/imageio/Colors.h>
+#include <tev/imageio/ImageLoader.h>
+#include <tev/imageio/ImageSaver.h>
+
+#include <algorithm>
+#include <chrono>
+#include <map>
+#include <unordered_set>
+#include <vector>
+
+using namespace nanogui;
+using namespace std;
+
+namespace tev {
+
+void BackgroundImagesLoader::enqueue(const fs::path& path, string_view channelSelector, bool shallSelect, const shared_ptr<Image>& toReplace) {
+    // If we're trying to open a directory, try loading all the images inside of that directory
+    if (fs::exists(path) && fs::is_directory(path)) {
+        tlog::info() << fmt::format("Loading images {}from directory {}", mRecursiveDirectories ? "recursively " : "", path);
+
+        const fs::path canonicalPath = fs::canonical(path);
+        mDirectories[canonicalPath].emplace(channelSelector);
+
+        vector<fs::directory_entry> entries;
+        forEachFileInDir(mRecursiveDirectories, canonicalPath, [&](const auto& entry) {
+            if (!entry.is_directory()) {
+                mFilesFoundInDirectories.emplace(PathAndChannelSelector{entry, string{channelSelector}});
+                entries.emplace_back(entry);
+            }
+        });
+
+        // Open directory entries in natural order (e.g. "file1.exr", "file2.exr", "file10.exr" instead of "file1.exr", "file10.exr"),
+        // selecting the first one.
+        sort(begin(entries), end(entries), [](const auto& a, const auto& b) { return naturalCompare(a.path().string(), b.path().string()); });
+
+        for (size_t i = 0; i < entries.size(); ++i) {
+            enqueue(entries[i], channelSelector, i == 0 ? shallSelect : false);
+        }
+
+        return;
+    }
+
+    // We want to measure the time it takes to load a whole batch of images. Start measuring when the loader queue goes from empty to
+    // non-empty and stop measuring when the queue goes from non-empty to empty again.
+    if (mUnsortedLoadCounter == mLoadCounter) {
+        mLoadStartTime = chrono::system_clock::now();
+        mLoadStartCounter = mUnsortedLoadCounter;
+    }
+
+    const int loadId = mUnsortedLoadCounter++;
+    invokeTaskDetached([loadId, path, channelSelector = string{channelSelector}, shallSelect, toReplace, this]() -> Task<void> {
+        const int taskPriority = -Image::drawId();
+
+        co_await ThreadPool::global().enqueueCoroutine(taskPriority);
+        const auto images = co_await tryLoadImage(taskPriority, path, channelSelector, mImageLoaderSettings, mGroupChannels);
+
+        {
+            const lock_guard lock{mPendingLoadedImagesMutex};
+            mPendingLoadedImages.push({loadId, shallSelect, images, toReplace});
+        }
+
+        if (publishSortedLoads()) {
+            redrawWindow();
+        }
+    });
+}
+
+void BackgroundImagesLoader::checkDirectoriesForNewFilesAndLoadThose() {
+    for (const auto& dir : mDirectories) {
+        forEachFileInDir(mRecursiveDirectories, dir.first, [&](const auto& entry) {
+            if (!entry.is_directory()) {
+                for (const auto& channelSelector : dir.second) {
+                    const PathAndChannelSelector p = {entry, channelSelector};
+                    if (!mFilesFoundInDirectories.contains(p)) {
+                        mFilesFoundInDirectories.emplace(p);
+                        enqueue(entry, channelSelector, false);
+                    }
+                }
+            }
+        });
+    }
+}
+
+optional<ImageAddition> BackgroundImagesLoader::tryPop() {
+    const lock_guard lock{mPendingLoadedImagesMutex};
+    return mLoadedImages.tryPop();
+}
+
+optional<nanogui::Vector2i> BackgroundImagesLoader::firstImageSize() const {
+    const lock_guard lock{mPendingLoadedImagesMutex};
+    if (mLoadedImages.empty()) {
+        return nullopt;
+    }
+
+    const ImageAddition& firstImage = mLoadedImages.front();
+    if (firstImage.images.empty()) {
+        return nullopt;
+    }
+
+    return firstImage.images.front()->size();
+}
+
+bool BackgroundImagesLoader::publishSortedLoads() {
+    const lock_guard lock{mPendingLoadedImagesMutex};
+    bool pushed = false;
+    while (!mPendingLoadedImages.empty() && mPendingLoadedImages.top().loadId == mLoadCounter) {
+        // null image pointers indicate failed loads. These shouldn't be pushed.
+        if (!mPendingLoadedImages.top().images.empty()) {
+            mLoadedImages.push(mPendingLoadedImages.top());
+        }
+
+        mPendingLoadedImages.pop();
+        pushed = true;
+
+        ++mLoadCounter;
+    }
+
+    if (mLoadCounter == mUnsortedLoadCounter && mLoadCounter - mLoadStartCounter > 1) {
+        const auto end = chrono::system_clock::now();
+        const chrono::duration<double> elapsedSeconds = end - mLoadStartTime;
+        tlog::success() << fmt::format("Loaded {} images in {:.3f} seconds.", mLoadCounter - mLoadStartCounter, elapsedSeconds.count());
+    }
+
+    return pushed;
+}
+
+bool BackgroundImagesLoader::hasPendingLoads() const {
+    const lock_guard lock{mPendingLoadedImagesMutex};
+    return mLoadCounter != mUnsortedLoadCounter;
+}
+
+} // namespace tev

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -760,7 +760,7 @@ Task<void> prepareTextureChannel(
     }
 }
 
-Texture* Image::texture(span<const string> channelNames, EInterpolationMode minFilter, EInterpolationMode magFilter) {
+Texture* Image::texture(span<const string> channelNames, EInterpolationMode minFilter, EInterpolationMode magFilter) & {
     if (size().x() > maxTextureSize() || size().y() > maxTextureSize()) {
         tlog::error() << fmt::format("{} is too large for Texturing. ({}x{})", mName, size().x(), size().y());
         return nullptr;
@@ -901,7 +901,7 @@ Texture* Image::texture(span<const string> channelNames, EInterpolationMode minF
     return texture.get();
 }
 
-vector<string> Image::channelsInGroup(string_view groupName) const {
+span<const string> Image::channelsInGroup(string_view groupName) const & {
     for (const auto& group : mChannelGroups) {
         if (group.name == groupName) {
             return group.channels;
@@ -1005,12 +1005,6 @@ vector<ChannelGroup> Image::getGroupedChannels(string_view layerName) const {
 
     TEV_ASSERT(!result.empty(), "Images with no channels should never exist.");
 
-    return result;
-}
-
-vector<string> Image::getExistingChannels(span<const string> requestedChannels) const {
-    vector<string> result;
-    copy_if(begin(requestedChannels), end(requestedChannels), back_inserter(result), [&](string_view c) { return hasChannel(c); });
     return result;
 }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1408,7 +1408,7 @@ Task<nanogui::Vector2i>
 }
 
 Task<vector<shared_ptr<Image>>> tryLoadImage(
-    int taskPriority, fs::path path, istream& iStream, string_view channelSelector, const GainmapHeadroom& gainmapHeadroom, bool groupChannels
+    int taskPriority, fs::path path, istream& iStream, string_view channelSelector, const ImageLoaderSettings& settings, bool groupChannels
 ) {
     const auto handleException = [&](const exception& e) {
         if (channelSelector.empty()) {
@@ -1445,7 +1445,7 @@ Task<vector<shared_ptr<Image>>> tryLoadImage(
         for (const auto& imageLoader : ImageLoader::getLoaders()) {
             try {
                 loadMethod = imageLoader->name();
-                imageData = co_await imageLoader->load(iStream, path, channelSelector, taskPriority, gainmapHeadroom);
+                imageData = co_await imageLoader->load(iStream, path, channelSelector, settings, taskPriority);
                 success = true;
                 break;
             } catch (const ImageLoader::FormatNotSupported& e) {
@@ -1508,12 +1508,12 @@ Task<vector<shared_ptr<Image>>> tryLoadImage(
 }
 
 Task<vector<shared_ptr<Image>>>
-    tryLoadImage(fs::path path, istream& iStream, string_view channelSelector, const GainmapHeadroom& gainmapHeadroom, bool groupChannels) {
-    co_return co_await tryLoadImage(-Image::drawId(), path, iStream, channelSelector, gainmapHeadroom, groupChannels);
+    tryLoadImage(fs::path path, istream& iStream, string_view channelSelector, const ImageLoaderSettings& settings, bool groupChannels) {
+    co_return co_await tryLoadImage(-Image::drawId(), path, iStream, channelSelector, settings, groupChannels);
 }
 
 Task<vector<shared_ptr<Image>>>
-    tryLoadImage(int taskPriority, fs::path path, string_view channelSelector, const GainmapHeadroom& gainmapHeadroom, bool groupChannels) {
+    tryLoadImage(int taskPriority, fs::path path, string_view channelSelector, const ImageLoaderSettings& settings, bool groupChannels) {
     try {
         path = fs::absolute(path);
     } catch (const runtime_error&) {
@@ -1522,128 +1522,12 @@ Task<vector<shared_ptr<Image>>>
     }
 
     ifstream fileStream{path, ios_base::binary};
-    co_return co_await tryLoadImage(taskPriority, path, fileStream, channelSelector, gainmapHeadroom, groupChannels);
+    co_return co_await tryLoadImage(taskPriority, path, fileStream, channelSelector, settings, groupChannels);
 }
 
 Task<vector<shared_ptr<Image>>>
-    tryLoadImage(fs::path path, string_view channelSelector, const GainmapHeadroom& gainmapHeadroom, bool groupChannels) {
-    co_return co_await tryLoadImage(-Image::drawId(), path, channelSelector, gainmapHeadroom, groupChannels);
-}
-
-void BackgroundImagesLoader::enqueue(const fs::path& path, string_view channelSelector, bool shallSelect, const shared_ptr<Image>& toReplace) {
-    // If we're trying to open a directory, try loading all the images inside of that directory
-    if (fs::exists(path) && fs::is_directory(path)) {
-        tlog::info() << fmt::format("Loading images {}from directory {}", mRecursiveDirectories ? "recursively " : "", path);
-
-        const fs::path canonicalPath = fs::canonical(path);
-        mDirectories[canonicalPath].emplace(channelSelector);
-
-        vector<fs::directory_entry> entries;
-        forEachFileInDir(mRecursiveDirectories, canonicalPath, [&](const auto& entry) {
-            if (!entry.is_directory()) {
-                mFilesFoundInDirectories.emplace(PathAndChannelSelector{entry, string{channelSelector}});
-                entries.emplace_back(entry);
-            }
-        });
-
-        // Open directory entries in natural order (e.g. "file1.exr", "file2.exr", "file10.exr" instead of "file1.exr", "file10.exr"),
-        // selecting the first one.
-        sort(begin(entries), end(entries), [](const auto& a, const auto& b) { return naturalCompare(a.path().string(), b.path().string()); });
-
-        for (size_t i = 0; i < entries.size(); ++i) {
-            enqueue(entries[i], channelSelector, i == 0 ? shallSelect : false);
-        }
-
-        return;
-    }
-
-    // We want to measure the time it takes to load a whole batch of images. Start measuring when the loader queue goes from empty to
-    // non-empty and stop measuring when the queue goes from non-empty to empty again.
-    if (mUnsortedLoadCounter == mLoadCounter) {
-        mLoadStartTime = chrono::system_clock::now();
-        mLoadStartCounter = mUnsortedLoadCounter;
-    }
-
-    const int loadId = mUnsortedLoadCounter++;
-    invokeTaskDetached([loadId, path, channelSelector = string{channelSelector}, shallSelect, toReplace, this]() -> Task<void> {
-        const int taskPriority = -Image::drawId();
-
-        co_await ThreadPool::global().enqueueCoroutine(taskPriority);
-        const auto images = co_await tryLoadImage(taskPriority, path, channelSelector, mGainmapHeadroom, mGroupChannels);
-
-        {
-            const lock_guard lock{mPendingLoadedImagesMutex};
-            mPendingLoadedImages.push({loadId, shallSelect, images, toReplace});
-        }
-
-        if (publishSortedLoads()) {
-            redrawWindow();
-        }
-    });
-}
-
-void BackgroundImagesLoader::checkDirectoriesForNewFilesAndLoadThose() {
-    for (const auto& dir : mDirectories) {
-        forEachFileInDir(mRecursiveDirectories, dir.first, [&](const auto& entry) {
-            if (!entry.is_directory()) {
-                for (const auto& channelSelector : dir.second) {
-                    const PathAndChannelSelector p = {entry, channelSelector};
-                    if (!mFilesFoundInDirectories.contains(p)) {
-                        mFilesFoundInDirectories.emplace(p);
-                        enqueue(entry, channelSelector, false);
-                    }
-                }
-            }
-        });
-    }
-}
-
-optional<ImageAddition> BackgroundImagesLoader::tryPop() {
-    const lock_guard lock{mPendingLoadedImagesMutex};
-    return mLoadedImages.tryPop();
-}
-
-optional<nanogui::Vector2i> BackgroundImagesLoader::firstImageSize() const {
-    const lock_guard lock{mPendingLoadedImagesMutex};
-    if (mLoadedImages.empty()) {
-        return nullopt;
-    }
-
-    const ImageAddition& firstImage = mLoadedImages.front();
-    if (firstImage.images.empty()) {
-        return nullopt;
-    }
-
-    return firstImage.images.front()->size();
-}
-
-bool BackgroundImagesLoader::publishSortedLoads() {
-    const lock_guard lock{mPendingLoadedImagesMutex};
-    bool pushed = false;
-    while (!mPendingLoadedImages.empty() && mPendingLoadedImages.top().loadId == mLoadCounter) {
-        // null image pointers indicate failed loads. These shouldn't be pushed.
-        if (!mPendingLoadedImages.top().images.empty()) {
-            mLoadedImages.push(mPendingLoadedImages.top());
-        }
-
-        mPendingLoadedImages.pop();
-        pushed = true;
-
-        ++mLoadCounter;
-    }
-
-    if (mLoadCounter == mUnsortedLoadCounter && mLoadCounter - mLoadStartCounter > 1) {
-        const auto end = chrono::system_clock::now();
-        const chrono::duration<double> elapsedSeconds = end - mLoadStartTime;
-        tlog::success() << fmt::format("Loaded {} images in {:.3f} seconds.", mLoadCounter - mLoadStartCounter, elapsedSeconds.count());
-    }
-
-    return pushed;
-}
-
-bool BackgroundImagesLoader::hasPendingLoads() const {
-    const lock_guard lock{mPendingLoadedImagesMutex};
-    return mLoadCounter != mUnsortedLoadCounter;
+    tryLoadImage(fs::path path, string_view channelSelector, const ImageLoaderSettings& settings, bool groupChannels) {
+    co_return co_await tryLoadImage(-Image::drawId(), path, channelSelector, settings, groupChannels);
 }
 
 } // namespace tev

--- a/src/ImageCanvas.cpp
+++ b/src/ImageCanvas.cpp
@@ -133,7 +133,9 @@ void ImageCanvas::drawPixelValuesAsText(NVGcontext* ctx) {
     };
 
     if (pixelSize.x() > 50 && pixelSize.x() < 1024) {
-        vector<string> channels = mImage->channelsInGroup(mRequestedChannelGroup);
+        const auto channelsSpan = mImage->channelsInGroup(mRequestedChannelGroup);
+        vector<string_view> channels(begin(channelsSpan), end(channelsSpan));
+
         // Remove duplicates
         channels.erase(unique(begin(channels), end(channels)), end(channels));
         if (channels.empty()) {
@@ -563,13 +565,13 @@ Vector2i ImageCanvas::getDisplayWindowCoords(const Image* image, Vector2i nanoPo
     return imageCoords;
 }
 
-void ImageCanvas::getValuesAtNanoPos(Vector2i nanoPos, vector<float>& result, span<const string> channels) {
+void ImageCanvas::getValuesAtNanoPos(Vector2i nanoPos, vector<float>& result, span<string_view> channels) {
     result.clear();
     if (!mImage) {
         return;
     }
 
-    auto imageCoords = getImageCoords(mImage.get(), nanoPos);
+    const auto imageCoords = getImageCoords(mImage.get(), nanoPos);
     for (const auto& channel : channels) {
         const Channel* c = mImage->channel(channel);
         TEV_ASSERT(c, "Requested channel must exist.");

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -1929,7 +1929,7 @@ void ImageViewer::normalizeExposureAndOffset() {
         return;
     }
 
-    auto channels = mCurrentImage->channelsInGroup(mCurrentGroup);
+    const auto channels = mCurrentImage->channelsInGroup(mCurrentGroup);
 
     float minimum = numeric_limits<float>::max();
     float maximum = numeric_limits<float>::min();
@@ -1940,7 +1940,7 @@ void ImageViewer::normalizeExposureAndOffset() {
         minimum = std::min(minimum, cmin);
     }
 
-    float factor = 1.0f / (maximum - minimum);
+    const float factor = 1.0f / (maximum - minimum);
     setExposure(log2(factor));
     setOffset(-minimum * factor);
 }
@@ -2724,7 +2724,8 @@ void ImageViewer::updateTitle() {
 
     ostringstream caption;
 
-    auto channels = mCurrentImage->channelsInGroup(mCurrentGroup);
+    const auto channelsSpan = mCurrentImage->channelsInGroup(mCurrentGroup);
+    vector<string_view> channels = {begin(channelsSpan), end(channelsSpan)};
 
     // Remove duplicates
     channels.erase(unique(begin(channels), end(channels)), end(channels));

--- a/src/ImageViewer.cpp
+++ b/src/ImageViewer.cpp
@@ -2474,7 +2474,7 @@ void ImageViewer::pasteImagesFromClipboard() {
 
     tlog::info() << "Loading image from clipboard...";
     auto imagesLoadTask = tryLoadImage(
-        fmt::format("clipboard ({})", ++mClipboardIndex), imageStream, "", mImagesLoader->gainmapHeadroom(), mImagesLoader->groupChannels()
+        fmt::format("clipboard ({})", ++mClipboardIndex), imageStream, "", mImagesLoader->imageLoaderSettings(), mImagesLoader->groupChannels()
     );
 
     const auto images = imagesLoadTask.get();

--- a/src/UberShader.cpp
+++ b/src/UberShader.cpp
@@ -573,7 +573,7 @@ void UberShader::draw(
 ) {
     // We're passing the channels found in `mImage` such that, if some channels don't exist in `mReference`, they're filled with default
     // values (0 for colors, 1 for alpha).
-    const vector<string> channels = image ? image->channelsInGroup(requestedChannelGroup) : vector<string>{};
+    const auto channels = image ? image->channelsInGroup(requestedChannelGroup) : span<const string>{};
     Texture* const textureImage = image ? image->texture(channels, minFilter, magFilter) : nullptr;
     Texture* const textureReference = reference ? reference->texture(channels, minFilter, magFilter) : nullptr;
 

--- a/src/WaylandClipboard.cpp
+++ b/src/WaylandClipboard.cpp
@@ -26,30 +26,33 @@
 #include <GLFW/glfw3.h>
 #include <GLFW/glfw3native.h>
 
+#include <string_view>
+
 using namespace std;
 
 namespace tev {
 
-void waylandSetClipboardPngImage(const char* data, size_t size) {
+void waylandSetClipboardPngImage(string_view data) {
     if (glfwGetPlatform() != GLFW_PLATFORM_WAYLAND) {
         throw runtime_error("Wayland clipboard operations are only supported on Wayland.");
     }
 
 #if !defined(__APPLE__) && !defined(_WIN32)
-    glfwSetWaylandClipboardData(data, "image/png", size);
+    glfwSetWaylandClipboardData(data.data(), "image/png", data.size());
 #endif
 }
 
-const char* waylandGetClipboardPngImage(size_t* size) {
+string_view waylandGetClipboardPngImage() {
     if (glfwGetPlatform() != GLFW_PLATFORM_WAYLAND) {
         throw runtime_error("Wayland clipboard operations are only supported on Wayland.");
     }
 
 #if !defined(__APPLE__) && !defined(_WIN32)
-    return glfwGetWaylandClipboardData("image/png", size);
+    size_t size = 0;
+    const char* data = glfwGetWaylandClipboardData("image/png", &size);
+    return {data, size};
 #else
-    *size = 0;
-    return nullptr;
+    return {};
 #endif
 }
 

--- a/src/imageio/ClipboardImageLoader.cpp
+++ b/src/imageio/ClipboardImageLoader.cpp
@@ -27,7 +27,7 @@ using namespace std;
 
 namespace tev {
 
-Task<vector<ImageData>> ClipboardImageLoader::load(istream& iStream, const fs::path&, string_view, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>> ClipboardImageLoader::load(istream& iStream, const fs::path&, string_view, const ImageLoaderSettings&, int priority) const {
     char magic[4];
     clip::image_spec spec;
 

--- a/src/imageio/DdsImageLoader.cpp
+++ b/src/imageio/DdsImageLoader.cpp
@@ -152,7 +152,7 @@ static size_t getDxgiChannelCount(DXGI_FORMAT fmt) {
     }
 }
 
-Task<vector<ImageData>> DdsImageLoader::load(istream& iStream, const fs::path&, string_view, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>> DdsImageLoader::load(istream& iStream, const fs::path&, string_view, const ImageLoaderSettings&, int priority) const {
     iStream.seekg(0, iStream.end);
     const size_t dataSize = iStream.tellg();
     if (dataSize < 4) {

--- a/src/imageio/EmptyImageLoader.cpp
+++ b/src/imageio/EmptyImageLoader.cpp
@@ -25,7 +25,7 @@ using namespace std;
 
 namespace tev {
 
-Task<vector<ImageData>> EmptyImageLoader::load(istream& iStream, const fs::path&, string_view, int, const GainmapHeadroom&) const {
+Task<vector<ImageData>> EmptyImageLoader::load(istream& iStream, const fs::path&, string_view, const ImageLoaderSettings&, int) const {
     char magic[6];
     iStream.read(magic, 6);
     string magicString(magic, 6);

--- a/src/imageio/ExrImageLoader.cpp
+++ b/src/imageio/ExrImageLoader.cpp
@@ -443,7 +443,7 @@ private:
     HeapArray<char> mData;
 };
 
-Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const fs::path& path, string_view channelSelector, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>> ExrImageLoader::load(istream& iStream, const fs::path& path, string_view channelSelector, const ImageLoaderSettings&, int priority) const {
     try {
         if (!isExrImage(iStream)) {
             throw FormatNotSupported{"File is not an EXR image."};

--- a/src/imageio/HeifImageLoader.cpp
+++ b/src/imageio/HeifImageLoader.cpp
@@ -41,7 +41,7 @@ using namespace std;
 namespace tev {
 
 Task<vector<ImageData>> HeifImageLoader::load(
-    istream& iStream, const fs::path&, string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom
+    istream& iStream, const fs::path&, string_view channelSelector, const ImageLoaderSettings& settings, int priority
 ) const {
     // libheif's spec says it needs the first 12 bytes to determine whether the image can be read.
     uint8_t header[12];
@@ -874,12 +874,12 @@ Task<vector<ImageData>> HeifImageLoader::load(
                 if (isoGainMapMetadata) {
                     tlog::debug() << fmt::format("Found ISO 21496-1 gain map w/ metadata: '{}'. Applying.", auxImg.name);
                     co_await preprocessAndApplyIsoGainMap(
-                        mainImage, auxImg.data, *isoGainMapMetadata, mainImage.nativeMetadata.chroma, altImgChroma, gainmapHeadroom, priority
+                        mainImage, auxImg.data, *isoGainMapMetadata, mainImage.nativeMetadata.chroma, altImgChroma, settings.gainmapHeadroom, priority
                     );
                 } else if (auxImg.isAppleGainmap) {
                     const auto appleMakerNote = exif ? exif->tryGetAppleMakerNote() : nullopt;
                     tlog::debug() << fmt::format("Found Apple HDR gain map: {} appleMakerNote={}", auxImg.name, appleMakerNote ? "yes" : "no");
-                    co_await preprocessAndApplyAppleGainMap(mainImage, auxImg.data, appleMakerNote, gainmapHeadroom, priority);
+                    co_await preprocessAndApplyAppleGainMap(mainImage, auxImg.data, appleMakerNote, settings.gainmapHeadroom, priority);
                 } else {
                     tlog::warning() << fmt::format(
                         "Found ISO 21496-1 gain map '{}' but no associated metadata. Skipping gain map application.", auxImg.name

--- a/src/imageio/IcoImageLoader.cpp
+++ b/src/imageio/IcoImageLoader.cpp
@@ -36,7 +36,7 @@ template <typename T> static T read(const uint8_t* data, bool reverseEndianness)
 }
 
 Task<vector<ImageData>> IcoImageLoader::load(
-    istream& iStream, const fs::path& path, string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom
+    istream& iStream, const fs::path& path, string_view channelSelector, const ImageLoaderSettings& settings, int priority
 ) const {
     const size_t initialPos = iStream.tellg();
     const bool reverseEndianness = endian::native == endian::big;
@@ -147,7 +147,7 @@ Task<vector<ImageData>> IcoImageLoader::load(
             }
 
             const auto pngLoader = PngImageLoader{};
-            imageData = co_await pngLoader.load(iStream, path, channelSelector, priority, gainmapHeadroom);
+            imageData = co_await pngLoader.load(iStream, path, channelSelector, settings, priority);
         } catch (const FormatNotSupported&) {
             tlog::debug() << fmt::format("Not a PNG image; trying BMP.", i);
         } catch (const ImageLoadError& e) {
@@ -168,9 +168,7 @@ Task<vector<ImageData>> IcoImageLoader::load(
                 auto size = Vector2i{entry.width, entry.height};
 
                 const auto bmpLoader = BmpImageLoader{};
-                imageData = co_await bmpLoader.loadWithoutFileHeader(
-                    iStream, path, channelSelector, priority, gainmapHeadroom, nullopt, &size, true
-                );
+                imageData = co_await bmpLoader.loadWithoutFileHeader(iStream, path, channelSelector, settings, priority, nullopt, &size, true);
 
                 if (size != Vector2i{entry.width, entry.height}) {
                     if (size != Vector2i{entry.width, entry.height * 2}) {

--- a/src/imageio/Jpeg2000ImageLoader.cpp
+++ b/src/imageio/Jpeg2000ImageLoader.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "tev/imageio/ImageLoader.h"
 #include <tev/Common.h>
 #include <tev/ThreadPool.h>
 #include <tev/imageio/Colors.h>
@@ -219,8 +220,8 @@ Task<vector<ImageData>> Jpeg2000ImageLoader::load(
     span<const uint8_t> data,
     const fs::path& path,
     string_view channelSelector,
+    const ImageLoaderSettings& settings,
     int priority,
-    const GainmapHeadroom& gainmapHeadroom,
     bool skipColorProcessing,
     size_t* bitsPerSampleOut,
     EPixelType* pixelTypeOut
@@ -517,7 +518,7 @@ Task<vector<ImageData>> Jpeg2000ImageLoader::load(
 }
 
 Task<vector<ImageData>> Jpeg2000ImageLoader::load(
-    istream& iStream, const fs::path& path, string_view channelSelector, int priority, const GainmapHeadroom& gainmapHeadroom
+    istream& iStream, const fs::path& path, string_view channelSelector, const ImageLoaderSettings& settings, int priority
 ) const {
     const size_t initialPos = iStream.tellg();
 
@@ -536,7 +537,7 @@ Task<vector<ImageData>> Jpeg2000ImageLoader::load(
     HeapArray<uint8_t> data(dataSize);
     iStream.read((char*)data.data(), dataSize);
 
-    co_return co_await load(data, path, channelSelector, priority, gainmapHeadroom, false);
+    co_return co_await load(data, path, channelSelector, settings, priority, false);
 }
 
 } // namespace tev

--- a/src/imageio/JpegTurboImageLoader.cpp
+++ b/src/imageio/JpegTurboImageLoader.cpp
@@ -39,7 +39,7 @@ using namespace std;
 namespace tev {
 
 Task<vector<ImageData>>
-    JpegTurboImageLoader::load(istream& iStream, const fs::path&, string_view, int priority, const GainmapHeadroom& gainmapHeadroom) const {
+    JpegTurboImageLoader::load(istream& iStream, const fs::path&, string_view, const ImageLoaderSettings& settings, int priority) const {
     const size_t initialPos = iStream.tellg();
 
     unsigned char header[2] = {0};
@@ -612,10 +612,10 @@ Task<vector<ImageData>>
             mainImage.attributes.emplace_back(isoMetadata.toAttributes());
 
             co_await preprocessAndApplyIsoGainMap(
-                mainImage, imageData, isoMetadata, mainImage.nativeMetadata.chroma, imageInfo.isoGainmapInfo->chroma, gainmapHeadroom, priority
+                mainImage, imageData, isoMetadata, mainImage.nativeMetadata.chroma, imageInfo.isoGainmapInfo->chroma, settings.gainmapHeadroom, priority
             );
         } else if (imageInfo.isAppleGainmap) {
-            co_await preprocessAndApplyAppleGainMap(mainImage, imageData, mainImageInfo.appleMakerNoteIfd, gainmapHeadroom, priority);
+            co_await preprocessAndApplyAppleGainMap(mainImage, imageData, mainImageInfo.appleMakerNoteIfd, settings.gainmapHeadroom, priority);
         }
 
         mainImage.channels.insert(

--- a/src/imageio/PfmImageLoader.cpp
+++ b/src/imageio/PfmImageLoader.cpp
@@ -97,7 +97,7 @@ static uint8_t version(const PamType pamType) {
     return (uint8_t)pamType;
 }
 
-Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, string_view, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>> PfmImageLoader::load(istream& iStream, const fs::path&, string_view, const ImageLoaderSettings&, int priority) const {
     size_t frameIdx = 0;
 
     const auto loadPam = [&iStream, &frameIdx, priority]() -> Task<vector<ImageData>> {

--- a/src/imageio/PngImageLoader.cpp
+++ b/src/imageio/PngImageLoader.cpp
@@ -30,7 +30,7 @@ using namespace std;
 
 namespace tev {
 
-Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, string_view, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>> PngImageLoader::load(istream& iStream, const fs::path&, string_view, const ImageLoaderSettings&, int priority) const {
     png_byte header[8] = {0};
     iStream.read(reinterpret_cast<char*>(header), 8);
     if (png_sig_cmp(header, 0, 8)) {

--- a/src/imageio/QoiImageLoader.cpp
+++ b/src/imageio/QoiImageLoader.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 namespace tev {
 
-Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, string_view, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>> QoiImageLoader::load(istream& iStream, const fs::path&, string_view, const ImageLoaderSettings&, int priority) const {
     char magic[4];
     iStream.read(magic, 4);
     string magicString(magic, 4);

--- a/src/imageio/RawImageLoader.cpp
+++ b/src/imageio/RawImageLoader.cpp
@@ -140,7 +140,7 @@ Box2i maskToBox(const int mask[4]) {
     };
 }
 
-Task<vector<ImageData>> RawImageLoader::load(istream& iStream, const fs::path& path, string_view, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>> RawImageLoader::load(istream& iStream, const fs::path& path, string_view, const ImageLoaderSettings&, int priority) const {
     if (toLower(toString(path.extension())) == ".dng") {
         throw FormatNotSupported{"DNG files will be handled by TiffImageLoader."};
     }

--- a/src/imageio/StbiImageLoader.cpp
+++ b/src/imageio/StbiImageLoader.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 namespace tev {
 
-Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&, string_view, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>> StbiImageLoader::load(istream& iStream, const fs::path&, string_view, const ImageLoaderSettings&, int priority) const {
     static const stbi_io_callbacks callbacks = {
         // Read
         [](void* context, char* data, int size) {

--- a/src/imageio/TiffImageLoader.cpp
+++ b/src/imageio/TiffImageLoader.cpp
@@ -2114,13 +2114,13 @@ Task<ImageData>
                             case COMPRESSION_JXL: {
                                 const auto loader = JxlImageLoader{};
                                 tmp = co_await loader.load(
-                                    compressedTileData, "", "", priority, {}, false, &nestedBitsPerSample, &nestedPixelType
+                                    compressedTileData, "", "", {}, priority, false, &nestedBitsPerSample, &nestedPixelType
                                 );
                             } break;
                             case COMPRESSION_JP2000: {
                                 const auto loader = Jpeg2000ImageLoader{};
                                 tmp = co_await loader.load(
-                                    compressedTileData, "", "", priority, {}, false, &nestedBitsPerSample, &nestedPixelType
+                                    compressedTileData, "", "", {}, priority, false, &nestedBitsPerSample, &nestedPixelType
                                 );
                             } break;
                             case COMPRESSION_JPEG:
@@ -2573,7 +2573,7 @@ Task<ImageData>
         }
 
         co_await postprocessLinearRawDng(
-            tif, samplesPerPixel, numColorChannels, numRgbaChannels, floatRgbaData, resultData, reverseEndian, priority
+            tif, samplesPerPixel, numColorChannels, numRgbaChannels, floatRgbaData, resultData, reverseEndian, settings.dngApplyCameraProfile, priority
         );
     } else if (photometric == PHOTOMETRIC_LOGLUV || photometric == PHOTOMETRIC_LOGL) {
         // If we're a LogLUV image, we've already configured the encoder to give us linear XYZ data, so we can just convert that to Rec.709.
@@ -2596,7 +2596,8 @@ Task<ImageData>
     co_return resultData;
 }
 
-Task<vector<ImageData>> TiffImageLoader::load(istream& iStream, const fs::path& path, string_view, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>>
+    TiffImageLoader::load(istream& iStream, const fs::path& path, string_view, const ImageLoaderSettings& settings, int priority) const {
     // This function tries to implement the most relevant parts of the TIFF 6.0 spec:
     // https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf
     char magic[4] = {0};

--- a/src/imageio/WebpImageLoader.cpp
+++ b/src/imageio/WebpImageLoader.cpp
@@ -31,7 +31,7 @@ using namespace std;
 
 namespace tev {
 
-Task<vector<ImageData>> WebpImageLoader::load(istream& iStream, const fs::path&, string_view, int priority, const GainmapHeadroom&) const {
+Task<vector<ImageData>> WebpImageLoader::load(istream& iStream, const fs::path&, string_view, const ImageLoaderSettings&, int priority) const {
     char magic[16] = {0};
     iStream.read(magic, sizeof(magic));
     if (!iStream || strncmp(magic, "RIFF", 4) != 0 || strncmp(magic + 8, "WEBP", 4) != 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -314,6 +314,16 @@ static int mainFunc(span<const string> arguments) {
         {'c', "convert-to"},
     };
 
+    Flag dngCameraProfileFlag{
+        parser,
+        "DNG CAMERA PROFILE",
+        "When loading DNG images, apply the embedded camera profile. "
+        "Enabling this setting moves the image farther from the raw sensor response and closer to a pleasing image, but potentially at the cost of colorimetric accuracy. "
+        "Regardless of this setting, the DNG's embedded color space, linearization, and white balance metadata will always be applied. "
+        "Default is off.",
+        {"dng-camera-profile"},
+    };
+
     ValueFlag<float> exposureFlag{
         parser,
         "EXPOSURE",
@@ -612,6 +622,10 @@ static int mainFunc(span<const string> arguments) {
     const shared_ptr<BackgroundImagesLoader> imagesLoader = make_shared<BackgroundImagesLoader>();
     imagesLoader->setRecursiveDirectories(recursiveFlag);
     imagesLoader->setGroupChannels(!channelGroupingFlagOff);
+
+    if (dngCameraProfileFlag) {
+        imagesLoader->imageLoaderSettings().dngApplyCameraProfile = true;
+    }
 
     if (gainmapHeadroomFlag) {
         try {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,7 +133,7 @@ static void handleIpcPacket(const IpcPacket& packet, const shared_ptr<Background
                     toPath(info.imageName),
                     imageStream,
                     "",
-                    sImageViewer->imagesLoader().gainmapHeadroom(),
+                    sImageViewer->imagesLoader().imageLoaderSettings(),
                     sImageViewer->imagesLoader().groupChannels()
                 );
                 const auto images = imagesLoadTask.get();
@@ -616,7 +616,7 @@ static int mainFunc(span<const string> arguments) {
     if (gainmapHeadroomFlag) {
         try {
             const auto gainmapHeadroom = GainmapHeadroom{get(gainmapHeadroomFlag)};
-            imagesLoader->setGainmapHeadroom(gainmapHeadroom);
+            imagesLoader->imageLoaderSettings().gainmapHeadroom = gainmapHeadroom;
         } catch (const invalid_argument& e) {
             tlog::error() << fmt::format("Invalid gainmap headroom '{}': {}", get(gainmapHeadroomFlag), e.what());
             return -6;


### PR DESCRIPTION
Exposes generic settings to all image loaders, allowing loaded-specific configuration. Currently, these settings consist of the existing `--gainmap-headroom` flag as well as a new `--dng-camera-profile` flag.