### PR TITLE
feat(wayland): fp16 framebuffers on NVIDIA

### DIFF
--- a/src/MultiGraph.cpp
+++ b/src/MultiGraph.cpp
@@ -61,7 +61,9 @@ void MultiGraph::draw(NVGcontext* ctx) {
         nvgSave(ctx);
 
         // Additive blending
-        nvgGlobalCompositeBlendFunc(ctx, NVGblendFactor::NVG_SRC_ALPHA, NVGblendFactor::NVG_ONE);
+        nvgGlobalCompositeBlendFuncSeparate(
+            ctx, NVGblendFactor::NVG_SRC_ALPHA, NVGblendFactor::NVG_ONE, NVGblendFactor::NVG_ZERO, NVGblendFactor::NVG_ONE
+        );
 
         size_t nBins = mValues.size() / mNChannels;
 


### PR DESCRIPTION
This relies on a slight hack within GLFW where the EGL opaque extension is disabled on wayland in order to obtain a supported fp16 framebuffer format. Since tev renders its framebuffer with an alpha of 1 always, this is no big deal and will display correctly.